### PR TITLE
Implement Supabase JWT auth for API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 
 API_VENV_PY := $(CURDIR)/apps/api/.venv/bin/python
 API_RUN := $(if $(wildcard $(API_VENV_PY)),$(API_VENV_PY) -m,uv run)
+API_BUILD := $(if $(wildcard $(API_VENV_PY)),$(API_VENV_PY) -m build,uv build)
 
 # Run both API and web in development mode
 dev:
@@ -126,7 +127,7 @@ test-e2e:
 build: build-api build-web
 
 build-api:
-	cd apps/api && $(API_RUN) build
+	cd apps/api && $(API_BUILD)
 
 build-web:
 	cd apps/web && pnpm build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 	typecheck typecheck-api test test-api test-web test-unit test-e2e \
 	build build-api build-web quality
 
+API_VENV_PY := $(CURDIR)/apps/api/.venv/bin/python
+API_RUN := $(if $(wildcard $(API_VENV_PY)),$(API_VENV_PY) -m,uv run)
+
 # Run both API and web in development mode
 dev:
 	@echo "Starting API and web servers..."
@@ -21,7 +24,7 @@ dev-up:
 
 # Run API server
 dev-api:
-	cd apps/api && uv run uvicorn main:app --reload --port 8000
+	cd apps/api && $(API_RUN) uvicorn main:app --reload --port 8000
 
 # Run web server
 dev-web:
@@ -48,6 +51,10 @@ supabase-env: supabase-start
 				value="$${line#SERVICE_ROLE_KEY=}"; \
 				echo "SUPABASE_SERVICE_ROLE_KEY=$$value"; \
 				;; \
+			JWT_SECRET=*) \
+				value="$${line#JWT_SECRET=}"; \
+				echo "SUPABASE_JWT_SECRET=$$value"; \
+				;; \
 		esac; \
 	done > .env
 	@echo "Wrote .env from local Supabase status."
@@ -73,7 +80,7 @@ quality: format-check lint typecheck test build
 lint: lint-api lint-web
 
 lint-api:
-	cd apps/api && uv run ruff check .
+	cd apps/api && $(API_RUN) ruff check .
 
 lint-web:
 	cd apps/web && pnpm lint
@@ -82,7 +89,7 @@ lint-web:
 format: format-api format-web
 
 format-api:
-	cd apps/api && uv run black .
+	cd apps/api && $(API_RUN) black .
 
 format-web:
 	cd apps/web && pnpm format
@@ -90,7 +97,7 @@ format-web:
 format-check: format-check-api format-check-web
 
 format-check-api:
-	cd apps/api && uv run black --check .
+	cd apps/api && $(API_RUN) black --check .
 
 format-check-web:
 	cd apps/web && pnpm format:check
@@ -99,13 +106,13 @@ format-check-web:
 typecheck: typecheck-api
 
 typecheck-api:
-	cd apps/api && uv run mypy .
+	cd apps/api && $(API_RUN) mypy .
 
 # Tests
 test: test-api test-web
 
 test-api:
-	cd apps/api && uv run pytest
+	cd apps/api && $(API_RUN) pytest
 
 test-web: test-unit test-e2e
 
@@ -119,7 +126,7 @@ test-e2e:
 build: build-api build-web
 
 build-api:
-	cd apps/api && uv run python -m build
+	cd apps/api && $(API_RUN) build
 
 build-web:
 	cd apps/web && pnpm build

--- a/apps/api/app/__init__.py
+++ b/apps/api/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package."""

--- a/apps/api/app/core/__init__.py
+++ b/apps/api/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities for API configuration, security, and error handling."""

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Settings:
+    supabase_url: str
+    supabase_jwt_audience: str | None
+    supabase_jwt_secret: str | None
+    supabase_jwks_cache_ttl_seconds: int
+    api_version: str
+
+
+_dotenv_loaded = False
+
+
+def _load_dotenv() -> None:
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+    _dotenv_loaded = True
+
+    parents = Path(__file__).resolve().parents
+    repo_root = parents[min(4, len(parents) - 1)]
+    candidates = [Path.cwd() / ".env", repo_root / ".env"]
+
+    for path in candidates:
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            value = line.strip()
+            if not value or value.startswith("#"):
+                continue
+            if value.startswith("export "):
+                value = value[len("export ") :].strip()
+            if "=" not in value:
+                continue
+            key, raw_value = value.split("=", 1)
+            key = key.strip()
+            raw_value = raw_value.strip()
+            if (
+                len(raw_value) >= 2
+                and raw_value[0] == raw_value[-1]
+                and raw_value[0] in {'"', "'"}
+            ):
+                raw_value = raw_value[1:-1]
+            os.environ.setdefault(key, raw_value)
+        break
+
+
+def _normalize_supabase_url(value: str) -> str:
+    return value.rstrip("/")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    _load_dotenv()
+    supabase_url = _normalize_supabase_url(os.getenv("SUPABASE_URL", "").strip())
+    audience: str | None = os.getenv("SUPABASE_JWT_AUDIENCE", "authenticated").strip()
+    if not audience:
+        audience = None
+    jwt_secret: str | None = os.getenv("SUPABASE_JWT_SECRET", "").strip()
+    if not jwt_secret:
+        jwt_secret = None
+    ttl_seconds = int(os.getenv("SUPABASE_JWKS_CACHE_TTL_SECONDS", "300"))
+    api_version = os.getenv("API_VERSION", "0.1.0").strip()
+    return Settings(
+        supabase_url=supabase_url,
+        supabase_jwt_audience=audience,
+        supabase_jwt_secret=jwt_secret,
+        supabase_jwks_cache_ttl_seconds=ttl_seconds,
+        api_version=api_version,
+    )
+
+
+def reset_settings_cache() -> None:
+    global _dotenv_loaded
+    get_settings.cache_clear()
+    _dotenv_loaded = False

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -33,6 +33,8 @@ def _find_repo_root() -> Path:
                 return parent
 
     parents = start_dir.parents
+    if not parents:
+        return start_dir
     return parents[min(4, len(parents) - 1)]
 
 

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -18,14 +18,31 @@ class Settings:
 _dotenv_loaded = False
 
 
+def _find_repo_root() -> Path:
+    env_dir = os.getenv("APP_CONFIG_DIR")
+    if env_dir:
+        config_path = Path(env_dir).expanduser()
+        if config_path.is_dir():
+            return config_path
+
+    start_dir = Path(__file__).resolve().parent
+    markers = ("pyproject.toml", "setup.cfg", ".git")
+    for parent in (start_dir, *start_dir.parents):
+        for marker in markers:
+            if (parent / marker).exists():
+                return parent
+
+    parents = start_dir.parents
+    return parents[min(4, len(parents) - 1)]
+
+
 def _load_dotenv() -> None:
     global _dotenv_loaded
     if _dotenv_loaded:
         return
     _dotenv_loaded = True
 
-    parents = Path(__file__).resolve().parents
-    repo_root = parents[min(4, len(parents) - 1)]
+    repo_root = _find_repo_root()
     candidates = [Path.cwd() / ".env", repo_root / ".env"]
 
     for path in candidates:
@@ -56,8 +73,20 @@ def _normalize_supabase_url(value: str) -> str:
     return value.rstrip("/")
 
 
+def _parse_ttl_seconds() -> int:
+    default_ttl = 300
+    raw_ttl = os.getenv("SUPABASE_JWKS_CACHE_TTL_SECONDS")
+    if raw_ttl is None or not raw_ttl.strip():
+        return default_ttl
+    try:
+        return int(raw_ttl)
+    except ValueError:
+        return default_ttl
+
+
 @lru_cache
 def get_settings() -> Settings:
+    """Settings are cached; call reset_settings_cache when env values change."""
     _load_dotenv()
     supabase_url = _normalize_supabase_url(os.getenv("SUPABASE_URL", "").strip())
     audience: str | None = os.getenv("SUPABASE_JWT_AUDIENCE", "authenticated").strip()
@@ -66,7 +95,7 @@ def get_settings() -> Settings:
     jwt_secret: str | None = os.getenv("SUPABASE_JWT_SECRET", "").strip()
     if not jwt_secret:
         jwt_secret = None
-    ttl_seconds = int(os.getenv("SUPABASE_JWKS_CACHE_TTL_SECONDS", "300"))
+    ttl_seconds = _parse_ttl_seconds()
     api_version = os.getenv("API_VERSION", "0.1.0").strip()
     return Settings(
         supabase_url=supabase_url,

--- a/apps/api/app/core/errors.py
+++ b/apps/api/app/core/errors.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.core.responses import fail
+from app.core.security import AuthError
+
+
+def auth_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    auth_exc = cast(AuthError, exc)
+    return JSONResponse(
+        status_code=auth_exc.status_code,
+        content=fail(
+            code=auth_exc.code,
+            message=auth_exc.message,
+            details=auth_exc.details,
+        ),
+    )
+
+
+def http_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    http_exc = cast(HTTPException, exc)
+    details: dict[str, Any] | None = None
+    code = "http_error"
+    message = str(http_exc.detail)
+    if isinstance(http_exc.detail, dict):
+        code = http_exc.detail.get("code", code)
+        message = http_exc.detail.get("message", message)
+        details = http_exc.detail.get("details")
+    return JSONResponse(
+        status_code=http_exc.status_code,
+        content=fail(code=code, message=message, details=details),
+    )
+
+
+def validation_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    validation_exc = cast(RequestValidationError, exc)
+    return JSONResponse(
+        status_code=422,
+        content=fail(
+            code="validation_error",
+            message="Request validation failed.",
+            details={"errors": validation_exc.errors()},
+        ),
+    )
+
+
+def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content=fail(code="internal_error", message="Internal server error."),
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(AuthError, auth_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/apps/api/app/core/errors.py
+++ b/apps/api/app/core/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException, Request
@@ -8,6 +9,8 @@ from fastapi.responses import JSONResponse
 
 from app.core.responses import fail
 from app.core.security import AuthError
+
+logger = logging.getLogger(__name__)
 
 
 def auth_exception_handler(_: Request, exc: Exception) -> JSONResponse:
@@ -50,6 +53,7 @@ def validation_exception_handler(_: Request, exc: Exception) -> JSONResponse:
 
 
 def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception", exc_info=exc)
     return JSONResponse(
         status_code=500,
         content=fail(code="internal_error", message="Internal server error."),

--- a/apps/api/app/core/jwks.py
+++ b/apps/api/app/core/jwks.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+FetchJWKS = Callable[[], Awaitable[dict[str, Any]]]
+TimeFn = Callable[[], float]
+
+
+@dataclass
+class JWKSCache:
+    fetcher: FetchJWKS
+    ttl_seconds: int
+    time_fn: TimeFn = time.monotonic
+    _jwks: dict[str, Any] | None = None
+    _fetched_at: float = 0.0
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def get(self) -> dict[str, Any]:
+        now = self.time_fn()
+        if self._jwks is not None and (now - self._fetched_at) < self.ttl_seconds:
+            return self._jwks
+        async with self._lock:
+            now = self.time_fn()
+            if self._jwks is not None and (now - self._fetched_at) < self.ttl_seconds:
+                return self._jwks
+            jwks = await self.fetcher()
+            self._jwks = jwks
+            self._fetched_at = self.time_fn()
+            return jwks

--- a/apps/api/app/core/responses.py
+++ b/apps/api/app/core/responses.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ErrorDetail(BaseModel):
+    code: str
+    message: str
+    details: dict[str, Any] | None = None
+
+
+class ResponseEnvelope(BaseModel):
+    data: Any | None = None
+    error: ErrorDetail | None = None
+
+
+def ok(data: Any) -> dict[str, Any]:
+    return ResponseEnvelope(data=data, error=None).model_dump()
+
+
+def fail(
+    code: str, message: str, details: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    return ResponseEnvelope(
+        data=None,
+        error=ErrorDetail(code=code, message=message, details=details),
+    ).model_dump()

--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -105,7 +105,6 @@ async def decode_jwt(
         raise AuthError(
             code="invalid_token",
             message="Invalid JWT header.",
-            details={"error": str(exc)},
         ) from exc
 
     alg = header.get("alg")
@@ -136,7 +135,6 @@ async def decode_jwt(
             raise AuthError(
                 code="invalid_token",
                 message="Invalid JWT.",
-                details={"error": str(exc)},
             ) from exc
 
     if alg not in ALGORITHMS_RS256:
@@ -153,7 +151,6 @@ async def decode_jwt(
             code="jwks_unavailable",
             message="Unable to fetch JWKS.",
             status_code=503,
-            details={"error": str(exc)},
         ) from exc
 
     key = _find_jwk(jwks, kid)
@@ -174,7 +171,6 @@ async def decode_jwt(
         raise AuthError(
             code="invalid_token",
             message="Invalid JWT.",
-            details={"error": str(exc)},
         ) from exc
 
 

--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated, Any, cast
+
+import httpx
+from fastapi import Depends, Header
+from jose import JWTError, jwt
+
+from app.core.config import Settings, get_settings
+from app.core.jwks import JWKSCache
+
+ALGORITHMS_RS256 = ["RS256"]
+ALGORITHMS_HS256 = ["HS256"]
+
+
+@dataclass
+class AuthError(Exception):
+    code: str
+    message: str
+    status_code: int = 401
+    details: dict[str, Any] | None = None
+
+
+_jwks_cache: JWKSCache | None = None
+_jwks_cache_key: tuple[str, int] | None = None
+_jwks_lock = asyncio.Lock()
+
+
+def _build_issuer(supabase_url: str) -> str:
+    return f"{supabase_url}/auth/v1"
+
+
+def _build_jwks_url(supabase_url: str) -> str:
+    return f"{supabase_url}/auth/v1/.well-known/jwks.json"
+
+
+async def _fetch_jwks(
+    settings: Settings,
+    client: httpx.AsyncClient | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> dict[str, Any]:
+    url = _build_jwks_url(settings.supabase_url)
+    if client is None:
+        async with httpx.AsyncClient(
+            timeout=5.0,
+            transport=transport,
+        ) as scoped_client:
+            response = await scoped_client.get(url)
+            response.raise_for_status()
+            return cast(dict[str, Any], response.json())
+    response = await client.get(url)
+    response.raise_for_status()
+    return cast(dict[str, Any], response.json())
+
+
+def _get_jwks_cache(settings: Settings) -> JWKSCache:
+    global _jwks_cache, _jwks_cache_key
+    cache_key = (settings.supabase_url, settings.supabase_jwks_cache_ttl_seconds)
+    if _jwks_cache is None or _jwks_cache_key != cache_key:
+        _jwks_cache = JWKSCache(
+            fetcher=lambda: _fetch_jwks(settings),
+            ttl_seconds=settings.supabase_jwks_cache_ttl_seconds,
+        )
+        _jwks_cache_key = cache_key
+    return _jwks_cache
+
+
+async def get_jwks_cache(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> JWKSCache:
+    async with _jwks_lock:
+        return _get_jwks_cache(settings)
+
+
+def reset_jwks_cache() -> None:
+    global _jwks_cache, _jwks_cache_key
+    _jwks_cache = None
+    _jwks_cache_key = None
+
+
+def _find_jwk(jwks: dict[str, Any], kid: str) -> dict[str, Any] | None:
+    for key in jwks.get("keys", []):
+        if key.get("kid") == kid:
+            return cast(dict[str, Any], key)
+    return None
+
+
+async def decode_jwt(
+    token: str,
+    settings: Settings,
+    jwks_cache: JWKSCache,
+) -> dict[str, Any]:
+    if not settings.supabase_url:
+        raise AuthError(
+            code="config_error",
+            message="SUPABASE_URL is not configured.",
+            status_code=500,
+        )
+
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError as exc:
+        raise AuthError(
+            code="invalid_token",
+            message="Invalid JWT header.",
+            details={"error": str(exc)},
+        ) from exc
+
+    alg = header.get("alg")
+    if not alg:
+        raise AuthError(code="invalid_token", message="JWT header missing alg.")
+
+    issuer = _build_issuer(settings.supabase_url)
+    options = {"verify_aud": settings.supabase_jwt_audience is not None}
+
+    if alg in ALGORITHMS_HS256:
+        if not settings.supabase_jwt_secret:
+            raise AuthError(
+                code="config_error",
+                message="SUPABASE_JWT_SECRET is not configured.",
+                status_code=500,
+            )
+        try:
+            payload = jwt.decode(
+                token,
+                settings.supabase_jwt_secret,
+                algorithms=ALGORITHMS_HS256,
+                issuer=issuer,
+                audience=settings.supabase_jwt_audience,
+                options=options,
+            )
+            return cast(dict[str, Any], payload)
+        except JWTError as exc:
+            raise AuthError(
+                code="invalid_token",
+                message="Invalid JWT.",
+                details={"error": str(exc)},
+            ) from exc
+
+    if alg not in ALGORITHMS_RS256:
+        raise AuthError(code="invalid_token", message="Unsupported JWT algorithm.")
+
+    kid = header.get("kid")
+    if not kid:
+        raise AuthError(code="invalid_token", message="JWT header missing kid.")
+
+    try:
+        jwks = await jwks_cache.get()
+    except httpx.HTTPError as exc:
+        raise AuthError(
+            code="jwks_unavailable",
+            message="Unable to fetch JWKS.",
+            status_code=503,
+            details={"error": str(exc)},
+        ) from exc
+
+    key = _find_jwk(jwks, kid)
+    if not key:
+        raise AuthError(code="invalid_token", message="JWKS key not found.")
+
+    try:
+        payload = jwt.decode(
+            token,
+            key,
+            algorithms=ALGORITHMS_RS256,
+            issuer=issuer,
+            audience=settings.supabase_jwt_audience,
+            options=options,
+        )
+        return cast(dict[str, Any], payload)
+    except JWTError as exc:
+        raise AuthError(
+            code="invalid_token",
+            message="Invalid JWT.",
+            details={"error": str(exc)},
+        ) from exc
+
+
+async def require_jwt(
+    settings: Annotated[Settings, Depends(get_settings)],
+    jwks_cache: Annotated[JWKSCache, Depends(get_jwks_cache)],
+    authorization: Annotated[str | None, Header()] = None,
+) -> dict[str, Any]:
+    if not authorization:
+        raise AuthError(code="missing_token", message="Missing Authorization header.")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise AuthError(
+            code="invalid_token",
+            message="Authorization header must be a Bearer token.",
+        )
+    return await decode_jwt(token, settings=settings, jwks_cache=jwks_cache)

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.core.config import get_settings
+from app.core.errors import register_exception_handlers
+from app.routers import health, protected, version
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    app = FastAPI(
+        title="ChapterVerse API",
+        description="API for the ChapterVerse book tracking application",
+        version=settings.api_version,
+    )
+    register_exception_handlers(app)
+    app.include_router(health.router)
+    app.include_router(version.router)
+    app.include_router(protected.router)
+    return app

--- a/apps/api/app/routers/__init__.py
+++ b/apps/api/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers."""

--- a/apps/api/app/routers/health.py
+++ b/apps/api/app/routers/health.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.responses import ok
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/api/v1/health")
+async def health() -> dict[str, object]:
+    return ok({"status": "ok"})

--- a/apps/api/app/routers/protected.py
+++ b/apps/api/app/routers/protected.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.responses import ok
+from app.core.security import require_jwt
+
+router = APIRouter(
+    prefix="/api/v1/protected",
+    tags=["protected"],
+    dependencies=[Depends(require_jwt)],
+)
+
+
+@router.get("/ping")
+async def protected_ping() -> dict[str, object]:
+    return ok({"pong": True})

--- a/apps/api/app/routers/version.py
+++ b/apps/api/app/routers/version.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from app.core.config import Settings, get_settings
+from app.core.responses import ok
+
+router = APIRouter(tags=["version"])
+
+
+@router.get("/api/v1/version")
+async def version(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> dict[str, object]:
+    return ok({"version": settings.api_version})

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,17 +1,3 @@
-from fastapi import FastAPI
+from app.main import create_app
 
-app = FastAPI(
-    title="ChapterVerse API",
-    description="API for the ChapterVerse book tracking application",
-    version="0.1.0",
-)
-
-
-@app.get("/api/v1/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
-
-
-@app.get("/api/v1/version")
-async def version() -> dict[str, str]:
-    return {"version": "0.1.0"}
+app = create_app()

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.127.0",
+    "httpx>=0.27.0",
+    "python-jose[cryptography]>=3.3.0",
     "uvicorn[standard]>=0.40.0",
 ]
 
@@ -13,7 +15,6 @@ dependencies = [
 dev = [
     "black>=24.10.0",
     "build>=1.2.2",
-    "httpx>=0.27.0",
     "mypy>=1.11.0",
     "pytest>=8.3.0",
     "pytest-cov>=5.0.0",
@@ -41,13 +42,17 @@ python_version = "3.11"
 strict = true
 warn_unused_configs = true
 
+[[tool.mypy.overrides]]
+module = ["jose", "jose.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
-addopts = "-ra --strict-config --strict-markers --cov=main --cov-report=term-missing --cov-fail-under=95"
+addopts = "-ra --strict-config --strict-markers --cov=app --cov=main --cov-report=term-missing --cov-fail-under=95"
 testpaths = ["tests"]
 
 [tool.coverage.run]
 branch = true
-source = ["main"]
+source = ["app", "main"]
 
 [tool.coverage.report]
 show_missing = true

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -1,0 +1,91 @@
+import os
+from pathlib import Path
+
+from app.core.config import _load_dotenv, get_settings, reset_settings_cache
+
+
+def test_get_settings_blank_audience_and_reset_cache() -> None:
+    original_env = os.environ.copy()
+    try:
+        os.environ["SUPABASE_URL"] = "https://example.supabase.co/"
+        os.environ["SUPABASE_JWT_AUDIENCE"] = ""
+        os.environ["SUPABASE_JWT_SECRET"] = "local-secret"
+        os.environ["SUPABASE_JWKS_CACHE_TTL_SECONDS"] = "120"
+        os.environ["API_VERSION"] = "9.9.9"
+        reset_settings_cache()
+
+        settings = get_settings()
+        assert settings.supabase_url == "https://example.supabase.co"
+        assert settings.supabase_jwt_audience is None
+        assert settings.supabase_jwt_secret == "local-secret"
+        assert settings.supabase_jwks_cache_ttl_seconds == 120
+        assert settings.api_version == "9.9.9"
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+        reset_settings_cache()
+
+
+def test_get_settings_loads_dotenv(tmp_path: Path) -> None:
+    original_env = os.environ.copy()
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "\n".join(
+                [
+                    "# comment",
+                    "",
+                    "export SUPABASE_URL=https://env.example",
+                    "SUPABASE_JWT_AUDIENCE=authenticated",
+                    'SUPABASE_JWT_SECRET="from-dotenv"',
+                    "NOEQUALS",
+                    "SUPABASE_JWKS_CACHE_TTL_SECONDS=90",
+                    'API_VERSION="1.2.3"',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        for key in [
+            "SUPABASE_URL",
+            "SUPABASE_JWT_AUDIENCE",
+            "SUPABASE_JWT_SECRET",
+            "SUPABASE_JWKS_CACHE_TTL_SECONDS",
+            "API_VERSION",
+        ]:
+            os.environ.pop(key, None)
+        reset_settings_cache()
+        settings = get_settings()
+        assert settings.supabase_url == "https://env.example"
+        assert settings.supabase_jwt_audience == "authenticated"
+        assert settings.supabase_jwt_secret == "from-dotenv"
+        assert settings.supabase_jwks_cache_ttl_seconds == 90
+        assert settings.api_version == "1.2.3"
+    finally:
+        os.chdir(original_cwd)
+        os.environ.clear()
+        os.environ.update(original_env)
+        reset_settings_cache()
+
+
+def test_load_dotenv_idempotent(tmp_path: Path) -> None:
+    original_env = os.environ.copy()
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "SUPABASE_URL=https://env.example\n",
+            encoding="utf-8",
+        )
+        os.environ.pop("SUPABASE_URL", None)
+        reset_settings_cache()
+        _load_dotenv()
+        _load_dotenv()
+        assert os.environ.get("SUPABASE_URL") == "https://env.example"
+    finally:
+        os.chdir(original_cwd)
+        os.environ.clear()
+        os.environ.update(original_env)
+        reset_settings_cache()

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -26,6 +26,21 @@ def test_get_settings_blank_audience_and_reset_cache() -> None:
         reset_settings_cache()
 
 
+def test_get_settings_invalid_ttl_defaults() -> None:
+    original_env = os.environ.copy()
+    try:
+        os.environ["SUPABASE_URL"] = "https://example.supabase.co/"
+        os.environ["SUPABASE_JWKS_CACHE_TTL_SECONDS"] = "not-a-number"
+        reset_settings_cache()
+
+        settings = get_settings()
+        assert settings.supabase_jwks_cache_ttl_seconds == 300
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+        reset_settings_cache()
+
+
 def test_get_settings_loads_dotenv(tmp_path: Path) -> None:
     original_env = os.environ.copy()
     original_cwd = os.getcwd()

--- a/apps/api/tests/test_endpoints.py
+++ b/apps/api/tests/test_endpoints.py
@@ -1,17 +1,17 @@
 from fastapi.testclient import TestClient
 
-from main import app
-
-client = TestClient(app)
+from app.main import create_app
 
 
 def test_health_endpoint() -> None:
+    client = TestClient(create_app())
     response = client.get("/api/v1/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json() == {"data": {"status": "ok"}, "error": None}
 
 
 def test_version_endpoint() -> None:
+    client = TestClient(create_app())
     response = client.get("/api/v1/version")
     assert response.status_code == 200
-    assert response.json() == {"version": "0.1.0"}
+    assert response.json() == {"data": {"version": "0.1.0"}, "error": None}

--- a/apps/api/tests/test_error_handlers.py
+++ b/apps/api/tests/test_error_handlers.py
@@ -1,0 +1,65 @@
+import json
+
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+
+from app.core.errors import (
+    auth_exception_handler,
+    http_exception_handler,
+    unhandled_exception_handler,
+    validation_exception_handler,
+)
+from app.core.security import AuthError
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "GET", "path": "/", "headers": []})
+
+
+def test_auth_exception_handler() -> None:
+    exc = AuthError(code="invalid_token", message="Invalid token")
+    response = auth_exception_handler(_request(), exc)
+    assert response.status_code == 401
+    payload = json.loads(bytes(response.body))
+    assert payload["data"] is None
+    assert payload["error"]["code"] == "invalid_token"
+
+
+def test_http_exception_handler_with_string_detail() -> None:
+    exc = HTTPException(status_code=404, detail="Not found")
+    response = http_exception_handler(_request(), exc)
+    assert response.status_code == 404
+    payload = json.loads(bytes(response.body))
+    assert payload["error"]["code"] == "http_error"
+    assert payload["error"]["message"] == "Not found"
+
+
+def test_http_exception_handler_with_dict_detail() -> None:
+    exc = HTTPException(
+        status_code=400,
+        detail={"code": "bad_request", "message": "Bad request"},
+    )
+    response = http_exception_handler(_request(), exc)
+    assert response.status_code == 400
+    payload = json.loads(bytes(response.body))
+    assert payload["error"]["code"] == "bad_request"
+    assert payload["error"]["message"] == "Bad request"
+
+
+def test_validation_exception_handler() -> None:
+    exc = RequestValidationError(
+        [{"loc": ("query", "q"), "msg": "field required", "type": "value_error"}]
+    )
+    response = validation_exception_handler(_request(), exc)
+    assert response.status_code == 422
+    payload = json.loads(bytes(response.body))
+    assert payload["error"]["code"] == "validation_error"
+    assert payload["error"]["details"]["errors"]
+
+
+def test_unhandled_exception_handler() -> None:
+    exc = Exception("boom")
+    response = unhandled_exception_handler(_request(), exc)
+    assert response.status_code == 500
+    payload = json.loads(bytes(response.body))
+    assert payload["error"]["code"] == "internal_error"

--- a/apps/api/tests/test_jwks_cache.py
+++ b/apps/api/tests/test_jwks_cache.py
@@ -1,0 +1,62 @@
+import asyncio
+
+from app.core.jwks import JWKSCache
+
+
+def test_jwks_cache_respects_ttl() -> None:
+    calls = {"count": 0}
+
+    async def fetcher() -> dict[str, object]:
+        calls["count"] += 1
+        return {"keys": [{"kid": "one"}]}
+
+    class FakeClock:
+        def __init__(self) -> None:
+            self.now = 1000.0
+
+        def monotonic(self) -> float:
+            return self.now
+
+        def advance(self, seconds: float) -> None:
+            self.now += seconds
+
+    clock = FakeClock()
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60, time_fn=clock.monotonic)
+
+    async def run() -> None:
+        first = await cache.get()
+        second = await cache.get()
+        assert first == second
+        assert calls["count"] == 1
+
+        clock.advance(61)
+        await cache.get()
+        assert calls["count"] == 2
+
+    asyncio.run(run())
+
+
+def test_jwks_cache_returns_after_concurrent_fetch() -> None:
+    calls = {"count": 0}
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fetcher() -> dict[str, object]:
+        calls["count"] += 1
+        started.set()
+        await release.wait()
+        return {"keys": [{"kid": "one"}]}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+
+    async def run() -> None:
+        task_one = asyncio.create_task(cache.get())
+        await started.wait()
+        task_two = asyncio.create_task(cache.get())
+        release.set()
+        result_one = await task_one
+        result_two = await task_two
+        assert result_one == result_two
+        assert calls["count"] == 1
+
+    asyncio.run(run())

--- a/apps/api/tests/test_main.py
+++ b/apps/api/tests/test_main.py
@@ -1,0 +1,12 @@
+from importlib import util
+from pathlib import Path
+
+
+def test_app_instance() -> None:
+    main_path = Path(__file__).resolve().parents[1] / "main.py"
+    spec = util.spec_from_file_location("main", main_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.app.title == "ChapterVerse API"

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -1,0 +1,434 @@
+import asyncio
+import base64
+import json
+import time
+from collections.abc import Generator
+from typing import cast
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from jose import jwk, jwt
+
+from app.core.config import Settings, get_settings
+from app.core.jwks import JWKSCache
+from app.core.security import (
+    AuthError,
+    _build_issuer,
+    _build_jwks_url,
+    _fetch_jwks,
+    _find_jwk,
+    decode_jwt,
+    get_jwks_cache,
+    require_jwt,
+    reset_jwks_cache,
+)
+from app.main import create_app
+
+SUPABASE_URL = "https://example.supabase.co"
+KID = "test-kid"
+JWT_SECRET = "local-jwt-secret"
+
+def _generate_rsa_keypair() -> tuple[str, str]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return private_pem, public_pem
+
+
+RSA_PRIVATE_KEY, RSA_PUBLIC_KEY = _generate_rsa_keypair()
+
+
+def _settings() -> Settings:
+    return Settings(
+        supabase_url=SUPABASE_URL,
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        api_version="0.1.0",
+    )
+
+
+def _settings_with_secret() -> Settings:
+    return Settings(
+        supabase_url=SUPABASE_URL,
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=JWT_SECRET,
+        supabase_jwks_cache_ttl_seconds=60,
+        api_version="0.1.0",
+    )
+
+
+def _build_jwks() -> dict[str, object]:
+    key = jwk.construct(RSA_PUBLIC_KEY, "RS256")
+    public_jwk = key.to_dict()
+    public_jwk["kid"] = KID
+    public_jwk["use"] = "sig"
+    return {"keys": [public_jwk]}
+
+
+def _make_token(audience: str = "authenticated") -> str:
+    issuer = f"{SUPABASE_URL}/auth/v1"
+    payload = {
+        "sub": "user-123",
+        "aud": audience,
+        "iss": issuer,
+        "exp": int(time.time()) + 3600,
+    }
+    token = jwt.encode(payload, RSA_PRIVATE_KEY, algorithm="RS256", headers={"kid": KID})
+    return cast(str, token)
+
+
+def _make_hs256_token(audience: str = "authenticated") -> str:
+    issuer = f"{SUPABASE_URL}/auth/v1"
+    payload = {
+        "sub": "user-123",
+        "aud": audience,
+        "iss": issuer,
+        "exp": int(time.time()) + 3600,
+    }
+    token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+    return cast(str, token)
+
+
+def _make_token_without_alg() -> str:
+    header = {"typ": "JWT"}
+    payload = {"sub": "user-123"}
+    header_b64 = (
+        base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+    )
+    payload_b64 = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
+    return f"{header_b64}.{payload_b64}.sig"
+
+
+def _make_token_with_alg(alg: str) -> str:
+    header = {"typ": "JWT", "alg": alg}
+    payload = {"sub": "user-123"}
+    header_b64 = (
+        base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+    )
+    payload_b64 = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
+    return f"{header_b64}.{payload_b64}.sig"
+
+
+@pytest.fixture()
+def fastapi_app() -> Generator[FastAPI, None, None]:
+    app = create_app()
+    yield app
+    app.dependency_overrides.clear()
+
+
+def test_decode_jwt_success() -> None:
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_token()
+    payload = asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert payload["sub"] == "user-123"
+
+
+def test_decode_jwt_hs256_success() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_hs256_token()
+    payload = asyncio.run(
+        decode_jwt(token, settings=_settings_with_secret(), jwks_cache=cache)
+    )
+    assert payload["sub"] == "user-123"
+
+
+def test_decode_jwt_hs256_missing_secret() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_hs256_token()
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "config_error"
+
+
+def test_decode_jwt_hs256_invalid_secret() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_hs256_token()
+    bad_settings = Settings(
+        supabase_url=SUPABASE_URL,
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret="wrong-secret",
+        supabase_jwks_cache_ttl_seconds=60,
+        api_version="0.1.0",
+    )
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=bad_settings, jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_decode_jwt_missing_alg() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_token_without_alg()
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_decode_jwt_unsupported_alg() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_token_with_alg("ES256")
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_decode_jwt_missing_kid() -> None:
+    issuer = f"{SUPABASE_URL}/auth/v1"
+    token = jwt.encode(
+        {"sub": "user-123", "aud": "authenticated", "iss": issuer, "exp": 9999999999},
+        PRIVATE_KEY,
+        algorithm="RS256",
+    )
+
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_decode_jwt_invalid_header() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt("not-a.jwt", settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_decode_jwt_jwks_unavailable() -> None:
+    async def fetcher() -> dict[str, object]:
+        raise httpx.HTTPError("boom")
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_token()
+
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "jwks_unavailable"
+
+
+def test_protected_endpoint_requires_auth(fastapi_app: FastAPI) -> None:
+    client = TestClient(fastapi_app)
+    response = client.get("/api/v1/protected/ping")
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["error"]["code"] == "missing_token"
+
+
+def test_protected_endpoint_rejects_invalid_token(fastapi_app: FastAPI) -> None:
+    fastapi_app.dependency_overrides[get_settings] = _settings
+
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    fastapi_app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+
+    client = TestClient(fastapi_app)
+    response = client.get(
+        "/api/v1/protected/ping",
+        headers={"Authorization": "Bearer not-a.jwt"},
+    )
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["error"]["code"] == "invalid_token"
+
+
+def test_protected_endpoint_accepts_valid_token(fastapi_app: FastAPI) -> None:
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    fastapi_app.dependency_overrides[get_settings] = _settings
+    fastapi_app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+
+    token = _make_token()
+    client = TestClient(fastapi_app)
+    response = client.get(
+        "/api/v1/protected/ping",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"data": {"pong": True}, "error": None}
+
+
+def test_protected_endpoint_accepts_hs256_token(fastapi_app: FastAPI) -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    fastapi_app.dependency_overrides[get_settings] = _settings_with_secret
+    fastapi_app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+
+    token = _make_hs256_token()
+    client = TestClient(fastapi_app)
+    response = client.get(
+        "/api/v1/protected/ping",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"data": {"pong": True}, "error": None}
+
+
+def test_decode_jwt_missing_supabase_url() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    bad_settings = Settings(
+        supabase_url="",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        api_version="0.1.0",
+    )
+
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt("token", settings=bad_settings, jwks_cache=cache))
+    assert exc.value.code == "config_error"
+
+
+def test_decode_jwt_key_not_found() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": [{"kid": "other"}]}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_token()
+
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_decode_jwt_invalid_audience() -> None:
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    token = _make_token(audience="wrong")
+
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
+    assert exc.value.code == "invalid_token"
+
+
+def test_require_jwt_rejects_non_bearer() -> None:
+    async def fetcher() -> dict[str, object]:
+        return {"keys": []}
+
+    cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(
+            require_jwt(
+                authorization="Basic abc",
+                settings=_settings(),
+                jwks_cache=cache,
+            )
+        )
+    assert exc.value.code == "invalid_token"
+
+
+def test_build_urls() -> None:
+    issuer = _build_issuer(SUPABASE_URL)
+    jwks_url = _build_jwks_url(SUPABASE_URL)
+    assert issuer == f"{SUPABASE_URL}/auth/v1"
+    assert jwks_url == f"{SUPABASE_URL}/auth/v1/.well-known/jwks.json"
+
+
+def test_find_jwk() -> None:
+    jwk_value = {"kid": "alpha"}
+    assert _find_jwk({"keys": [jwk_value]}, "alpha") == jwk_value
+    assert _find_jwk({"keys": [jwk_value]}, "missing") is None
+
+
+def test_fetch_jwks() -> None:
+    jwks_payload = {"keys": [{"kid": "local"}]}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/auth/v1/.well-known/jwks.json"
+        body = json.dumps(jwks_payload).encode("utf-8")
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            content=body,
+        )
+
+    transport = httpx.MockTransport(handler)
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        api_version="0.1.0",
+    )
+
+    result = asyncio.run(_fetch_jwks(settings, transport=transport))
+    assert result == jwks_payload
+
+
+def test_get_jwks_cache_reuses_instance() -> None:
+    reset_jwks_cache()
+    settings = _settings()
+    cache_one = asyncio.run(get_jwks_cache(settings))
+    cache_two = asyncio.run(get_jwks_cache(settings))
+    assert cache_one is cache_two
+
+    settings_updated = Settings(
+        supabase_url=settings.supabase_url,
+        supabase_jwt_audience=settings.supabase_jwt_audience,
+        supabase_jwt_secret=settings.supabase_jwt_secret,
+        supabase_jwks_cache_ttl_seconds=120,
+        api_version=settings.api_version,
+    )
+    cache_three = asyncio.run(get_jwks_cache(settings_updated))
+    assert cache_three is not cache_one
+    reset_jwks_cache()

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -32,6 +32,7 @@ SUPABASE_URL = "https://example.supabase.co"
 KID = "test-kid"
 JWT_SECRET = "local-jwt-secret"
 
+
 def _generate_rsa_keypair() -> tuple[str, str]:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     private_pem = private_key.private_bytes(
@@ -39,10 +40,14 @@ def _generate_rsa_keypair() -> tuple[str, str]:
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
-    public_pem = private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
     return private_pem, public_pem
 
 
@@ -85,7 +90,9 @@ def _make_token(audience: str = "authenticated") -> str:
         "iss": issuer,
         "exp": int(time.time()) + 3600,
     }
-    token = jwt.encode(payload, RSA_PRIVATE_KEY, algorithm="RS256", headers={"kid": KID})
+    token = jwt.encode(
+        payload, RSA_PRIVATE_KEY, algorithm="RS256", headers={"kid": KID}
+    )
     return cast(str, token)
 
 
@@ -211,7 +218,7 @@ def test_decode_jwt_missing_kid() -> None:
     issuer = f"{SUPABASE_URL}/auth/v1"
     token = jwt.encode(
         {"sub": "user-123", "aud": "authenticated", "iss": issuer, "exp": 9999999999},
-        PRIVATE_KEY,
+        RSA_PRIVATE_KEY,
         algorithm="RS256",
     )
 

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -94,11 +94,83 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "chapterverse-api"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
+    { name = "python-jose", extra = ["cryptography"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -106,7 +178,6 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "build" },
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -118,10 +189,11 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.10.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "fastapi", specifier = ">=0.127.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
 ]
@@ -238,6 +310,80 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/42/9c391dd801d6cf0d561b5890549d4b27bafcc53b39c31a817e69d87c625b/cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a", size = 7225004, upload-time = "2025-10-15T23:16:52.239Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/67/38769ca6b65f07461eb200e85fc1639b438bdc667be02cf7f2cd6a64601c/cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc", size = 4296667, upload-time = "2025-10-15T23:16:54.369Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/498c86566a1d80e978b42f0d702795f69887005548c041636df6ae1ca64c/cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d", size = 4450807, upload-time = "2025-10-15T23:16:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/863a3604112174c8624a2ac3c038662d9e59970c7f926acdcfaed8d61142/cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb", size = 4299615, upload-time = "2025-10-15T23:16:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/64/02/b73a533f6b64a69f3cd3872acb6ebc12aef924d8d103133bb3ea750dc703/cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849", size = 4016800, upload-time = "2025-10-15T23:17:00.378Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d5/16e41afbfa450cde85a3b7ec599bebefaef16b5c6ba4ec49a3532336ed72/cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8", size = 4984707, upload-time = "2025-10-15T23:17:01.98Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/56/e7e69b427c3878352c2fb9b450bd0e19ed552753491d39d7d0a2f5226d41/cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec", size = 4482541, upload-time = "2025-10-15T23:17:04.078Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f6/50736d40d97e8483172f1bb6e698895b92a223dba513b0ca6f06b2365339/cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91", size = 4299464, upload-time = "2025-10-15T23:17:05.483Z" },
+    { url = "https://files.pythonhosted.org/packages/00/de/d8e26b1a855f19d9994a19c702fa2e93b0456beccbcfe437eda00e0701f2/cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e", size = 4950838, upload-time = "2025-10-15T23:17:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/798fc4ec461a1c9e9f735f2fc58741b0daae30688f41b2497dcbc9ed1355/cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926", size = 4481596, upload-time = "2025-10-15T23:17:09.343Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8d/03cd48b20a573adfff7652b76271078e3045b9f49387920e7f1f631d125e/cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71", size = 4426782, upload-time = "2025-10-15T23:17:11.22Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/ebacbfe53317d55cf33165bda24c86523497a6881f339f9aae5c2e13e57b/cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac", size = 4698381, upload-time = "2025-10-15T23:17:12.829Z" },
+    { url = "https://files.pythonhosted.org/packages/96/92/8a6a9525893325fc057a01f654d7efc2c64b9de90413adcf605a85744ff4/cryptography-46.0.3-cp311-abi3-win32.whl", hash = "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018", size = 3055988, upload-time = "2025-10-15T23:17:14.65Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/bf/80fbf45253ea585a1e492a6a17efcb93467701fa79e71550a430c5e60df0/cryptography-46.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb", size = 3514451, upload-time = "2025-10-15T23:17:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/af/9b302da4c87b0beb9db4e756386a7c6c5b8003cd0e742277888d352ae91d/cryptography-46.0.3-cp311-abi3-win_arm64.whl", hash = "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c", size = 2928007, upload-time = "2025-10-15T23:17:18.04Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e2/a510aa736755bffa9d2f75029c229111a1d02f8ecd5de03078f4c18d91a3/cryptography-46.0.3-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217", size = 7158012, upload-time = "2025-10-15T23:17:19.982Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dc/9aa866fbdbb95b02e7f9d086f1fccfeebf8953509b87e3f28fff927ff8a0/cryptography-46.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5", size = 4288728, upload-time = "2025-10-15T23:17:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/fd/bc1daf8230eaa075184cbbf5f8cd00ba9db4fd32d63fb83da4671b72ed8a/cryptography-46.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715", size = 4435078, upload-time = "2025-10-15T23:17:23.042Z" },
+    { url = "https://files.pythonhosted.org/packages/82/98/d3bd5407ce4c60017f8ff9e63ffee4200ab3e23fe05b765cab805a7db008/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54", size = 4293460, upload-time = "2025-10-15T23:17:24.885Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e9/e23e7900983c2b8af7a08098db406cf989d7f09caea7897e347598d4cd5b/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459", size = 3995237, upload-time = "2025-10-15T23:17:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/af68c509d4a138cfe299d0d7ddb14afba15233223ebd933b4bbdbc7155d3/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422", size = 4967344, upload-time = "2025-10-15T23:17:28.06Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e3/8643d077c53868b681af077edf6b3cb58288b5423610f21c62aadcbe99f4/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7", size = 4466564, upload-time = "2025-10-15T23:17:29.665Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/43/c1e8726fa59c236ff477ff2b5dc071e54b21e5a1e51aa2cee1676f1c986f/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044", size = 4292415, upload-time = "2025-10-15T23:17:31.686Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f9/2f8fefdb1aee8a8e3256a0568cffc4e6d517b256a2fe97a029b3f1b9fe7e/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665", size = 4931457, upload-time = "2025-10-15T23:17:33.478Z" },
+    { url = "https://files.pythonhosted.org/packages/79/30/9b54127a9a778ccd6d27c3da7563e9f2d341826075ceab89ae3b41bf5be2/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3", size = 4466074, upload-time = "2025-10-15T23:17:35.158Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/b4f4a10928e26c941b1b6a179143af9f4d27d88fe84a6a3c53592d2e76bf/cryptography-46.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20", size = 4420569, upload-time = "2025-10-15T23:17:37.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/49/3746dab4c0d1979888f125226357d3262a6dd40e114ac29e3d2abdf1ec55/cryptography-46.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de", size = 4681941, upload-time = "2025-10-15T23:17:39.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/30/27654c1dbaf7e4a3531fa1fc77986d04aefa4d6d78259a62c9dc13d7ad36/cryptography-46.0.3-cp314-cp314t-win32.whl", hash = "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914", size = 3022339, upload-time = "2025-10-15T23:17:40.888Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/30/640f34ccd4d2a1bc88367b54b926b781b5a018d65f404d409aba76a84b1c/cryptography-46.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db", size = 3494315, upload-time = "2025-10-15T23:17:42.769Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8b/88cc7e3bd0a8e7b861f26981f7b820e1f46aa9d26cc482d0feba0ecb4919/cryptography-46.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21", size = 2919331, upload-time = "2025-10-15T23:17:44.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/23/45fe7f376a7df8daf6da3556603b36f53475a99ce4faacb6ba2cf3d82021/cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936", size = 7218248, upload-time = "2025-10-15T23:17:46.294Z" },
+    { url = "https://files.pythonhosted.org/packages/27/32/b68d27471372737054cbd34c84981f9edbc24fe67ca225d389799614e27f/cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683", size = 4294089, upload-time = "2025-10-15T23:17:48.269Z" },
+    { url = "https://files.pythonhosted.org/packages/26/42/fa8389d4478368743e24e61eea78846a0006caffaf72ea24a15159215a14/cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d", size = 4440029, upload-time = "2025-10-15T23:17:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/f483db0ec5ac040824f269e93dd2bd8a21ecd1027e77ad7bdf6914f2fd80/cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0", size = 4297222, upload-time = "2025-10-15T23:17:51.357Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/da9502c4e1912cb1da3807ea3618a6829bee8207456fbbeebc361ec38ba3/cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc", size = 4012280, upload-time = "2025-10-15T23:17:52.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8f/9adb86b93330e0df8b3dcf03eae67c33ba89958fc2e03862ef1ac2b42465/cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3", size = 4978958, upload-time = "2025-10-15T23:17:54.965Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/5fa77988289c34bdb9f913f5606ecc9ada1adb5ae870bd0d1054a7021cc4/cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971", size = 4473714, upload-time = "2025-10-15T23:17:56.754Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e5/fc82d72a58d41c393697aa18c9abe5ae1214ff6f2a5c18ac470f92777895/cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac", size = 4296970, upload-time = "2025-10-15T23:17:58.588Z" },
+    { url = "https://files.pythonhosted.org/packages/78/06/5663ed35438d0b09056973994f1aec467492b33bd31da36e468b01ec1097/cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04", size = 4940236, upload-time = "2025-10-15T23:18:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/59/873633f3f2dcd8a053b8dd1d38f783043b5fce589c0f6988bf55ef57e43e/cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506", size = 4472642, upload-time = "2025-10-15T23:18:02.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/8e71f3930e40f6877737d6f69248cf74d4e34b886a3967d32f919cc50d3b/cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963", size = 4423126, upload-time = "2025-10-15T23:18:04.85Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c7/f65027c2810e14c3e7268353b1681932b87e5a48e65505d8cc17c99e36ae/cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4", size = 4686573, upload-time = "2025-10-15T23:18:06.908Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/1c8331ddf91ca4730ab3086a0f1be19c65510a33b5a441cb334e7a2d2560/cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df", size = 3036695, upload-time = "2025-10-15T23:18:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/b0d691df20633eff80955a0fc7695ff9051ffce8b69741444bd9ed7bd0db/cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f", size = 3501720, upload-time = "2025-10-15T23:18:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cb/2da4cc83f5edb9c3257d09e1e7ab7b23f049c7962cae8d842bbef0a9cec9/cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372", size = 2918740, upload-time = "2025-10-15T23:18:12.277Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/e60e46adab4362a682cf142c7dcb5bf79b782ab2199b0dcb81f55970807f/cryptography-46.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7ce938a99998ed3c8aa7e7272dca1a610401ede816d36d0693907d863b10d9ea", size = 3698132, upload-time = "2025-10-15T23:18:17.056Z" },
+    { url = "https://files.pythonhosted.org/packages/da/38/f59940ec4ee91e93d3311f7532671a5cef5570eb04a144bf203b58552d11/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:191bb60a7be5e6f54e30ba16fdfae78ad3a342a0599eb4193ba88e3f3d6e185b", size = 4243992, upload-time = "2025-10-15T23:18:18.695Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/0c/35b3d92ddebfdfda76bb485738306545817253d0a3ded0bfe80ef8e67aa5/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c70cc23f12726be8f8bc72e41d5065d77e4515efae3690326764ea1b07845cfb", size = 4409944, upload-time = "2025-10-15T23:18:20.597Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/181022996c4063fc0e7666a47049a1ca705abb9c8a13830f074edb347495/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717", size = 4242957, upload-time = "2025-10-15T23:18:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/af/72cd6ef29f9c5f731251acadaeb821559fe25f10852f44a63374c9ca08c1/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9", size = 4409447, upload-time = "2025-10-15T23:18:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c3/e90f4a4feae6410f914f8ebac129b9ae7a8c92eb60a638012dde42030a9d/cryptography-46.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c", size = 3438528, upload-time = "2025-10-15T23:18:26.227Z" },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
 ]
 
 [[package]]
@@ -494,6 +640,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -663,6 +827,25 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -727,6 +910,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.10"
 source = { registry = "https://pypi.org/simple" }
@@ -750,6 +945,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -3,11 +3,13 @@
 This is a suggested order of execution based on dependencies and risk.
 
 ## 1) Foundation
-- #29 Initialize Nuxt 3 project with UI library
+
+- #29 Initialize Nuxt 3 project with UI library - DONE
 - #18 Set up FastAPI with Supabase JWT verification middleware
 - #7 Configure Alembic for database migrations
 
 ## 2) Core data model
+
 - #8 Create bibliographic tables: authors, works, editions, work_authors
 - #9 Create external provider tracking tables: external_ids, source_records
 - #10 Create user tables: users, library_items, reading_sessions
@@ -16,6 +18,7 @@ This is a suggested order of execution based on dependencies and risk.
 - #13 Configure RLS policies for user-owned tables
 
 ## 3) Auth
+
 - #6 Disable email/password sign-in in Supabase Auth
 - #4 Configure Supabase Auth with Apple and Google OAuth providers
 - #5 Configure and test magic link (passwordless) login
@@ -25,6 +28,7 @@ This is a suggested order of execution based on dependencies and risk.
 - #28 Implement rate limiting per (client_id, user_id)
 
 ## 4) API features
+
 - #14 Implement Open Library Search API integration with caching
 - #15 Implement import endpoint for Open Library works and editions
 - #16 Cache Open Library cover images to Supabase Storage
@@ -37,24 +41,29 @@ This is a suggested order of execution based on dependencies and risk.
 - #24 Implement review endpoints with public listing
 
 ## 5) Web UI
+
 - #30 Implement login page with OAuth and magic link options
 - #31 Implement book search and import interface
 - #32 Implement library list with filters
 - #33 Implement book detail page with reading/notes/highlights
 
 ## 6) iOS
+
 - #34 Initialize SwiftUI project with OAuth PKCE authentication
 - #35 Implement API client layer for iOS app
 - #36 Implement library list and book search in SwiftUI
 - #37 Implement notes, highlights, and reviews UI in iOS
 
 ## 7) Federation / ActivityPub
+
 - #38 Define and document canonical public URL patterns
 - #39 Add optional ap_uri columns for federation readiness
 - #40 Reserve ActivityPub endpoints with placeholder responses
 
 ## 8) Hosting wiring
+
 - #44 Configure hosting env vars for Supabase staging/production
 
 ## Notes
+
 - #3 (Supabase staging/production projects) is done. Hosting wiring is tracked separately in #44.

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -34,9 +34,11 @@ supabase status -o env
 # API_URL -> SUPABASE_URL / NUXT_PUBLIC_SUPABASE_URL
 # ANON_KEY -> SUPABASE_ANON_KEY / NUXT_PUBLIC_SUPABASE_ANON_KEY
 # SERVICE_ROLE_KEY -> SUPABASE_SERVICE_ROLE_KEY
+# JWT_SECRET -> SUPABASE_JWT_SECRET
 ```
 
 Use the output to populate your local `.env` (not committed). The `service_role` key is server-only.
+The API also reads `.env` automatically on startup, so you can run `make dev-api` without manually sourcing it.
 
 Local development is fully independent of hosting. You can build and run the app with local Supabase even if staging/production hosting is not set up yet.
 


### PR DESCRIPTION
## Summary
- add FastAPI app structure with health/version/protected routes
- implement Supabase JWT verification with JWKS cache and HS256 fallback for local tokens
- load .env for API config and map JWT_SECRET in supabase docs/Makefile
- expand API tests and ensure coverage gates pass
- mark issue-roadmap #29 as done

## Testing
- make quality

Closes #18