### PR TITLE
Add platform tables for API clients and audit logs

### DIFF
--- a/apps/api/alembic/versions/0006_platform_tables.py
+++ b/apps/api/alembic/versions/0006_platform_tables.py
@@ -1,0 +1,123 @@
+"""Create platform tables.
+
+Revision ID: 0006_platform_tables
+Revises: 0005_content_tables
+Create Date: 2025-01-04 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0006_platform_tables"
+down_revision = "0005_content_tables"
+branch_labels = None
+depends_on = None
+
+api_client_status_enum = postgresql.ENUM(
+    "active",
+    "suspended",
+    name="api_client_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    api_client_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "api_clients",
+        sa.Column(
+            "client_id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column(
+            "owner_user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            api_client_status_enum,
+            nullable=False,
+            server_default=sa.text("'active'::api_client_status"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_api_clients_owner_user_id",
+        "api_clients",
+        ["owner_user_id"],
+    )
+
+    op.create_table(
+        "api_audit_logs",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "client_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("api_clients.client_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+        ),
+        sa.Column("method", sa.String(16), nullable=False),
+        sa.Column("path", sa.Text, nullable=False),
+        sa.Column("status", sa.SmallInteger, nullable=False),
+        sa.Column("latency_ms", sa.Integer, nullable=False),
+        sa.Column("ip", postgresql.INET, nullable=False),
+    )
+    op.create_index(
+        "ix_api_audit_logs_client_user",
+        "api_audit_logs",
+        ["client_id", "user_id"],
+    )
+    op.create_index(
+        "ix_api_audit_logs_occurred_at",
+        "api_audit_logs",
+        ["occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_api_audit_logs_occurred_at",
+        table_name="api_audit_logs",
+    )
+    op.drop_index(
+        "ix_api_audit_logs_client_user",
+        table_name="api_audit_logs",
+    )
+    op.drop_table("api_audit_logs")
+    op.drop_index(
+        "ix_api_clients_owner_user_id",
+        table_name="api_clients",
+    )
+    op.drop_table("api_clients")
+    api_client_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/apps/api/app/db/models/__init__.py
+++ b/apps/api/app/db/models/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
 from app.db.models.content import Highlight, Note, Review
 from app.db.models.external_provider import ExternalId, SourceRecord
+from app.db.models.platform import ApiAuditLog, ApiClient
 from app.db.models.users import (
     LibraryItem,
     ReadingSession,
@@ -11,6 +12,8 @@ from app.db.models.users import (
 )
 
 __all__ = [
+    "ApiAuditLog",
+    "ApiClient",
     "Author",
     "Edition",
     "ExternalId",

--- a/apps/api/app/db/models/platform.py
+++ b/apps/api/app/db/models/platform.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM, INET
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+api_client_status_enum = ENUM(
+    "active",
+    "suspended",
+    name="api_client_status",
+    create_type=False,
+)
+
+
+class ApiClient(Base):
+    __tablename__ = "api_clients"
+    __table_args__ = (sa.Index("ix_api_clients_owner_user_id", "owner_user_id"),)
+
+    client_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    owner_user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(
+        api_client_status_enum,
+        nullable=False,
+        server_default=sa.text("'active'::api_client_status"),
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class ApiAuditLog(Base):
+    __tablename__ = "api_audit_logs"
+    __table_args__ = (
+        sa.Index("ix_api_audit_logs_client_user", "client_id", "user_id"),
+        sa.Index("ix_api_audit_logs_occurred_at", "occurred_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    occurred_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    client_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("api_clients.client_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="SET NULL"),
+    )
+    method: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    path: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    status: Mapped[int] = mapped_column(sa.SmallInteger, nullable=False)
+    latency_ms: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    ip: Mapped[str] = mapped_column(INET, nullable=False)

--- a/apps/api/tests/test_platform_models.py
+++ b/apps/api/tests/test_platform_models.py
@@ -1,0 +1,87 @@
+from typing import cast
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import INET
+
+from app.db.base import Base
+from app.db.models import ApiAuditLog, ApiClient
+
+
+def _get_table(name: str) -> sa.Table:
+    return Base.metadata.tables[name]
+
+
+def test_platform_tables_registered() -> None:
+    assert ApiClient.__tablename__ in Base.metadata.tables
+    assert ApiAuditLog.__tablename__ in Base.metadata.tables
+
+
+def test_api_clients_table_schema() -> None:
+    table = _get_table("api_clients")
+    assert set(table.columns.keys()) == {
+        "client_id",
+        "name",
+        "owner_user_id",
+        "status",
+        "created_at",
+    }
+    assert isinstance(table.columns["client_id"].type, sa.UUID)
+    assert isinstance(table.columns["name"].type, sa.String)
+    assert table.columns["name"].type.length == 255
+    assert isinstance(table.columns["owner_user_id"].type, sa.UUID)
+    assert isinstance(table.columns["status"].type, sa.Enum)
+    assert table.columns["status"].type.enums == ["active", "suspended"]
+    assert table.columns["status"].server_default is not None
+
+    created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
+    assert created_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "users.id" in fk_targets
+    owner_fk = next(fk for fk in table.foreign_keys if fk.target_fullname == "users.id")
+    assert owner_fk.ondelete == "CASCADE"
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_api_clients_owner_user_id" in index_names
+
+
+def test_api_audit_logs_table_schema() -> None:
+    table = _get_table("api_audit_logs")
+    assert set(table.columns.keys()) == {
+        "id",
+        "occurred_at",
+        "client_id",
+        "user_id",
+        "method",
+        "path",
+        "status",
+        "latency_ms",
+        "ip",
+    }
+    assert isinstance(table.columns["id"].type, sa.UUID)
+    occurred_at_type = table.columns["occurred_at"].type
+    assert isinstance(occurred_at_type, sa.DateTime)
+    assert isinstance(table.columns["client_id"].type, sa.UUID)
+    assert isinstance(table.columns["user_id"].type, sa.UUID)
+    assert isinstance(table.columns["method"].type, sa.String)
+    assert table.columns["method"].type.length == 16
+    assert isinstance(table.columns["path"].type, sa.Text)
+    assert isinstance(table.columns["status"].type, sa.SmallInteger)
+    assert isinstance(table.columns["latency_ms"].type, sa.Integer)
+    assert isinstance(table.columns["ip"].type, INET)
+
+    assert occurred_at_type.timezone is True
+
+    fk_targets = {fk.target_fullname for fk in table.foreign_keys}
+    assert "api_clients.client_id" in fk_targets
+    assert "users.id" in fk_targets
+    client_fk = next(
+        fk for fk in table.foreign_keys if fk.target_fullname == "api_clients.client_id"
+    )
+    user_fk = next(fk for fk in table.foreign_keys if fk.target_fullname == "users.id")
+    assert client_fk.ondelete == "CASCADE"
+    assert user_fk.ondelete == "SET NULL"
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_api_audit_logs_client_user" in index_names
+    assert "ix_api_audit_logs_occurred_at" in index_names

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -14,7 +14,7 @@ This is a suggested order of execution based on dependencies and risk.
 - #9 Create external provider tracking tables: external_ids, source_records - DONE
 - #10 Create user tables: users, library_items, reading_sessions - DONE
 - #11 Create content tables: notes, highlights, reviews - DONE
-- #12 Create platform tables: api_clients, api_audit_logs
+- #12 Create platform tables: api_clients, api_audit_logs - DONE
 - #13 Configure RLS policies for user-owned tables
 
 ## 3) Auth


### PR DESCRIPTION
## Summary
- add api_clients and api_audit_logs models + enum
- add Alembic migration for platform tables
- add schema tests for new tables
- mark Issue #12 as done in docs

## Testing
- make quality

Closes #12