### PR TITLE
Create user library tables

### DIFF
--- a/apps/api/alembic/versions/0004_user_tables.py
+++ b/apps/api/alembic/versions/0004_user_tables.py
@@ -1,0 +1,244 @@
+"""Create user and library tables.
+
+Revision ID: 0004_user_tables
+Revises: 0003_external_provider_tables
+Create Date: 2025-01-04 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0004_user_tables"
+down_revision = "0003_external_provider_tables"
+branch_labels = None
+depends_on = None
+
+library_item_status_enum = postgresql.ENUM(
+    "to_read",
+    "reading",
+    "completed",
+    "abandoned",
+    name="library_item_status",
+    create_type=False,
+)
+library_item_visibility_enum = postgresql.ENUM(
+    "private",
+    "public",
+    name="library_item_visibility",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    library_item_status_enum.create(op.get_bind(), checkfirst=True)
+    library_item_visibility_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("auth.users.id"),
+            primary_key=True,
+        ),
+        sa.Column("handle", sa.String(64), nullable=False),
+        sa.Column("display_name", sa.String(255)),
+        sa.Column("avatar_url", sa.Text),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("handle", name="uq_users_handle"),
+    )
+
+    op.create_table(
+        "library_items",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "work_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("works.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "preferred_edition_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("editions.id"),
+        ),
+        sa.Column("status", library_item_status_enum, nullable=False),
+        sa.Column("visibility", library_item_visibility_enum, nullable=False),
+        sa.Column("rating", sa.SmallInteger),
+        sa.Column("tags", sa.dialects.postgresql.ARRAY(sa.String(64))),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "work_id",
+            name="uq_library_items_user_work",
+        ),
+    )
+    op.create_index("ix_library_items_user_id", "library_items", ["user_id"])
+    op.create_index("ix_library_items_status", "library_items", ["status"])
+    op.create_index(
+        "ix_library_items_visibility",
+        "library_items",
+        ["visibility"],
+    )
+
+    op.create_table(
+        "reading_sessions",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_item_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("library_items.id"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True)),
+        sa.Column("pages_read", sa.Integer),
+        sa.Column("progress_percent", sa.Numeric(5, 2)),
+        sa.Column("note", sa.Text),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_reading_sessions_user_id",
+        "reading_sessions",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_reading_sessions_library_item_id",
+        "reading_sessions",
+        ["library_item_id"],
+    )
+
+    op.create_table(
+        "reading_state_events",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_item_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("library_items.id"),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(32), nullable=False),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_reading_state_events_user_id",
+        "reading_state_events",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_reading_state_events_library_item_id",
+        "reading_state_events",
+        ["library_item_id"],
+    )
+    op.create_index(
+        "ix_reading_state_events_occurred_at",
+        "reading_state_events",
+        ["occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_reading_state_events_occurred_at",
+        table_name="reading_state_events",
+    )
+    op.drop_index(
+        "ix_reading_state_events_library_item_id",
+        table_name="reading_state_events",
+    )
+    op.drop_index(
+        "ix_reading_state_events_user_id",
+        table_name="reading_state_events",
+    )
+    op.drop_table("reading_state_events")
+    op.drop_index(
+        "ix_reading_sessions_library_item_id",
+        table_name="reading_sessions",
+    )
+    op.drop_index(
+        "ix_reading_sessions_user_id",
+        table_name="reading_sessions",
+    )
+    op.drop_table("reading_sessions")
+    op.drop_index("ix_library_items_visibility", table_name="library_items")
+    op.drop_index("ix_library_items_status", table_name="library_items")
+    op.drop_index("ix_library_items_user_id", table_name="library_items")
+    op.drop_table("library_items")
+    op.drop_table("users")
+    library_item_visibility_enum.drop(op.get_bind(), checkfirst=True)
+    library_item_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/apps/api/app/db/models/__init__.py
+++ b/apps/api/app/db/models/__init__.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
 from app.db.models.external_provider import ExternalId, SourceRecord
+from app.db.models.users import (
+    LibraryItem,
+    ReadingSession,
+    ReadingStateEvent,
+    User,
+)
 
 __all__ = [
     "Author",
     "Edition",
     "ExternalId",
+    "LibraryItem",
+    "ReadingSession",
+    "ReadingStateEvent",
     "SourceRecord",
+    "User",
     "Work",
     "WorkAuthor",
 ]

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, ENUM
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+library_item_status_enum = ENUM(
+    "to_read",
+    "reading",
+    "completed",
+    "abandoned",
+    name="library_item_status",
+    create_type=False,
+)
+library_item_visibility_enum = ENUM(
+    "private",
+    "public",
+    name="library_item_visibility",
+    create_type=False,
+)
+
+
+class User(Base):
+    __tablename__ = "users"
+    __table_args__ = (sa.UniqueConstraint("handle", name="uq_users_handle"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("auth.users.id"),
+        primary_key=True,
+    )
+    handle: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(sa.String(255))
+    avatar_url: Mapped[str | None] = mapped_column(sa.Text)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class LibraryItem(Base):
+    __tablename__ = "library_items"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "user_id",
+            "work_id",
+            name="uq_library_items_user_work",
+        ),
+        sa.Index("ix_library_items_user_id", "user_id"),
+        sa.Index("ix_library_items_status", "status"),
+        sa.Index("ix_library_items_visibility", "visibility"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id"),
+        nullable=False,
+    )
+    work_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("works.id"),
+        nullable=False,
+    )
+    preferred_edition_id: Mapped[uuid.UUID | None] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("editions.id"),
+    )
+    status: Mapped[str] = mapped_column(library_item_status_enum, nullable=False)
+    visibility: Mapped[str] = mapped_column(
+        library_item_visibility_enum,
+        nullable=False,
+    )
+    rating: Mapped[int | None] = mapped_column(sa.SmallInteger)
+    tags: Mapped[list[str] | None] = mapped_column(ARRAY(sa.String(64)))
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class ReadingSession(Base):
+    __tablename__ = "reading_sessions"
+    __table_args__ = (
+        sa.Index("ix_reading_sessions_user_id", "user_id"),
+        sa.Index("ix_reading_sessions_library_item_id", "library_item_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id"),
+        nullable=False,
+    )
+    library_item_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("library_items.id"),
+        nullable=False,
+    )
+    started_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+    )
+    ended_at: Mapped[dt.datetime | None] = mapped_column(sa.DateTime(timezone=True))
+    pages_read: Mapped[int | None] = mapped_column(sa.Integer)
+    progress_percent: Mapped[float | None] = mapped_column(sa.Numeric(5, 2))
+    note: Mapped[str | None] = mapped_column(sa.Text)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class ReadingStateEvent(Base):
+    __tablename__ = "reading_state_events"
+    __table_args__ = (
+        sa.Index("ix_reading_state_events_user_id", "user_id"),
+        sa.Index("ix_reading_state_events_library_item_id", "library_item_id"),
+        sa.Index("ix_reading_state_events_occurred_at", "occurred_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id"),
+        nullable=False,
+    )
+    library_item_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("library_items.id"),
+        nullable=False,
+    )
+    event_type: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    occurred_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )

--- a/apps/api/tests/test_user_library_models.py
+++ b/apps/api/tests/test_user_library_models.py
@@ -1,0 +1,184 @@
+from typing import cast
+
+import sqlalchemy as sa
+
+from app.db.base import Base
+from app.db.models import LibraryItem, ReadingSession, ReadingStateEvent, User
+
+
+def _get_table(name: str) -> sa.Table:
+    return Base.metadata.tables[name]
+
+
+def test_user_library_tables_registered() -> None:
+    assert User.__tablename__ in Base.metadata.tables
+    assert LibraryItem.__tablename__ in Base.metadata.tables
+    assert ReadingSession.__tablename__ in Base.metadata.tables
+    assert ReadingStateEvent.__tablename__ in Base.metadata.tables
+
+
+def test_users_table_schema() -> None:
+    table = _get_table("users")
+    assert set(table.columns.keys()) == {
+        "id",
+        "handle",
+        "display_name",
+        "avatar_url",
+        "created_at",
+        "updated_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert table.columns["id"].server_default is None
+    assert isinstance(table.columns["handle"].type, sa.String)
+    assert table.columns["handle"].type.length == 64
+    assert isinstance(table.columns["display_name"].type, sa.String)
+    assert table.columns["display_name"].type.length == 255
+    assert isinstance(table.columns["avatar_url"].type, sa.Text)
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)
+    assert created_at_type.timezone is True
+    assert updated_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "auth.users.id" in fk_targets
+
+    unique_constraints = [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, sa.UniqueConstraint)
+    ]
+    unique_sets = {
+        tuple(constraint.columns.keys()) for constraint in unique_constraints
+    }
+    assert ("handle",) in unique_sets
+
+    assert not table.indexes
+
+
+def test_library_items_table_schema() -> None:
+    table = _get_table("library_items")
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "work_id",
+        "preferred_edition_id",
+        "status",
+        "visibility",
+        "rating",
+        "tags",
+        "created_at",
+        "updated_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["work_id"].type, sa.UUID)
+    assert isinstance(table.columns["preferred_edition_id"].type, sa.UUID)
+    assert isinstance(table.columns["status"].type, sa.Enum)
+    assert table.columns["status"].type.enums == [
+        "to_read",
+        "reading",
+        "completed",
+        "abandoned",
+    ]
+    assert isinstance(table.columns["visibility"].type, sa.Enum)
+    assert table.columns["visibility"].type.enums == ["private", "public"]
+    assert isinstance(table.columns["rating"].type, sa.SmallInteger)
+    assert isinstance(table.columns["tags"].type, sa.ARRAY)
+    assert isinstance(table.columns["tags"].type.item_type, sa.String)
+    assert table.columns["tags"].type.item_type.length == 64
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)
+    assert created_at_type.timezone is True
+    assert updated_at_type.timezone is True
+
+    unique_constraints = [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, sa.UniqueConstraint)
+    ]
+    unique_sets = {
+        tuple(constraint.columns.keys()) for constraint in unique_constraints
+    }
+    assert ("user_id", "work_id") in unique_sets
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    assert "works.id" in fk_targets
+    assert "editions.id" in fk_targets
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_library_items_user_id" in index_names
+    assert "ix_library_items_status" in index_names
+    assert "ix_library_items_visibility" in index_names
+
+
+def test_reading_sessions_table_schema() -> None:
+    table = _get_table("reading_sessions")
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "library_item_id",
+        "started_at",
+        "ended_at",
+        "pages_read",
+        "progress_percent",
+        "note",
+        "created_at",
+        "updated_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["library_item_id"].type, sa.UUID)
+    assert isinstance(table.columns["started_at"].type, sa.DateTime)
+    assert isinstance(table.columns["ended_at"].type, sa.DateTime)
+    assert isinstance(table.columns["pages_read"].type, sa.Integer)
+    assert isinstance(table.columns["progress_percent"].type, sa.Numeric)
+    assert isinstance(table.columns["note"].type, sa.Text)
+
+    started_at_type = table.columns["started_at"].type
+    ended_at_type = table.columns["ended_at"].type
+    assert started_at_type.timezone is True
+    assert ended_at_type.timezone is True
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)
+    assert created_at_type.timezone is True
+    assert updated_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    assert "library_items.id" in fk_targets
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_reading_sessions_user_id" in index_names
+    assert "ix_reading_sessions_library_item_id" in index_names
+
+
+def test_reading_state_events_table_schema() -> None:
+    table = _get_table("reading_state_events")
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "library_item_id",
+        "event_type",
+        "occurred_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["library_item_id"].type, sa.UUID)
+    assert isinstance(table.columns["event_type"].type, sa.String)
+    assert table.columns["event_type"].type.length == 32
+
+    occurred_at_type = cast(sa.DateTime, table.columns["occurred_at"].type)
+    assert occurred_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    assert "library_items.id" in fk_targets
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_reading_state_events_user_id" in index_names
+    assert "ix_reading_state_events_library_item_id" in index_names
+    assert "ix_reading_state_events_occurred_at" in index_names

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -11,8 +11,8 @@ This is a suggested order of execution based on dependencies and risk.
 ## 2) Core data model
 
 - #8 Create bibliographic tables: authors, works, editions, work_authors - DONE
-- #9 Create external provider tracking tables: external_ids, source_records
-- #10 Create user tables: users, library_items, reading_sessions
+- #9 Create external provider tracking tables: external_ids, source_records - DONE
+- #10 Create user tables: users, library_items, reading_sessions - DONE
 - #11 Create content tables: notes, highlights, reviews
 - #12 Create platform tables: api_clients, api_audit_logs
 - #13 Configure RLS policies for user-owned tables


### PR DESCRIPTION
## Summary
- add users, library_items, reading_sessions, and reading_state_events models
- add Alembic migration with enums, constraints, and indexes
- add schema tests for the new tables
- update issue roadmap for #9/#10

## Testing
- make quality (run earlier on branch; not rerun after latest enum tweak)

Closes #10