### PR TITLE
Create content tables for notes, highlights, reviews

### DIFF
--- a/apps/api/alembic/versions/0005_content_tables.py
+++ b/apps/api/alembic/versions/0005_content_tables.py
@@ -1,0 +1,212 @@
+"""Create content tables.
+
+Revision ID: 0005_content_tables
+Revises: 0004_user_tables
+Create Date: 2025-01-04 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0005_content_tables"
+down_revision = "0004_user_tables"
+branch_labels = None
+depends_on = None
+
+content_visibility_enum = postgresql.ENUM(
+    "private",
+    "public",
+    name="content_visibility",
+    create_type=False,
+)
+highlight_location_type_enum = postgresql.ENUM(
+    "page",
+    "percent",
+    "location",
+    "cfi",
+    name="highlight_location_type",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    content_visibility_enum.create(op.get_bind(), checkfirst=True)
+    highlight_location_type_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "notes",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_item_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(255)),
+        sa.Column("body", sa.Text, nullable=False),
+        sa.Column(
+            "visibility",
+            content_visibility_enum,
+            nullable=False,
+            server_default=sa.text("'private'::content_visibility"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_notes_user_id", "notes", ["user_id"])
+    op.create_index("ix_notes_library_item_id", "notes", ["library_item_id"])
+    op.create_index("ix_notes_visibility", "notes", ["visibility"])
+    op.create_index("ix_notes_created_at", "notes", ["created_at"])
+
+    op.create_table(
+        "highlights",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_item_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("quote", sa.Text, nullable=False),
+        sa.Column("location", postgresql.JSONB),
+        sa.Column("location_type", highlight_location_type_enum),
+        sa.Column("location_sort", sa.Numeric(10, 2)),
+        sa.Column(
+            "visibility",
+            content_visibility_enum,
+            nullable=False,
+            server_default=sa.text("'private'::content_visibility"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_highlights_user_id", "highlights", ["user_id"])
+    op.create_index(
+        "ix_highlights_library_item_id",
+        "highlights",
+        ["library_item_id"],
+    )
+    op.create_index("ix_highlights_visibility", "highlights", ["visibility"])
+    op.create_index("ix_highlights_created_at", "highlights", ["created_at"])
+
+    op.create_table(
+        "reviews",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_item_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(255)),
+        sa.Column("body", sa.Text, nullable=False),
+        sa.Column("rating", sa.SmallInteger),
+        sa.Column(
+            "visibility",
+            content_visibility_enum,
+            nullable=False,
+            server_default=sa.text("'private'::content_visibility"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "library_item_id",
+            name="uq_reviews_user_library_item",
+        ),
+        sa.CheckConstraint(
+            "rating >= 0 AND rating <= 10",
+            name="ck_reviews_rating_range",
+        ),
+    )
+    op.create_index("ix_reviews_user_id", "reviews", ["user_id"])
+    op.create_index("ix_reviews_library_item_id", "reviews", ["library_item_id"])
+    op.create_index("ix_reviews_visibility", "reviews", ["visibility"])
+    op.create_index("ix_reviews_created_at", "reviews", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reviews_created_at", table_name="reviews")
+    op.drop_index("ix_reviews_visibility", table_name="reviews")
+    op.drop_index("ix_reviews_library_item_id", table_name="reviews")
+    op.drop_index("ix_reviews_user_id", table_name="reviews")
+    op.drop_table("reviews")
+    op.drop_index("ix_highlights_created_at", table_name="highlights")
+    op.drop_index("ix_highlights_visibility", table_name="highlights")
+    op.drop_index("ix_highlights_library_item_id", table_name="highlights")
+    op.drop_index("ix_highlights_user_id", table_name="highlights")
+    op.drop_table("highlights")
+    op.drop_index("ix_notes_created_at", table_name="notes")
+    op.drop_index("ix_notes_visibility", table_name="notes")
+    op.drop_index("ix_notes_library_item_id", table_name="notes")
+    op.drop_index("ix_notes_user_id", table_name="notes")
+    op.drop_table("notes")
+    highlight_location_type_enum.drop(op.get_bind(), checkfirst=True)
+    content_visibility_enum.drop(op.get_bind(), checkfirst=True)

--- a/apps/api/app/db/models/__init__.py
+++ b/apps/api/app/db/models/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
+from app.db.models.content import Highlight, Note, Review
 from app.db.models.external_provider import ExternalId, SourceRecord
 from app.db.models.users import (
     LibraryItem,
@@ -13,9 +14,12 @@ __all__ = [
     "Author",
     "Edition",
     "ExternalId",
+    "Highlight",
     "LibraryItem",
+    "Note",
     "ReadingSession",
     "ReadingStateEvent",
+    "Review",
     "SourceRecord",
     "User",
     "Work",

--- a/apps/api/app/db/models/content.py
+++ b/apps/api/app/db/models/content.py
@@ -75,6 +75,11 @@ class Highlight(Base):
         sa.Index("ix_highlights_library_item_id", "library_item_id"),
         sa.Index("ix_highlights_visibility", "visibility"),
         sa.Index("ix_highlights_created_at", "created_at"),
+        sa.Index(
+            "ix_highlights_library_item_id_location_sort",
+            "library_item_id",
+            "location_sort",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/apps/api/app/db/models/content.py
+++ b/apps/api/app/db/models/content.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+content_visibility_enum = ENUM(
+    "private",
+    "public",
+    name="content_visibility",
+    create_type=False,
+)
+highlight_location_type_enum = ENUM(
+    "page",
+    "percent",
+    "location",
+    "cfi",
+    name="highlight_location_type",
+    create_type=False,
+)
+
+
+class Note(Base):
+    __tablename__ = "notes"
+    __table_args__ = (
+        sa.Index("ix_notes_user_id", "user_id"),
+        sa.Index("ix_notes_library_item_id", "library_item_id"),
+        sa.Index("ix_notes_visibility", "visibility"),
+        sa.Index("ix_notes_created_at", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    library_item_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str | None] = mapped_column(sa.String(255))
+    body: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    visibility: Mapped[str] = mapped_column(
+        content_visibility_enum,
+        nullable=False,
+        server_default=sa.text("'private'::content_visibility"),
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class Highlight(Base):
+    __tablename__ = "highlights"
+    __table_args__ = (
+        sa.Index("ix_highlights_user_id", "user_id"),
+        sa.Index("ix_highlights_library_item_id", "library_item_id"),
+        sa.Index("ix_highlights_visibility", "visibility"),
+        sa.Index("ix_highlights_created_at", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    library_item_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    quote: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    location: Mapped[dict[str, object] | None] = mapped_column(JSONB)
+    location_type: Mapped[str | None] = mapped_column(highlight_location_type_enum)
+    location_sort: Mapped[float | None] = mapped_column(sa.Numeric(10, 2))
+    visibility: Mapped[str] = mapped_column(
+        content_visibility_enum,
+        nullable=False,
+        server_default=sa.text("'private'::content_visibility"),
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class Review(Base):
+    __tablename__ = "reviews"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "user_id",
+            "library_item_id",
+            name="uq_reviews_user_library_item",
+        ),
+        sa.CheckConstraint(
+            "rating >= 0 AND rating <= 10",
+            name="ck_reviews_rating_range",
+        ),
+        sa.Index("ix_reviews_user_id", "user_id"),
+        sa.Index("ix_reviews_library_item_id", "library_item_id"),
+        sa.Index("ix_reviews_visibility", "visibility"),
+        sa.Index("ix_reviews_created_at", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    library_item_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str | None] = mapped_column(sa.String(255))
+    body: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    rating: Mapped[int | None] = mapped_column(sa.SmallInteger)
+    visibility: Mapped[str] = mapped_column(
+        content_visibility_enum,
+        nullable=False,
+        server_default=sa.text("'private'::content_visibility"),
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )

--- a/apps/api/tests/test_content_models.py
+++ b/apps/api/tests/test_content_models.py
@@ -1,0 +1,178 @@
+from typing import cast
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.db.base import Base
+from app.db.models import Highlight, Note, Review
+
+
+def _get_table(name: str) -> sa.Table:
+    return Base.metadata.tables[name]
+
+
+def test_content_tables_registered() -> None:
+    assert Note.__tablename__ in Base.metadata.tables
+    assert Highlight.__tablename__ in Base.metadata.tables
+    assert Review.__tablename__ in Base.metadata.tables
+
+
+def test_notes_table_schema() -> None:
+    table = _get_table("notes")
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "library_item_id",
+        "title",
+        "body",
+        "visibility",
+        "created_at",
+        "updated_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["library_item_id"].type, sa.UUID)
+    assert isinstance(table.columns["title"].type, sa.String)
+    assert table.columns["title"].type.length == 255
+    assert isinstance(table.columns["body"].type, sa.Text)
+    assert isinstance(table.columns["visibility"].type, sa.Enum)
+    assert table.columns["visibility"].type.enums == ["private", "public"]
+    assert table.columns["visibility"].server_default is not None
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)
+    assert created_at_type.timezone is True
+    assert updated_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    assert "library_items.id" in fk_targets
+    user_fk = next(fk for fk in table.foreign_keys if fk.target_fullname == "users.id")
+    library_item_fk = next(
+        fk for fk in table.foreign_keys if fk.target_fullname == "library_items.id"
+    )
+    assert user_fk.ondelete == "CASCADE"
+    assert library_item_fk.ondelete == "CASCADE"
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_notes_user_id" in index_names
+    assert "ix_notes_library_item_id" in index_names
+    assert "ix_notes_visibility" in index_names
+    assert "ix_notes_created_at" in index_names
+
+
+def test_highlights_table_schema() -> None:
+    table = _get_table("highlights")
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "library_item_id",
+        "quote",
+        "location",
+        "location_type",
+        "location_sort",
+        "visibility",
+        "created_at",
+        "updated_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["library_item_id"].type, sa.UUID)
+    assert isinstance(table.columns["quote"].type, sa.Text)
+    assert isinstance(table.columns["location"].type, JSONB)
+    assert isinstance(table.columns["location_type"].type, sa.Enum)
+    assert table.columns["location_type"].type.enums == [
+        "page",
+        "percent",
+        "location",
+        "cfi",
+    ]
+    assert isinstance(table.columns["location_sort"].type, sa.Numeric)
+    assert isinstance(table.columns["visibility"].type, sa.Enum)
+    assert table.columns["visibility"].type.enums == ["private", "public"]
+    assert table.columns["visibility"].server_default is not None
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)
+    assert created_at_type.timezone is True
+    assert updated_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    assert "library_items.id" in fk_targets
+    user_fk = next(fk for fk in table.foreign_keys if fk.target_fullname == "users.id")
+    library_item_fk = next(
+        fk for fk in table.foreign_keys if fk.target_fullname == "library_items.id"
+    )
+    assert user_fk.ondelete == "CASCADE"
+    assert library_item_fk.ondelete == "CASCADE"
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_highlights_user_id" in index_names
+    assert "ix_highlights_library_item_id" in index_names
+    assert "ix_highlights_visibility" in index_names
+    assert "ix_highlights_created_at" in index_names
+
+
+def test_reviews_table_schema_and_constraints() -> None:
+    table = _get_table("reviews")
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "library_item_id",
+        "title",
+        "body",
+        "rating",
+        "visibility",
+        "created_at",
+        "updated_at",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["library_item_id"].type, sa.UUID)
+    assert isinstance(table.columns["title"].type, sa.String)
+    assert table.columns["title"].type.length == 255
+    assert isinstance(table.columns["body"].type, sa.Text)
+    assert isinstance(table.columns["rating"].type, sa.SmallInteger)
+    assert isinstance(table.columns["visibility"].type, sa.Enum)
+    assert table.columns["visibility"].type.enums == ["private", "public"]
+    assert table.columns["visibility"].server_default is not None
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)
+    assert created_at_type.timezone is True
+    assert updated_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    assert "library_items.id" in fk_targets
+    user_fk = next(fk for fk in table.foreign_keys if fk.target_fullname == "users.id")
+    library_item_fk = next(
+        fk for fk in table.foreign_keys if fk.target_fullname == "library_items.id"
+    )
+    assert user_fk.ondelete == "CASCADE"
+    assert library_item_fk.ondelete == "CASCADE"
+
+    unique_constraints = [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, sa.UniqueConstraint)
+    ]
+    unique_sets = {
+        tuple(constraint.columns.keys()) for constraint in unique_constraints
+    }
+    assert ("user_id", "library_item_id") in unique_sets
+
+    check_constraints = [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, sa.CheckConstraint)
+    ]
+    check_names = {constraint.name for constraint in check_constraints}
+    assert "ck_reviews_rating_range" in check_names
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_reviews_user_id" in index_names
+    assert "ix_reviews_library_item_id" in index_names
+    assert "ix_reviews_visibility" in index_names
+    assert "ix_reviews_created_at" in index_names

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -13,7 +13,7 @@ This is a suggested order of execution based on dependencies and risk.
 - #8 Create bibliographic tables: authors, works, editions, work_authors - DONE
 - #9 Create external provider tracking tables: external_ids, source_records - DONE
 - #10 Create user tables: users, library_items, reading_sessions - DONE
-- #11 Create content tables: notes, highlights, reviews
+- #11 Create content tables: notes, highlights, reviews - DONE
 - #12 Create platform tables: api_clients, api_audit_logs
 - #13 Configure RLS policies for user-owned tables
 


### PR DESCRIPTION
## Summary
- add notes/highlights/reviews models with private-by-default visibility
- add Alembic migration for content tables, enums, constraints, indexes
- add schema tests for coverage gates and mark #11 done in roadmap

## Testing
- user reported: uv run pytest

Closes #11