### PR TITLE
Add API auth, rate limits, books import/search, and library endpoints

### DIFF
--- a/apps/api/app/core/audit.py
+++ b/apps/api/app/core/audit.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from app.db.config import get_database_url
+
+logger = logging.getLogger(__name__)
+
+_engine_lock = threading.Lock()
+_engine: Engine | None = None
+_engine_key: str | None = None
+
+
+def _get_engine() -> Engine:
+    global _engine, _engine_key
+
+    db_url = get_database_url()
+    with _engine_lock:
+        if _engine is None or _engine_key != db_url:
+            _engine = sa.create_engine(db_url, future=True, pool_pre_ping=True)
+            _engine_key = db_url
+        return _engine
+
+
+def write_api_audit_log(
+    *,
+    client_id: uuid.UUID,
+    user_id: uuid.UUID | None,
+    method: str,
+    path: str,
+    status: int,
+    latency_ms: int,
+    ip: str,
+) -> None:
+    try:
+        engine = _get_engine()
+    except RuntimeError:
+        # DB env is not configured in all local/unit test contexts.
+        return
+    except Exception:
+        logger.exception("Failed to initialize API audit log engine.")
+        return
+
+    statement = sa.text(
+        """
+        insert into public.api_audit_logs
+            (client_id, user_id, method, path, status, latency_ms, ip)
+        values
+            (:client_id, :user_id, :method, :path, :status, :latency_ms, cast(:ip as inet))
+        """
+    )
+    params: dict[str, Any] = {
+        "client_id": client_id,
+        "user_id": user_id,
+        "method": method,
+        "path": path,
+        "status": status,
+        "latency_ms": latency_ms,
+        "ip": ip,
+    }
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(statement, params)
+    except Exception:
+        logger.exception("Failed to write api_audit_logs record.")

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -13,6 +13,12 @@ class Settings:
     supabase_jwt_secret: str | None
     supabase_jwks_cache_ttl_seconds: int
     api_version: str
+    cors_allowed_origins: tuple[str, ...] = (
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:3001",
+        "http://127.0.0.1:3001",
+    )
 
 
 _dotenv_loaded = False
@@ -90,6 +96,18 @@ def _parse_ttl_seconds() -> int:
         return default_ttl
 
 
+def _parse_cors_origins() -> tuple[str, ...]:
+    raw_origins = os.getenv("CORS_ALLOW_ORIGINS", "").strip()
+    if not raw_origins:
+        return (
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:3001",
+            "http://127.0.0.1:3001",
+        )
+    return tuple(origin.strip() for origin in raw_origins.split(",") if origin.strip())
+
+
 @lru_cache
 def get_settings() -> Settings:
     """Settings are cached; call reset_settings_cache when env values change."""
@@ -102,12 +120,14 @@ def get_settings() -> Settings:
     if not jwt_secret:
         jwt_secret = None
     ttl_seconds = _parse_ttl_seconds()
+    cors_allowed_origins = _parse_cors_origins()
     api_version = os.getenv("API_VERSION", "0.1.0").strip()
     return Settings(
         supabase_url=supabase_url,
         supabase_jwt_audience=audience,
         supabase_jwt_secret=jwt_secret,
         supabase_jwks_cache_ttl_seconds=ttl_seconds,
+        cors_allowed_origins=cors_allowed_origins,
         api_version=api_version,
     )
 

--- a/apps/api/app/core/errors.py
+++ b/apps/api/app/core/errors.py
@@ -7,13 +7,29 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
+from app.core.config import get_settings
 from app.core.responses import fail
 from app.core.security import AuthError
 
 logger = logging.getLogger(__name__)
 
 
-def auth_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+def _cors_headers_for_request(request: Request) -> dict[str, str]:
+    origin = request.headers.get("origin")
+    if not origin:
+        return {}
+
+    settings = get_settings()
+    if origin not in settings.cors_allowed_origins:
+        return {}
+
+    return {
+        "Access-Control-Allow-Origin": origin,
+        "Vary": "Origin",
+    }
+
+
+def auth_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     auth_exc = cast(AuthError, exc)
     return JSONResponse(
         status_code=auth_exc.status_code,
@@ -22,10 +38,11 @@ def auth_exception_handler(_: Request, exc: Exception) -> JSONResponse:
             message=auth_exc.message,
             details=auth_exc.details,
         ),
+        headers=_cors_headers_for_request(request),
     )
 
 
-def http_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     http_exc = cast(HTTPException, exc)
     details: dict[str, Any] | None = None
     code = "http_error"
@@ -34,13 +51,18 @@ def http_exception_handler(_: Request, exc: Exception) -> JSONResponse:
         code = http_exc.detail.get("code", code)
         message = http_exc.detail.get("message", message)
         details = http_exc.detail.get("details")
+    headers: dict[str, str] = {}
+    if http_exc.headers:
+        headers.update(http_exc.headers)
+    headers.update(_cors_headers_for_request(request))
     return JSONResponse(
         status_code=http_exc.status_code,
         content=fail(code=code, message=message, details=details),
+        headers=headers,
     )
 
 
-def validation_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+def validation_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     validation_exc = cast(RequestValidationError, exc)
     return JSONResponse(
         status_code=422,
@@ -49,14 +71,16 @@ def validation_exception_handler(_: Request, exc: Exception) -> JSONResponse:
             message="Request validation failed.",
             details={"errors": validation_exc.errors()},
         ),
+        headers=_cors_headers_for_request(request),
     )
 
 
-def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     logger.exception("Unhandled exception", exc_info=exc)
     return JSONResponse(
         status_code=500,
         content=fail(code="internal_error", message="Internal server error."),
+        headers=_cors_headers_for_request(request),
     )
 
 

--- a/apps/api/app/core/rate_limit.py
+++ b/apps/api/app/core/rate_limit.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+
+from app.core.security import AuthContext, require_auth_context
+
+
+@dataclass(frozen=True)
+class RateLimitConfig:
+    default_limit: int
+    window_seconds: int
+    endpoint_limits: dict[str, int]
+
+
+class InMemoryRateLimiter:
+    def __init__(self) -> None:
+        self._events: dict[tuple[uuid.UUID, uuid.UUID, str], deque[float]] = (
+            defaultdict(deque)
+        )
+        self._lock = threading.Lock()
+
+    def check(
+        self,
+        *,
+        key: tuple[uuid.UUID, uuid.UUID, str],
+        limit: int,
+        window_seconds: int,
+        now: float | None = None,
+    ) -> int | None:
+        current = now if now is not None else time.time()
+        cutoff = current - window_seconds
+
+        with self._lock:
+            bucket = self._events[key]
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+
+            if len(bucket) >= limit:
+                retry_after = max(1, int(bucket[0] + window_seconds - current))
+                return retry_after
+
+            bucket.append(current)
+            return None
+
+
+_rate_limiter = InMemoryRateLimiter()
+
+
+def _parse_positive_int(value: str | None, *, fallback: int) -> int:
+    if value is None:
+        return fallback
+    raw = value.strip()
+    if not raw:
+        return fallback
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return fallback
+    if parsed <= 0:
+        return fallback
+    return parsed
+
+
+def _parse_endpoint_limits(raw: str | None) -> dict[str, int]:
+    if raw is None:
+        return {}
+    limits: dict[str, int] = {}
+    for part in raw.split(","):
+        item = part.strip()
+        if not item or ":" not in item:
+            continue
+        key, value = item.rsplit(":", 1)
+        key = key.strip()
+        if not key:
+            continue
+        parsed = _parse_positive_int(value, fallback=-1)
+        if parsed > 0:
+            limits[key] = parsed
+    return limits
+
+
+@lru_cache
+def get_rate_limit_config() -> RateLimitConfig:
+    default_limit = _parse_positive_int(
+        os.getenv("API_RATE_LIMIT_DEFAULT_MAX"), fallback=120
+    )
+    window_seconds = _parse_positive_int(
+        os.getenv("API_RATE_LIMIT_WINDOW_SECONDS"), fallback=60
+    )
+    endpoint_limits = _parse_endpoint_limits(os.getenv("API_RATE_LIMIT_OVERRIDES"))
+    return RateLimitConfig(
+        default_limit=default_limit,
+        window_seconds=window_seconds,
+        endpoint_limits=endpoint_limits,
+    )
+
+
+def reset_rate_limit_config_cache() -> None:
+    get_rate_limit_config.cache_clear()
+
+
+def _resolve_limit(config: RateLimitConfig, request: Request) -> int:
+    method_path = f"{request.method.upper()} {request.url.path}"
+    if method_path in config.endpoint_limits:
+        return config.endpoint_limits[method_path]
+    if request.url.path in config.endpoint_limits:
+        return config.endpoint_limits[request.url.path]
+    return config.default_limit
+
+
+def enforce_client_user_rate_limit(
+    request: Request,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    config: Annotated[RateLimitConfig, Depends(get_rate_limit_config)],
+) -> None:
+    if config.default_limit <= 0:
+        return
+
+    endpoint_key = f"{request.method.upper()} {request.url.path}"
+    limit = _resolve_limit(config, request)
+    effective_client_id = auth.client_id or auth.user_id
+    retry_after = _rate_limiter.check(
+        key=(effective_client_id, auth.user_id, endpoint_key),
+        limit=limit,
+        window_seconds=config.window_seconds,
+    )
+    if retry_after is None:
+        return
+
+    request.state.rate_limit_event = {
+        "client_id": effective_client_id,
+        "user_id": auth.user_id,
+        "method": request.method.upper(),
+        "path": request.url.path,
+        "status": 429,
+        "latency_ms": 0,
+        "ip": request.client.host if request.client else "0.0.0.0",
+    }
+
+    raise HTTPException(
+        status_code=429,
+        detail={
+            "code": "rate_limited",
+            "message": "Rate limit exceeded.",
+            "details": {
+                "client_id": str(effective_client_id),
+                "user_id": str(auth.user_id),
+                "limit": limit,
+                "window_seconds": config.window_seconds,
+            },
+        },
+        headers={"Retry-After": str(retry_after)},
+    )

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -24,6 +24,15 @@ library_item_visibility_enum = ENUM(
     create_type=False,
 )
 
+# Minimal auth.users metadata so SQLAlchemy can resolve FK dependency
+# for public.users.id -> auth.users.id during flush ordering.
+auth_users_table = sa.Table(
+    "users",
+    Base.metadata,
+    sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+    schema="auth",
+)
+
 
 class User(Base):
     __tablename__ = "users"

--- a/apps/api/app/db/session.py
+++ b/apps/api/app/db/session.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from functools import lru_cache
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.db.config import get_database_url
+
+
+@lru_cache
+def _session_factory() -> sessionmaker[Session]:
+    engine = sa.create_engine(get_database_url(), future=True, pool_pre_ping=True)
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def reset_session_factory() -> None:
+    _session_factory.cache_clear()
+
+
+def get_db_session() -> Iterator[Session]:
+    session = _session_factory()()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from collections.abc import Awaitable, Callable
+from time import perf_counter
 
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.responses import Response
+
+from app.core.audit import write_api_audit_log
 from app.core.config import get_settings
 from app.core.errors import register_exception_handlers
-from app.routers import health, protected, version
+from app.routers import books, health, library, me, protected, version
 
 
 def create_app() -> FastAPI:
@@ -14,8 +20,40 @@ def create_app() -> FastAPI:
         description="API for The Seedbed book tracking application",
         version=settings.api_version,
     )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(settings.cors_allowed_origins),
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     register_exception_handlers(app)
+
+    @app.middleware("http")
+    async def rate_limit_audit_log_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        start = perf_counter()
+        response = await call_next(request)
+        event = getattr(request.state, "rate_limit_event", None)
+        if event:
+            latency_ms = int((perf_counter() - start) * 1000)
+            write_api_audit_log(
+                client_id=event["client_id"],
+                user_id=event["user_id"],
+                method=event["method"],
+                path=event["path"],
+                status=event["status"],
+                latency_ms=max(latency_ms, event["latency_ms"]),
+                ip=event["ip"],
+            )
+        return response
+
     app.include_router(health.router)
     app.include_router(version.router)
     app.include_router(protected.router)
+    app.include_router(books.router)
+    app.include_router(me.router)
+    app.include_router(library.router)
     return app

--- a/apps/api/app/routers/__init__.py
+++ b/apps/api/app/routers/__init__.py
@@ -1,1 +1,10 @@
-"""API routers."""
+from . import books, health, library, me, protected, version
+
+__all__ = [
+    "books",
+    "health",
+    "library",
+    "me",
+    "protected",
+    "version",
+]

--- a/apps/api/app/routers/books.py
+++ b/apps/api/app/routers/books.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.responses import ok
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.services.catalog import import_openlibrary_bundle
+from app.services.open_library import OpenLibraryClient
+
+
+class ImportBookRequest(BaseModel):
+    work_key: str = Field(min_length=3)
+    edition_key: str | None = None
+
+
+def get_open_library_client() -> OpenLibraryClient:
+    return OpenLibraryClient()
+
+
+router = APIRouter(
+    prefix="/api/v1/books",
+    tags=["books"],
+    dependencies=[Depends(enforce_client_user_rate_limit)],
+)
+
+
+@router.get("/search")
+async def search_books(
+    query: Annotated[str, Query(min_length=1)],
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+    page: Annotated[int, Query(ge=1)] = 1,
+) -> dict[str, object]:
+    try:
+        response = await open_library.search_books(query=query, limit=limit, page=page)
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "open_library_unavailable",
+                "message": "Open Library is unavailable. Please try again shortly.",
+            },
+        ) from exc
+    return ok(
+        {
+            "items": [
+                {
+                    "work_key": item.work_key,
+                    "title": item.title,
+                    "author_names": item.author_names,
+                    "first_publish_year": item.first_publish_year,
+                    "cover_url": item.cover_url,
+                }
+                for item in response.items
+            ],
+            "cache_hit": response.cache_hit,
+        }
+    )
+
+
+@router.post("/import")
+async def import_book(
+    payload: ImportBookRequest,
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+) -> dict[str, object]:
+    try:
+        bundle = await open_library.fetch_work_bundle(
+            work_key=payload.work_key,
+            edition_key=payload.edition_key,
+        )
+        result = import_openlibrary_bundle(session, bundle=bundle)
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "open_library_unavailable",
+                "message": "Open Library is unavailable. Please try again shortly.",
+            },
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return ok(result)

--- a/apps/api/app/routers/library.py
+++ b/apps/api/app/routers/library.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.responses import ok
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.services.user_library import create_or_get_library_item, list_library_items
+
+
+class CreateLibraryItemRequest(BaseModel):
+    work_id: uuid.UUID
+    preferred_edition_id: uuid.UUID | None = None
+    status: str | None = Field(default=None, max_length=32)
+    visibility: str | None = Field(default=None, max_length=32)
+    rating: int | None = Field(default=None, ge=0, le=10)
+    tags: list[str] | None = None
+
+
+router = APIRouter(
+    prefix="/api/v1/library/items",
+    tags=["library"],
+    dependencies=[Depends(enforce_client_user_rate_limit)],
+)
+
+
+@router.get("")
+def list_items(
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    cursor: str | None = None,
+    status: str | None = None,
+) -> dict[str, object]:
+    try:
+        result = list_library_items(
+            session,
+            user_id=auth.user_id,
+            limit=limit,
+            cursor=cursor,
+            status=status,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ok(result)
+
+
+@router.post("")
+def create_item(
+    payload: CreateLibraryItemRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        item, created = create_or_get_library_item(
+            session,
+            user_id=auth.user_id,
+            work_id=payload.work_id,
+            preferred_edition_id=payload.preferred_edition_id,
+            status=payload.status,
+            visibility=payload.visibility,
+            rating=payload.rating,
+            tags=payload.tags,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return ok(
+        {
+            "id": str(item.id),
+            "work_id": str(item.work_id),
+            "status": item.status,
+            "visibility": item.visibility,
+            "rating": item.rating,
+            "tags": item.tags or [],
+            "created": created,
+        }
+    )

--- a/apps/api/app/routers/me.py
+++ b/apps/api/app/routers/me.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.responses import ok
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.services.user_library import get_or_create_profile, update_profile
+
+
+class UpdateProfileRequest(BaseModel):
+    handle: str | None = Field(default=None, max_length=64)
+    display_name: str | None = Field(default=None, max_length=255)
+    avatar_url: str | None = Field(default=None, max_length=2048)
+
+
+router = APIRouter(
+    prefix="/api/v1/me",
+    tags=["me"],
+    dependencies=[Depends(enforce_client_user_rate_limit)],
+)
+
+
+@router.get("")
+def get_me(
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    profile = get_or_create_profile(session, user_id=auth.user_id)
+    return ok(
+        {
+            "id": str(profile.id),
+            "handle": profile.handle,
+            "display_name": profile.display_name,
+            "avatar_url": profile.avatar_url,
+        }
+    )
+
+
+@router.patch("")
+def patch_me(
+    payload: UpdateProfileRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        profile = update_profile(
+            session,
+            user_id=auth.user_id,
+            handle=payload.handle,
+            display_name=payload.display_name,
+            avatar_url=payload.avatar_url,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return ok(
+        {
+            "id": str(profile.id),
+            "handle": profile.handle,
+            "display_name": profile.display_name,
+            "avatar_url": profile.avatar_url,
+        }
+    )

--- a/apps/api/app/routers/protected.py
+++ b/apps/api/app/routers/protected.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 
+from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import require_jwt
+from app.core.security import AuthContext, require_client_auth_context
 
 router = APIRouter(
     prefix="/api/v1/protected",
     tags=["protected"],
-    dependencies=[Depends(require_jwt)],
+    dependencies=[Depends(enforce_client_user_rate_limit)],
 )
 
 
 @router.get("/ping")
-async def protected_ping() -> dict[str, object]:
+async def protected_ping(
+    _auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+) -> dict[str, object]:
     return ok({"pong": True})

--- a/apps/api/app/services/__init__.py
+++ b/apps/api/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service modules for API integrations and domain operations."""

--- a/apps/api/app/services/catalog.py
+++ b/apps/api/app/services/catalog.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
+from app.db.models.external_provider import ExternalId, SourceRecord
+from app.services.open_library import OpenLibraryWorkBundle
+
+
+def _get_external_id(
+    session: Session,
+    *,
+    entity_type: str,
+    provider: str,
+    provider_id: str,
+) -> ExternalId | None:
+    return session.scalar(
+        sa.select(ExternalId).where(
+            ExternalId.entity_type == entity_type,
+            ExternalId.provider == provider,
+            ExternalId.provider_id == provider_id,
+        )
+    )
+
+
+def _upsert_source_record(
+    session: Session,
+    *,
+    provider: str,
+    entity_type: str,
+    provider_id: str,
+    raw: dict[str, Any],
+) -> None:
+    existing = session.scalar(
+        sa.select(SourceRecord).where(
+            SourceRecord.provider == provider,
+            SourceRecord.entity_type == entity_type,
+            SourceRecord.provider_id == provider_id,
+        )
+    )
+    if existing is None:
+        session.add(
+            SourceRecord(
+                provider=provider,
+                entity_type=entity_type,
+                provider_id=provider_id,
+                raw=raw,
+            )
+        )
+    else:
+        existing.raw = raw
+
+
+def import_openlibrary_bundle(
+    session: Session,
+    *,
+    bundle: OpenLibraryWorkBundle,
+) -> dict[str, Any]:
+    provider = "openlibrary"
+
+    work_external = _get_external_id(
+        session,
+        entity_type="work",
+        provider=provider,
+        provider_id=bundle.work_key,
+    )
+    if work_external is not None:
+        work = session.get(Work, work_external.entity_id)
+        if work is None:
+            raise RuntimeError("work external ID points to missing work")
+    else:
+        work = Work(
+            title=bundle.title,
+            description=bundle.description,
+            first_publish_year=bundle.first_publish_year,
+            default_cover_url=bundle.cover_url,
+        )
+        session.add(work)
+        session.flush()
+        session.add(
+            ExternalId(
+                entity_type="work",
+                entity_id=work.id,
+                provider=provider,
+                provider_id=bundle.work_key,
+            )
+        )
+
+    _upsert_source_record(
+        session,
+        provider=provider,
+        entity_type="work",
+        provider_id=bundle.work_key,
+        raw=bundle.raw_work,
+    )
+
+    created_authors = 0
+    for author in bundle.authors:
+        provider_id = author["key"]
+        name = author["name"]
+        author_external = _get_external_id(
+            session,
+            entity_type="author",
+            provider=provider,
+            provider_id=provider_id,
+        )
+        if author_external is not None:
+            author_model = session.get(Author, author_external.entity_id)
+            if author_model is None:
+                raise RuntimeError("author external ID points to missing author")
+        else:
+            author_model = Author(name=name)
+            session.add(author_model)
+            session.flush()
+            session.add(
+                ExternalId(
+                    entity_type="author",
+                    entity_id=author_model.id,
+                    provider=provider,
+                    provider_id=provider_id,
+                )
+            )
+            created_authors += 1
+
+        existing_link = session.scalar(
+            sa.select(WorkAuthor).where(
+                WorkAuthor.work_id == work.id,
+                WorkAuthor.author_id == author_model.id,
+            )
+        )
+        if existing_link is None:
+            session.add(WorkAuthor(work_id=work.id, author_id=author_model.id))
+
+    created_edition = False
+    edition_id = None
+    edition_key = None
+    if bundle.edition is not None:
+        edition_key = str(bundle.edition["key"])
+        edition_external = _get_external_id(
+            session,
+            entity_type="edition",
+            provider=provider,
+            provider_id=edition_key,
+        )
+        if edition_external is not None:
+            edition = session.get(Edition, edition_external.entity_id)
+            if edition is None:
+                raise RuntimeError("edition external ID points to missing edition")
+        else:
+            edition = Edition(
+                work_id=work.id,
+                isbn10=bundle.edition.get("isbn10"),
+                isbn13=bundle.edition.get("isbn13"),
+                publisher=bundle.edition.get("publisher"),
+                publish_date=None,
+                language=None,
+                format=None,
+                cover_url=bundle.cover_url,
+            )
+            session.add(edition)
+            session.flush()
+            session.add(
+                ExternalId(
+                    entity_type="edition",
+                    entity_id=edition.id,
+                    provider=provider,
+                    provider_id=edition_key,
+                )
+            )
+            created_edition = True
+
+        edition_id = str(edition.id)
+        if bundle.raw_edition is not None:
+            _upsert_source_record(
+                session,
+                provider=provider,
+                entity_type="edition",
+                provider_id=edition_key,
+                raw=bundle.raw_edition,
+            )
+
+    session.commit()
+
+    return {
+        "work": {
+            "id": str(work.id),
+            "title": work.title,
+            "created": work_external is None,
+        },
+        "edition": (
+            {
+                "id": edition_id,
+                "provider_id": edition_key,
+                "created": created_edition,
+            }
+            if edition_id and edition_key
+            else None
+        ),
+        "authors_processed": len(bundle.authors),
+        "authors_created": created_authors,
+    }

--- a/apps/api/app/services/open_library.py
+++ b/apps/api/app/services/open_library.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, cast
+
+import httpx
+
+
+@dataclass(frozen=True)
+class OpenLibrarySearchResult:
+    work_key: str
+    title: str
+    author_names: list[str]
+    first_publish_year: int | None
+    cover_url: str | None
+
+
+@dataclass(frozen=True)
+class OpenLibraryWorkBundle:
+    work_key: str
+    title: str
+    description: str | None
+    first_publish_year: int | None
+    cover_url: str | None
+    authors: list[dict[str, str]]
+    edition: dict[str, Any] | None
+    raw_work: dict[str, Any]
+    raw_edition: dict[str, Any] | None
+
+
+@dataclass
+class OpenLibrarySearchResponse:
+    items: list[OpenLibrarySearchResult]
+    cache_hit: bool
+
+
+class _TTLCache:
+    def __init__(self, *, ttl_seconds: int, max_entries: int) -> None:
+        self._ttl_seconds = max(ttl_seconds, 1)
+        self._max_entries = max(max_entries, 1)
+        self._items: dict[str, tuple[float, OpenLibrarySearchResponse]] = {}
+
+    def get(self, key: str) -> OpenLibrarySearchResponse | None:
+        cached = self._items.get(key)
+        if cached is None:
+            return None
+        expires_at, value = cached
+        if expires_at < time.time():
+            self._items.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: str, value: OpenLibrarySearchResponse) -> None:
+        if len(self._items) >= self._max_entries:
+            oldest_key = min(self._items.items(), key=lambda item: item[1][0])[0]
+            self._items.pop(oldest_key, None)
+        self._items[key] = (time.time() + self._ttl_seconds, value)
+
+
+def _normalize_work_key(work_key: str) -> str:
+    value = work_key.strip()
+    if value.startswith("/works/"):
+        return value
+    if value.startswith("OL"):
+        return f"/works/{value}"
+    raise ValueError("work_key must be an Open Library work key")
+
+
+def _normalize_edition_key(edition_key: str) -> str:
+    value = edition_key.strip()
+    if value.startswith("/books/"):
+        return value
+    if value.startswith("OL"):
+        return f"/books/{value}"
+    raise ValueError("edition_key must be an Open Library edition key")
+
+
+def _extract_description(payload: dict[str, Any]) -> str | None:
+    description = payload.get("description")
+    if isinstance(description, str):
+        return description
+    if isinstance(description, dict):
+        value = description.get("value")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+class OpenLibraryClient:
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://openlibrary.org",
+        user_agent: str | None = None,
+        cache_ttl_seconds: int = 300,
+        cache_max_entries: int = 256,
+        max_retries: int = 3,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._user_agent = (
+            user_agent
+            or os.getenv(
+                "OPENLIBRARY_USER_AGENT",
+                "TheSeedbed/0.1 (contact@theseedbed.app)",
+            )
+            or "TheSeedbed/0.1 (contact@theseedbed.app)"
+        )
+        self._max_retries = max(max_retries, 1)
+        self._cache = _TTLCache(
+            ttl_seconds=cache_ttl_seconds,
+            max_entries=cache_max_entries,
+        )
+        self._transport = transport
+
+    async def _request_json(
+        self,
+        path: str,
+        *,
+        params: dict[str, str | int] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        headers = {"User-Agent": self._user_agent}
+        backoff = 0.2
+
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                async with httpx.AsyncClient(
+                    timeout=10.0, transport=self._transport
+                ) as client:
+                    response = await client.get(url, params=params, headers=headers)
+                if (
+                    response.status_code in {429, 500, 502, 503, 504}
+                    and attempt < self._max_retries
+                ):
+                    await asyncio.sleep(backoff)
+                    backoff *= 2
+                    continue
+                response.raise_for_status()
+                return cast(dict[str, Any], response.json())
+            except httpx.HTTPError:
+                if attempt >= self._max_retries:
+                    raise
+                await asyncio.sleep(backoff)
+                backoff *= 2
+
+        raise RuntimeError("open library request failed")
+
+    async def search_books(
+        self, *, query: str, limit: int = 10, page: int = 1
+    ) -> OpenLibrarySearchResponse:
+        normalized_query = query.strip()
+        cache_key = f"{normalized_query.lower()}::{limit}::{page}"
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return OpenLibrarySearchResponse(items=cached.items, cache_hit=True)
+
+        payload = await self._request_json(
+            "/search.json",
+            params={"q": normalized_query, "limit": limit, "page": page},
+        )
+        docs = payload.get("docs", [])
+        items: list[OpenLibrarySearchResult] = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            work_key = doc.get("key")
+            title = doc.get("title")
+            if not isinstance(work_key, str) or not isinstance(title, str):
+                continue
+            cover_id = doc.get("cover_i")
+            cover_url = None
+            if isinstance(cover_id, int):
+                cover_url = f"https://covers.openlibrary.org/b/id/{cover_id}-M.jpg"
+            author_names = doc.get("author_name")
+            normalized_authors = []
+            if isinstance(author_names, list):
+                normalized_authors = [
+                    name for name in author_names if isinstance(name, str)
+                ]
+            first_publish_year = doc.get("first_publish_year")
+            items.append(
+                OpenLibrarySearchResult(
+                    work_key=work_key,
+                    title=title,
+                    author_names=normalized_authors,
+                    first_publish_year=(
+                        first_publish_year
+                        if isinstance(first_publish_year, int)
+                        else None
+                    ),
+                    cover_url=cover_url,
+                )
+            )
+
+        result = OpenLibrarySearchResponse(items=items, cache_hit=False)
+        self._cache.set(cache_key, result)
+        return result
+
+    async def fetch_work_bundle(
+        self,
+        *,
+        work_key: str,
+        edition_key: str | None = None,
+    ) -> OpenLibraryWorkBundle:
+        normalized_work_key = _normalize_work_key(work_key)
+        work_payload = await self._request_json(f"{normalized_work_key}.json")
+
+        author_entries = work_payload.get("authors", [])
+        authors: list[dict[str, str]] = []
+        for author_entry in author_entries:
+            if not isinstance(author_entry, dict):
+                continue
+            author_obj = author_entry.get("author")
+            if not isinstance(author_obj, dict):
+                continue
+            author_key = author_obj.get("key")
+            if isinstance(author_key, str):
+                author_payload = await self._request_json(f"{author_key}.json")
+                name = author_payload.get("name")
+                if isinstance(name, str):
+                    authors.append({"key": author_key, "name": name})
+
+        normalized_edition_key: str | None = None
+        raw_edition: dict[str, Any] | None = None
+        if edition_key:
+            normalized_edition_key = _normalize_edition_key(edition_key)
+            raw_edition = await self._request_json(f"{normalized_edition_key}.json")
+        else:
+            editions_payload = await self._request_json(
+                f"{normalized_work_key}/editions.json", params={"limit": 1}
+            )
+            entries = editions_payload.get("entries", [])
+            if isinstance(entries, list) and entries and isinstance(entries[0], dict):
+                maybe_key = entries[0].get("key")
+                if isinstance(maybe_key, str):
+                    normalized_edition_key = maybe_key
+                    raw_edition = entries[0]
+
+        cover_url = None
+        covers = work_payload.get("covers")
+        if isinstance(covers, list) and covers and isinstance(covers[0], int):
+            cover_url = f"https://covers.openlibrary.org/b/id/{covers[0]}-L.jpg"
+
+        edition: dict[str, Any] | None = None
+        if raw_edition is not None and normalized_edition_key is not None:
+            isbn10 = None
+            isbn13 = None
+            isbn_10_values = raw_edition.get("isbn_10")
+            if isinstance(isbn_10_values, list):
+                isbn10 = next((v for v in isbn_10_values if isinstance(v, str)), None)
+            isbn_13_values = raw_edition.get("isbn_13")
+            if isinstance(isbn_13_values, list):
+                isbn13 = next((v for v in isbn_13_values if isinstance(v, str)), None)
+            edition = {
+                "key": normalized_edition_key,
+                "isbn10": isbn10,
+                "isbn13": isbn13,
+                "publisher": next(
+                    (
+                        v
+                        for v in raw_edition.get("publishers", [])
+                        if isinstance(raw_edition.get("publishers"), list)
+                        and isinstance(v, str)
+                    ),
+                    None,
+                ),
+                "publish_date": (
+                    raw_edition.get("publish_date")
+                    if isinstance(raw_edition.get("publish_date"), str)
+                    else None
+                ),
+            }
+
+        return OpenLibraryWorkBundle(
+            work_key=normalized_work_key,
+            title=str(work_payload.get("title") or "Untitled"),
+            description=_extract_description(work_payload),
+            first_publish_year=(
+                work_payload.get("first_publish_date")
+                if isinstance(work_payload.get("first_publish_date"), int)
+                else (
+                    work_payload.get("first_publish_year")
+                    if isinstance(work_payload.get("first_publish_year"), int)
+                    else None
+                )
+            ),
+            cover_url=cover_url,
+            authors=authors,
+            edition=edition,
+            raw_work=work_payload,
+            raw_edition=raw_edition,
+        )

--- a/apps/api/app/services/user_library.py
+++ b/apps/api/app/services/user_library.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import json
+import uuid
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.bibliography import Work
+from app.db.models.users import LibraryItem, User
+
+DEFAULT_LIBRARY_STATUS = "to_read"
+DEFAULT_LIBRARY_VISIBILITY = "private"
+
+
+def _default_handle(user_id: uuid.UUID) -> str:
+    return f"user_{user_id.hex[:8]}"
+
+
+def _encode_cursor(created_at: dt.datetime, item_id: uuid.UUID) -> str:
+    payload = {"created_at": created_at.isoformat(), "id": str(item_id)}
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_cursor(cursor: str) -> tuple[dt.datetime, uuid.UUID]:
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        payload = json.loads(raw)
+        return dt.datetime.fromisoformat(payload["created_at"]), uuid.UUID(
+            payload["id"]
+        )
+    except (ValueError, KeyError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid cursor") from exc
+
+
+def get_or_create_profile(session: Session, *, user_id: uuid.UUID) -> User:
+    profile = session.get(User, user_id)
+    if profile is not None:
+        return profile
+
+    profile = User(
+        id=user_id, handle=_default_handle(user_id), display_name=None, avatar_url=None
+    )
+    session.add(profile)
+    session.commit()
+    return profile
+
+
+def update_profile(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    handle: str | None,
+    display_name: str | None,
+    avatar_url: str | None,
+) -> User:
+    profile = get_or_create_profile(session, user_id=user_id)
+
+    if handle is not None:
+        normalized = handle.strip()
+        if not normalized:
+            raise ValueError("handle cannot be blank")
+        existing = session.scalar(
+            sa.select(User).where(User.handle == normalized, User.id != user_id)
+        )
+        if existing is not None:
+            raise ValueError("handle is already taken")
+        profile.handle = normalized
+
+    if display_name is not None:
+        profile.display_name = display_name.strip() or None
+
+    if avatar_url is not None:
+        profile.avatar_url = avatar_url.strip() or None
+
+    session.commit()
+    return profile
+
+
+def create_or_get_library_item(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    work_id: uuid.UUID,
+    status: str | None,
+    visibility: str | None,
+    rating: int | None,
+    tags: list[str] | None,
+    preferred_edition_id: uuid.UUID | None,
+) -> tuple[LibraryItem, bool]:
+    # Ensure the app-level profile row exists before writing library_items.
+    # library_items.user_id references users.id (not auth.users.id directly).
+    get_or_create_profile(session, user_id=user_id)
+
+    work_exists = session.scalar(sa.select(Work.id).where(Work.id == work_id))
+    if work_exists is None:
+        raise LookupError("work not found")
+
+    existing = session.scalar(
+        sa.select(LibraryItem).where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.work_id == work_id,
+        )
+    )
+    if existing is not None:
+        return existing, False
+
+    item = LibraryItem(
+        user_id=user_id,
+        work_id=work_id,
+        preferred_edition_id=preferred_edition_id,
+        status=status or DEFAULT_LIBRARY_STATUS,
+        visibility=visibility or DEFAULT_LIBRARY_VISIBILITY,
+        rating=rating,
+        tags=tags,
+    )
+    session.add(item)
+    session.commit()
+    return item, True
+
+
+def list_library_items(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    limit: int,
+    cursor: str | None,
+    status: str | None,
+) -> dict[str, Any]:
+    stmt = (
+        sa.select(LibraryItem, Work.title)
+        .join(Work, Work.id == LibraryItem.work_id)
+        .where(LibraryItem.user_id == user_id)
+        .order_by(LibraryItem.created_at.desc(), LibraryItem.id.desc())
+    )
+    if status is not None:
+        stmt = stmt.where(LibraryItem.status == status)
+
+    if cursor:
+        cursor_created, cursor_id = _decode_cursor(cursor)
+        stmt = stmt.where(
+            sa.or_(
+                LibraryItem.created_at < cursor_created,
+                sa.and_(
+                    LibraryItem.created_at == cursor_created,
+                    LibraryItem.id < cursor_id,
+                ),
+            )
+        )
+
+    rows = session.execute(stmt.limit(limit + 1)).all()
+    has_next = len(rows) > limit
+    selected = rows[:limit]
+
+    items: list[dict[str, Any]] = []
+    for item, work_title in selected:
+        items.append(
+            {
+                "id": str(item.id),
+                "work_id": str(item.work_id),
+                "work_title": work_title,
+                "status": item.status,
+                "visibility": item.visibility,
+                "rating": item.rating,
+                "tags": item.tags or [],
+                "created_at": item.created_at.isoformat(),
+            }
+        )
+
+    next_cursor = None
+    if has_next and selected:
+        last_item = selected[-1][0]
+        next_cursor = _encode_cursor(last_item.created_at, last_item.id)
+
+    return {"items": items, "next_cursor": next_cursor}

--- a/apps/api/tests/test_audit.py
+++ b/apps/api/tests/test_audit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, cast
+
+import pytest
+
+from app.core import audit
+
+
+def test_write_api_audit_log_skips_when_db_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_runtime_error() -> None:
+        raise RuntimeError("missing db")
+
+    monkeypatch.setattr(audit, "_get_engine", raise_runtime_error)
+
+    audit.write_api_audit_log(
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        method="GET",
+        path="/api/v1/protected/ping",
+        status=429,
+        latency_ms=1,
+        ip="127.0.0.1",
+    )
+
+
+def test_write_api_audit_log_handles_write_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BrokenEngine:
+        @contextmanager
+        def begin(self) -> Iterator[None]:
+            raise RuntimeError("boom")
+            yield
+
+    monkeypatch.setattr(audit, "_get_engine", lambda: BrokenEngine())
+
+    audit.write_api_audit_log(
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        method="GET",
+        path="/api/v1/protected/ping",
+        status=429,
+        latency_ms=1,
+        ip="127.0.0.1",
+    )
+
+
+def test_write_api_audit_log_handles_engine_init_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_generic_error() -> None:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(audit, "_get_engine", raise_generic_error)
+
+    audit.write_api_audit_log(
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        method="GET",
+        path="/api/v1/protected/ping",
+        status=429,
+        latency_ms=1,
+        ip="127.0.0.1",
+    )
+
+
+def test_write_api_audit_log_executes_insert(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeConnection:
+        def execute(self, statement: object, params: dict[str, Any]) -> None:
+            captured["statement"] = str(statement)
+            captured["params"] = params
+
+    class FakeEngine:
+        @contextmanager
+        def begin(self) -> Iterator[FakeConnection]:
+            yield FakeConnection()
+
+    monkeypatch.setattr(audit, "_get_engine", lambda: FakeEngine())
+
+    audit.write_api_audit_log(
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        method="GET",
+        path="/api/v1/protected/ping",
+        status=429,
+        latency_ms=1,
+        ip="127.0.0.1",
+    )
+
+    statement = cast(str, captured["statement"])
+    assert "insert into public.api_audit_logs" in statement
+    params = cast(dict[str, Any], captured["params"])
+    assert isinstance(params, dict)
+    assert params["status"] == 429

--- a/apps/api/tests/test_books_router.py
+++ b/apps/api/tests/test_books_router.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.routers.books import get_open_library_client, router
+from app.routers.library import router as library_router
+from app.services.open_library import (
+    OpenLibrarySearchResponse,
+    OpenLibrarySearchResult,
+    OpenLibraryWorkBundle,
+)
+
+
+class _FakeOpenLibrary:
+    async def search_books(
+        self, *, query: str, limit: int = 10, page: int = 1
+    ) -> OpenLibrarySearchResponse:
+        return OpenLibrarySearchResponse(
+            items=[
+                OpenLibrarySearchResult(
+                    work_key="/works/OL1W",
+                    title=f"{query}-title",
+                    author_names=["Author A"],
+                    first_publish_year=2000,
+                    cover_url=None,
+                )
+            ],
+            cache_hit=False,
+        )
+
+    async def fetch_work_bundle(
+        self, *, work_key: str, edition_key: str | None = None
+    ) -> OpenLibraryWorkBundle:
+        if work_key == "bad":
+            raise ValueError("work_key must be an Open Library work key")
+        return OpenLibraryWorkBundle(
+            work_key="/works/OL1W",
+            title="Book",
+            description=None,
+            first_publish_year=2001,
+            cover_url=None,
+            authors=[{"key": "/authors/OL2A", "name": "Author A"}],
+            edition={
+                "key": "/books/OL3M",
+                "isbn10": None,
+                "isbn13": None,
+                "publisher": None,
+                "publish_date": None,
+            },
+            raw_work={},
+            raw_edition={},
+        )
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
+    app = FastAPI()
+    app.include_router(router)
+
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+    )
+    app.dependency_overrides[enforce_client_user_rate_limit] = lambda: None
+    app.dependency_overrides[get_open_library_client] = lambda: _FakeOpenLibrary()
+
+    def _fake_session() -> Generator[object, None, None]:
+        yield object()
+
+    app.dependency_overrides[get_db_session] = _fake_session
+
+    monkeypatch.setattr(
+        "app.routers.books.import_openlibrary_bundle",
+        lambda session, *, bundle: {
+            "work": {"id": "w1", "title": bundle.title, "created": True}
+        },
+    )
+    yield app
+
+
+def test_books_search_endpoint(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get("/api/v1/books/search", params={"query": "hello"})
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["items"][0]["title"] == "hello-title"
+    assert payload["cache_hit"] is False
+
+
+def test_books_import_endpoint(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post("/api/v1/books/import", json={"work_key": "OL1W"})
+    assert response.status_code == 200
+    assert response.json()["data"]["work"]["created"] is True
+
+
+def test_books_import_returns_400_for_invalid_key(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post("/api/v1/books/import", json={"work_key": "bad"})
+    assert response.status_code == 400
+
+
+def test_books_import_returns_404_when_catalog_lookup_fails(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.books.import_openlibrary_bundle",
+        lambda session, *, bundle: (_ for _ in ()).throw(LookupError("missing")),
+    )
+    client = TestClient(app)
+    response = client.post("/api/v1/books/import", json={"work_key": "OL1W"})
+    assert response.status_code == 404
+
+
+def test_get_open_library_client_factory() -> None:
+    client = get_open_library_client()
+    assert client is not None
+
+
+def test_books_search_returns_502_when_open_library_unavailable(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _raise_unavailable(
+        *_args: object, **_kwargs: object
+    ) -> OpenLibrarySearchResponse:
+        raise httpx.HTTPError("upstream unavailable")
+
+    monkeypatch.setattr(_FakeOpenLibrary, "search_books", _raise_unavailable)
+    client = TestClient(app)
+    response = client.get("/api/v1/books/search", params={"query": "hello"})
+    assert response.status_code == 502
+    payload = response.json()["detail"]
+    assert payload["code"] == "open_library_unavailable"
+
+
+def test_books_import_returns_502_when_open_library_unavailable(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _raise_unavailable(
+        *_args: object, **_kwargs: object
+    ) -> OpenLibraryWorkBundle:
+        raise httpx.HTTPError("upstream unavailable")
+
+    monkeypatch.setattr(_FakeOpenLibrary, "fetch_work_bundle", _raise_unavailable)
+    client = TestClient(app)
+    response = client.post("/api/v1/books/import", json={"work_key": "OL1W"})
+    assert response.status_code == 502
+    payload = response.json()["detail"]
+    assert payload["code"] == "open_library_unavailable"
+
+
+def test_import_then_add_library_item_happy_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    app.include_router(library_router)
+
+    user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=user_id,
+    )
+    app.dependency_overrides[enforce_client_user_rate_limit] = lambda: None
+    app.dependency_overrides[get_open_library_client] = lambda: _FakeOpenLibrary()
+
+    def _fake_session() -> Generator[object, None, None]:
+        yield object()
+
+    app.dependency_overrides[get_db_session] = _fake_session
+
+    imported_work_id = uuid.uuid4()
+    monkeypatch.setattr(
+        "app.routers.books.import_openlibrary_bundle",
+        lambda session, *, bundle: {
+            "work": {
+                "id": str(imported_work_id),
+                "title": bundle.title,
+                "created": True,
+            }
+        },
+    )
+
+    def _create_or_get_library_item(
+        session: object, **kwargs: object
+    ) -> tuple[SimpleNamespace, bool]:
+        assert kwargs["work_id"] == imported_work_id
+        return (
+            SimpleNamespace(
+                id=uuid.uuid4(),
+                work_id=imported_work_id,
+                status="to_read",
+                visibility="private",
+                rating=None,
+                tags=[],
+            ),
+            True,
+        )
+
+    monkeypatch.setattr(
+        "app.routers.library.create_or_get_library_item",
+        _create_or_get_library_item,
+    )
+
+    client = TestClient(app)
+    import_response = client.post("/api/v1/books/import", json={"work_key": "OL1W"})
+    assert import_response.status_code == 200
+
+    work_id = import_response.json()["data"]["work"]["id"]
+    add_response = client.post("/api/v1/library/items", json={"work_id": work_id})
+    assert add_response.status_code == 200
+    assert add_response.json()["data"]["created"] is True

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import sqlalchemy as sa
+
+from app.db.models.bibliography import Author, Edition, Work
+from app.db.models.external_provider import ExternalId, SourceRecord
+from app.services.catalog import (
+    _get_external_id,
+    _upsert_source_record,
+    import_openlibrary_bundle,
+)
+from app.services.open_library import OpenLibraryWorkBundle
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+        self.source_record: SourceRecord | None = None
+        self.scalar_values: list[Any] = []
+        self.get_map: dict[tuple[type[Any], Any], Any] = {}
+        self.committed = False
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+        if isinstance(obj, SourceRecord):
+            self.source_record = obj
+
+    def flush(self) -> None:
+        for obj in self.added:
+            if getattr(obj, "id", None) is None and hasattr(obj, "id"):
+                obj.id = uuid.uuid4()
+
+    def scalar(self, stmt: sa.Select[Any]) -> Any:
+        if self.scalar_values:
+            return self.scalar_values.pop(0)
+        return None
+
+    def get(self, model: type[Any], key: Any) -> Any:
+        return self.get_map.get((model, key))
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def _bundle() -> OpenLibraryWorkBundle:
+    return OpenLibraryWorkBundle(
+        work_key="/works/OL1W",
+        title="Book",
+        description="Desc",
+        first_publish_year=2000,
+        cover_url="https://covers.openlibrary.org/b/id/1-L.jpg",
+        authors=[{"key": "/authors/OL2A", "name": "Author A"}],
+        edition={
+            "key": "/books/OL3M",
+            "isbn10": "123",
+            "isbn13": "456",
+            "publisher": "Pub",
+            "publish_date": None,
+        },
+        raw_work={"k": "v"},
+        raw_edition={"ek": "ev"},
+    )
+
+
+def test_get_external_id_delegates_to_session_scalar() -> None:
+    session = FakeSession()
+    expected = ExternalId(
+        entity_type="work",
+        entity_id=uuid.uuid4(),
+        provider="openlibrary",
+        provider_id="/works/OL1W",
+    )
+    session.scalar_values = [expected]
+    actual = _get_external_id(
+        session=cast(Any, session),
+        entity_type="work",
+        provider="openlibrary",
+        provider_id="/works/OL1W",
+    )
+    assert actual is expected
+
+
+def test_upsert_source_record_creates_and_updates() -> None:
+    session = FakeSession()
+    _upsert_source_record(
+        cast(Any, session),
+        provider="openlibrary",
+        entity_type="work",
+        provider_id="/works/OL1W",
+        raw={"a": 1},
+    )
+    assert session.source_record is not None
+
+    existing = SourceRecord(
+        provider="openlibrary",
+        entity_type="work",
+        provider_id="/works/OL1W",
+        raw={"a": 1},
+    )
+    session.scalar_values = [existing]
+    _upsert_source_record(
+        cast(Any, session),
+        provider="openlibrary",
+        entity_type="work",
+        provider_id="/works/OL1W",
+        raw={"a": 2},
+    )
+    assert existing.raw == {"a": 2}
+
+
+def test_import_openlibrary_bundle_creates_records() -> None:
+    session = FakeSession()
+    # one scalar call for existing work-author link -> none
+    session.scalar_values = [None]
+
+    result = import_openlibrary_bundle(cast(Any, session), bundle=_bundle())
+
+    assert session.committed is True
+    assert result["work"]["created"] is True
+    assert result["authors_created"] == 1
+    assert result["edition"]["created"] is True
+
+
+def test_import_openlibrary_bundle_uses_existing_records() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    edition_id = uuid.uuid4()
+
+    work_external = ExternalId(
+        entity_type="work",
+        entity_id=work_id,
+        provider="openlibrary",
+        provider_id="/works/OL1W",
+    )
+    author_external = ExternalId(
+        entity_type="author",
+        entity_id=author_id,
+        provider="openlibrary",
+        provider_id="/authors/OL2A",
+    )
+    edition_external = ExternalId(
+        entity_type="edition",
+        entity_id=edition_id,
+        provider="openlibrary",
+        provider_id="/books/OL3M",
+    )
+
+    # scalar sequence: source record exists (work), existing work-author link, source record exists (edition)
+    session.scalar_values = [
+        SourceRecord(
+            provider="openlibrary",
+            entity_type="work",
+            provider_id="/works/OL1W",
+            raw={},
+        ),
+        object(),
+        SourceRecord(
+            provider="openlibrary",
+            entity_type="edition",
+            provider_id="/books/OL3M",
+            raw={},
+        ),
+    ]
+    session.get_map = {
+        (Work, work_id): Work(id=work_id, title="Book", description=None),
+        (Author, author_id): Author(id=author_id, name="Author A"),
+        (
+            Edition,
+            edition_id,
+        ): Edition(
+            id=edition_id,
+            work_id=work_id,
+            publisher=None,
+            publish_date=None,
+            language=None,
+            format=None,
+            cover_url=None,
+        ),
+    }
+
+    def fake_get_external(
+        _session: FakeSession,
+        *,
+        entity_type: str,
+        provider: str,
+        provider_id: str,
+    ) -> ExternalId | None:
+        assert provider == "openlibrary"
+        mapping = {
+            ("work", "/works/OL1W"): work_external,
+            ("author", "/authors/OL2A"): author_external,
+            ("edition", "/books/OL3M"): edition_external,
+        }
+        return mapping.get((entity_type, provider_id))
+
+    import app.services.catalog as catalog
+
+    original = catalog._get_external_id
+    try:
+        catalog._get_external_id = cast(Any, fake_get_external)
+        result = import_openlibrary_bundle(cast(Any, session), bundle=_bundle())
+    finally:
+        catalog._get_external_id = original
+
+    assert result["work"]["created"] is False
+    assert result["authors_created"] == 0
+    assert result["edition"]["created"] is False
+
+
+def test_import_openlibrary_bundle_raises_when_external_missing_target() -> None:
+    session = FakeSession()
+    missing_work_external = ExternalId(
+        entity_type="work",
+        entity_id=uuid.uuid4(),
+        provider="openlibrary",
+        provider_id="/works/OL1W",
+    )
+
+    import app.services.catalog as catalog
+
+    original = catalog._get_external_id
+    try:
+        catalog._get_external_id = cast(
+            Any, lambda *_args, **_kwargs: missing_work_external
+        )
+        try:
+            import_openlibrary_bundle(cast(Any, session), bundle=_bundle())
+        except RuntimeError as exc:
+            assert "missing work" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+    finally:
+        catalog._get_external_id = original

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -21,6 +21,12 @@ def test_get_settings_blank_audience_and_reset_cache() -> None:
         assert settings.supabase_jwt_audience is None
         assert settings.supabase_jwt_secret == "local-secret"
         assert settings.supabase_jwks_cache_ttl_seconds == 120
+        assert settings.cors_allowed_origins == (
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:3001",
+            "http://127.0.0.1:3001",
+        )
         assert settings.api_version == "9.9.9"
     finally:
         os.environ.clear()
@@ -37,6 +43,26 @@ def test_get_settings_invalid_ttl_defaults() -> None:
 
         settings = config_module.get_settings()
         assert settings.supabase_jwks_cache_ttl_seconds == 300
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+        config_module.reset_settings_cache()
+
+
+def test_get_settings_custom_cors_origins() -> None:
+    original_env = os.environ.copy()
+    try:
+        os.environ["SUPABASE_URL"] = "https://example.supabase.co/"
+        os.environ["CORS_ALLOW_ORIGINS"] = (
+            "https://app.example.com, https://admin.example.com "
+        )
+        config_module.reset_settings_cache()
+
+        settings = config_module.get_settings()
+        assert settings.cors_allowed_origins == (
+            "https://app.example.com",
+            "https://admin.example.com",
+        )
     finally:
         os.environ.clear()
         os.environ.update(original_env)

--- a/apps/api/tests/test_db_session.py
+++ b/apps/api/tests/test_db_session.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any, cast
+
+import pytest
+
+from app.db.session import get_db_session, reset_session_factory
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeFactory:
+    def __init__(self) -> None:
+        self.session = _FakeSession()
+
+    def __call__(self) -> _FakeSession:
+        return self.session
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> Generator[None, None, None]:
+    reset_session_factory()
+    yield
+    reset_session_factory()
+
+
+def test_get_db_session_yields_and_closes(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_factory = _FakeFactory()
+    monkeypatch.setattr("app.db.session._session_factory", lambda: fake_factory)
+
+    gen = get_db_session()
+    session = next(gen)
+    assert session is cast(Any, fake_factory.session)
+
+    with pytest.raises(StopIteration):
+        next(gen)
+    assert fake_factory.session.closed is True
+
+
+def test_reset_session_factory_clears_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.db.session.get_database_url", lambda: "postgresql+psycopg://local/db"
+    )
+
+    class _Engine:
+        pass
+
+    monkeypatch.setattr(
+        "app.db.session.sa.create_engine", lambda *args, **kwargs: _Engine()
+    )
+
+    from app.db.session import _session_factory
+
+    _session_factory()
+    reset_session_factory()
+    _session_factory()

--- a/apps/api/tests/test_endpoints.py
+++ b/apps/api/tests/test_endpoints.py
@@ -15,3 +15,16 @@ def test_version_endpoint() -> None:
     response = client.get("/api/v1/version")
     assert response.status_code == 200
     assert response.json() == {"data": {"version": "0.1.0"}, "error": None}
+
+
+def test_cors_preflight_for_library_endpoint() -> None:
+    client = TestClient(create_app())
+    response = client.options(
+        "/api/v1/library/items?limit=10",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"

--- a/apps/api/tests/test_me_library_router.py
+++ b/apps/api/tests/test_me_library_router.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from collections.abc import Generator
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.routers.library import router as library_router
+from app.routers.me import router as me_router
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
+    app = FastAPI()
+    app.include_router(me_router)
+    app.include_router(library_router)
+
+    user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=user_id,
+    )
+    app.dependency_overrides[enforce_client_user_rate_limit] = lambda: None
+
+    def _fake_session() -> Generator[object, None, None]:
+        yield object()
+
+    app.dependency_overrides[get_db_session] = _fake_session
+
+    monkeypatch.setattr(
+        "app.routers.me.get_or_create_profile",
+        lambda session, *, user_id: SimpleNamespace(
+            id=user_id, handle="seed", display_name="Seed", avatar_url=None
+        ),
+    )
+    monkeypatch.setattr(
+        "app.routers.me.update_profile",
+        lambda session, *, user_id, handle, display_name, avatar_url: SimpleNamespace(
+            id=user_id,
+            handle=handle or "seed",
+            display_name=display_name,
+            avatar_url=avatar_url,
+        ),
+    )
+
+    monkeypatch.setattr(
+        "app.routers.library.list_library_items",
+        lambda session, *, user_id, limit, cursor, status: {
+            "items": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "work_id": str(uuid.uuid4()),
+                    "work_title": "Book",
+                    "status": status or "to_read",
+                    "visibility": "private",
+                    "rating": None,
+                    "tags": [],
+                    "created_at": dt.datetime.now(tz=dt.UTC).isoformat(),
+                }
+            ],
+            "next_cursor": None,
+        },
+    )
+    monkeypatch.setattr(
+        "app.routers.library.create_or_get_library_item",
+        lambda session, **_: (
+            SimpleNamespace(
+                id=uuid.uuid4(),
+                work_id=uuid.uuid4(),
+                status="to_read",
+                visibility="private",
+                rating=None,
+                tags=None,
+            ),
+            True,
+        ),
+    )
+
+    yield app
+
+
+def test_get_me(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get("/api/v1/me")
+    assert response.status_code == 200
+    assert response.json()["data"]["handle"] == "seed"
+
+
+def test_patch_me(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.patch("/api/v1/me", json={"display_name": "Updated"})
+    assert response.status_code == 200
+    assert response.json()["data"]["display_name"] == "Updated"
+
+
+def test_patch_me_returns_400_on_validation_error(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.me.update_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad")),
+    )
+    client = TestClient(app)
+    response = client.patch("/api/v1/me", json={"handle": ""})
+    assert response.status_code == 400
+
+
+def test_list_library_items(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get("/api/v1/library/items", params={"status": "reading"})
+    assert response.status_code == 200
+    assert response.json()["data"]["items"][0]["status"] == "reading"
+
+
+def test_create_library_item(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/library/items",
+        json={"work_id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["created"] is True
+
+
+def test_create_library_item_returns_404(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.create_or_get_library_item",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(LookupError("missing work")),
+    )
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/library/items",
+        json={"work_id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 404
+
+
+def test_list_library_items_returns_400_for_bad_cursor(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.list_library_items",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("invalid cursor")),
+    )
+    client = TestClient(app)
+    response = client.get("/api/v1/library/items", params={"cursor": "bad"})
+    assert response.status_code == 400

--- a/apps/api/tests/test_open_library_service.py
+++ b/apps/api/tests/test_open_library_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+
+import httpx
+import pytest
+
+from app.services.open_library import (
+    OpenLibraryClient,
+    _normalize_edition_key,
+    _normalize_work_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    async def _fake_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("app.services.open_library.asyncio.sleep", _fake_sleep)
+    yield
+
+
+def test_search_books_uses_user_agent_and_cache() -> None:
+    seen_user_agents: list[str] = []
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        ua = request.headers.get("User-Agent")
+        if ua:
+            seen_user_agents.append(ua)
+        return httpx.Response(
+            200,
+            json={
+                "docs": [
+                    {
+                        "key": "/works/OL1W",
+                        "title": "Book A",
+                        "author_name": ["Author A"],
+                        "first_publish_year": 1999,
+                        "cover_i": 100,
+                    }
+                ]
+            },
+        )
+
+    client = OpenLibraryClient(
+        user_agent="SeedbedTest/1.0 (dev@example.com)",
+        transport=httpx.MockTransport(handler),
+    )
+
+    first = asyncio.run(client.search_books(query="book", limit=5, page=1))
+    second = asyncio.run(client.search_books(query="book", limit=5, page=1))
+
+    assert calls["count"] == 1
+    assert seen_user_agents == ["SeedbedTest/1.0 (dev@example.com)"]
+    assert first.cache_hit is False
+    assert second.cache_hit is True
+    assert first.items[0].title == "Book A"
+
+
+def test_fetch_work_bundle_collects_author_and_first_edition() -> None:
+    responses = {
+        "/works/OL1W.json": {
+            "title": "Book A",
+            "authors": [{"author": {"key": "/authors/OL2A"}}],
+            "covers": [12],
+        },
+        "/authors/OL2A.json": {"name": "Author A"},
+        "/works/OL1W/editions.json": {
+            "entries": [
+                {"key": "/books/OL3M", "isbn_10": ["1234567890"], "publishers": ["Pub"]}
+            ]
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    bundle = asyncio.run(client.fetch_work_bundle(work_key="OL1W"))
+
+    assert bundle.work_key == "/works/OL1W"
+    assert bundle.title == "Book A"
+    assert bundle.authors == [{"key": "/authors/OL2A", "name": "Author A"}]
+    assert bundle.edition is not None
+    assert bundle.edition["key"] == "/books/OL3M"
+    assert bundle.cover_url == "https://covers.openlibrary.org/b/id/12-L.jpg"
+
+
+def test_request_retries_on_5xx() -> None:
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(503, json={"message": "retry"})
+        return httpx.Response(200, json={"docs": []})
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler), max_retries=2)
+    result = asyncio.run(client.search_books(query="retry"))
+
+    assert calls["count"] == 2
+    assert result.items == []
+
+
+def test_normalize_keys() -> None:
+    assert _normalize_work_key("OL1W") == "/works/OL1W"
+    assert _normalize_work_key("/works/OL1W") == "/works/OL1W"
+    assert _normalize_edition_key("OL1M") == "/books/OL1M"
+    with pytest.raises(ValueError):
+        _normalize_work_key("bad-key")
+    with pytest.raises(ValueError):
+        _normalize_edition_key("bad-key")
+
+
+def test_fetch_work_bundle_with_explicit_edition_and_description_object() -> None:
+    responses = {
+        "/works/OL1W.json": {
+            "title": "Book A",
+            "description": {"value": "Desc"},
+            "authors": [],
+            "covers": [],
+        },
+        "/books/OL3M.json": {
+            "isbn_13": ["9999999999999"],
+            "publish_date": "2020",
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    bundle = asyncio.run(
+        client.fetch_work_bundle(work_key="/works/OL1W", edition_key="OL3M")
+    )
+    assert bundle.description == "Desc"
+    assert bundle.edition is not None
+    assert bundle.edition["key"] == "/books/OL3M"
+    assert bundle.edition["isbn13"] == "9999999999999"
+
+
+def test_request_raises_after_retry_exhausted() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"message": "still failing"})
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler), max_retries=2)
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(client.search_books(query="boom"))

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from jose import jwk, jwt
+
+from app.core.config import Settings, get_settings
+from app.core.jwks import JWKSCache
+from app.core.rate_limit import _rate_limiter, reset_rate_limit_config_cache
+from app.core.security import get_jwks_cache, reset_jwks_cache
+from app.main import create_app
+
+SUPABASE_URL = "https://example.supabase.co"
+KID = "test-kid"
+
+
+def _settings() -> Settings:
+    return Settings(
+        supabase_url=SUPABASE_URL,
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        api_version="0.1.0",
+    )
+
+
+def _generate_rsa_keypair() -> tuple[str, str]:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+RSA_PRIVATE_KEY, RSA_PUBLIC_KEY = _generate_rsa_keypair()
+
+
+def _build_jwks() -> dict[str, object]:
+    key = jwk.construct(RSA_PUBLIC_KEY, "RS256")
+    public_jwk = key.to_dict()
+    public_jwk["kid"] = KID
+    public_jwk["use"] = "sig"
+    return {"keys": [public_jwk]}
+
+
+def _make_token(client_id: str, sub: str) -> str:
+    issuer = f"{SUPABASE_URL}/auth/v1"
+    payload = {
+        "sub": sub,
+        "client_id": client_id,
+        "aud": "authenticated",
+        "iss": issuer,
+        "exp": int(time.time()) + 3600,
+    }
+    token = jwt.encode(
+        payload, RSA_PRIVATE_KEY, algorithm="RS256", headers={"kid": KID}
+    )
+    return cast(str, token)
+
+
+@pytest.fixture()
+def fastapi_app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
+    monkeypatch.setenv("API_RATE_LIMIT_DEFAULT_MAX", "2")
+    monkeypatch.setenv("API_RATE_LIMIT_WINDOW_SECONDS", "60")
+    monkeypatch.delenv("API_RATE_LIMIT_OVERRIDES", raising=False)
+    reset_rate_limit_config_cache()
+    reset_jwks_cache()
+    _rate_limiter._events.clear()
+
+    app = create_app()
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    app.dependency_overrides[get_settings] = _settings
+    app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+    yield app
+    app.dependency_overrides.clear()
+    _rate_limiter._events.clear()
+    reset_rate_limit_config_cache()
+    reset_jwks_cache()
+
+
+def test_rate_limit_returns_429_and_retry_after(fastapi_app: FastAPI) -> None:
+    token = _make_token(
+        client_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        sub="11111111-1111-1111-1111-111111111111",
+    )
+    client = TestClient(fastapi_app)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response_1 = client.get("/api/v1/protected/ping", headers=headers)
+    response_2 = client.get("/api/v1/protected/ping", headers=headers)
+    response_3 = client.get("/api/v1/protected/ping", headers=headers)
+
+    assert response_1.status_code == 200
+    assert response_2.status_code == 200
+    assert response_3.status_code == 429
+    assert "Retry-After" in response_3.headers
+    assert int(response_3.headers["Retry-After"]) >= 1
+    assert response_3.json()["error"]["code"] == "rate_limited"
+
+
+def test_rate_limit_scopes_by_client_and_user_pair(fastapi_app: FastAPI) -> None:
+    token_a = _make_token(
+        client_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        sub="11111111-1111-1111-1111-111111111111",
+    )
+    token_b = _make_token(
+        client_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        sub="11111111-1111-1111-1111-111111111111",
+    )
+    client = TestClient(fastapi_app)
+
+    response_a1 = client.get(
+        "/api/v1/protected/ping", headers={"Authorization": f"Bearer {token_a}"}
+    )
+    response_a2 = client.get(
+        "/api/v1/protected/ping", headers={"Authorization": f"Bearer {token_a}"}
+    )
+    response_a3 = client.get(
+        "/api/v1/protected/ping", headers={"Authorization": f"Bearer {token_a}"}
+    )
+    response_b1 = client.get(
+        "/api/v1/protected/ping", headers={"Authorization": f"Bearer {token_b}"}
+    )
+
+    assert response_a1.status_code == 200
+    assert response_a2.status_code == 200
+    assert response_a3.status_code == 429
+    assert response_b1.status_code == 200
+
+
+def test_rate_limit_records_audit_log_event(
+    fastapi_app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.main as app_main
+
+    captured: list[dict[str, object]] = []
+
+    def fake_write_api_audit_log(**kwargs: object) -> None:
+        captured.append(kwargs)
+
+    monkeypatch.setattr(app_main, "write_api_audit_log", fake_write_api_audit_log)
+
+    token = _make_token(
+        client_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        sub="11111111-1111-1111-1111-111111111111",
+    )
+    client = TestClient(fastapi_app)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    client.get("/api/v1/protected/ping", headers=headers)
+    client.get("/api/v1/protected/ping", headers=headers)
+    response = client.get("/api/v1/protected/ping", headers=headers)
+
+    assert response.status_code == 429
+    assert captured
+    event = captured[-1]
+    assert event["status"] == 429
+    assert event["method"] == "GET"
+    assert event["path"] == "/api/v1/protected/ping"

--- a/apps/api/tests/test_rate_limit_unit.py
+++ b/apps/api/tests/test_rate_limit_unit.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import Request
+
+from app.core.rate_limit import (
+    InMemoryRateLimiter,
+    RateLimitConfig,
+    _parse_endpoint_limits,
+    _parse_positive_int,
+    _resolve_limit,
+    enforce_client_user_rate_limit,
+)
+from app.core.security import AuthContext
+
+
+def _request(method: str, path: str, client_host: str | None = "127.0.0.1") -> Request:
+    client = (client_host, 12345) if client_host is not None else None
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [],
+            "client": client,
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "query_string": b"",
+        }
+    )
+
+
+def test_parse_positive_int() -> None:
+    assert _parse_positive_int(None, fallback=7) == 7
+    assert _parse_positive_int("", fallback=7) == 7
+    assert _parse_positive_int("abc", fallback=7) == 7
+    assert _parse_positive_int("0", fallback=7) == 7
+    assert _parse_positive_int("-1", fallback=7) == 7
+    assert _parse_positive_int("12", fallback=7) == 12
+
+
+def test_parse_endpoint_limits() -> None:
+    assert _parse_endpoint_limits(None) == {}
+    assert _parse_endpoint_limits("bad") == {}
+    assert _parse_endpoint_limits("GET /x:5,/x:2,invalid:0,:9") == {
+        "GET /x": 5,
+        "/x": 2,
+    }
+
+
+def test_resolve_limit_prefers_method_path_then_path() -> None:
+    config = RateLimitConfig(
+        default_limit=50,
+        window_seconds=60,
+        endpoint_limits={"GET /api/v1/protected/ping": 2, "/api/v1/protected/ping": 3},
+    )
+    request = _request("GET", "/api/v1/protected/ping")
+    assert _resolve_limit(config, request) == 2
+
+    config2 = RateLimitConfig(
+        default_limit=50,
+        window_seconds=60,
+        endpoint_limits={"/api/v1/protected/ping": 3},
+    )
+    assert _resolve_limit(config2, request) == 3
+
+    config3 = RateLimitConfig(default_limit=50, window_seconds=60, endpoint_limits={})
+    assert _resolve_limit(config3, request) == 50
+
+
+def test_in_memory_rate_limiter_prunes_old_entries() -> None:
+    limiter = InMemoryRateLimiter()
+    key = (
+        uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        "GET /api/v1/protected/ping",
+    )
+    assert limiter.check(key=key, limit=1, window_seconds=60, now=100.0) is None
+    assert limiter.check(key=key, limit=1, window_seconds=60, now=161.0) is None
+
+
+def test_enforce_rate_limit_noop_when_default_limit_disabled() -> None:
+    request = _request("GET", "/api/v1/protected/ping")
+    auth = AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+    )
+    config = RateLimitConfig(default_limit=0, window_seconds=60, endpoint_limits={})
+
+    enforce_client_user_rate_limit(request=request, auth=auth, config=config)
+    assert not hasattr(request.state, "rate_limit_event")

--- a/apps/api/tests/test_security.py
+++ b/apps/api/tests/test_security.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import time
+import uuid
 from collections.abc import Generator
 from typing import cast
 
@@ -111,40 +112,61 @@ def _build_ec_jwks() -> dict[str, object]:
     return {"keys": [public_jwk]}
 
 
-def _make_token(audience: str = "authenticated") -> str:
+def _make_token(
+    audience: str = "authenticated",
+    *,
+    client_id: str | None = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    sub: str = "11111111-1111-1111-1111-111111111111",
+) -> str:
     issuer = f"{SUPABASE_URL}/auth/v1"
     payload = {
-        "sub": "user-123",
+        "sub": sub,
         "aud": audience,
         "iss": issuer,
         "exp": int(time.time()) + 3600,
     }
+    if client_id is not None:
+        payload["client_id"] = client_id
     token = jwt.encode(
         payload, RSA_PRIVATE_KEY, algorithm="RS256", headers={"kid": KID}
     )
     return cast(str, token)
 
 
-def _make_es256_token(audience: str = "authenticated") -> str:
+def _make_es256_token(
+    audience: str = "authenticated",
+    *,
+    client_id: str | None = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    sub: str = "11111111-1111-1111-1111-111111111111",
+) -> str:
     issuer = f"{SUPABASE_URL}/auth/v1"
     payload = {
-        "sub": "user-123",
+        "sub": sub,
         "aud": audience,
         "iss": issuer,
         "exp": int(time.time()) + 3600,
     }
+    if client_id is not None:
+        payload["client_id"] = client_id
     token = jwt.encode(payload, EC_PRIVATE_KEY, algorithm="ES256", headers={"kid": KID})
     return cast(str, token)
 
 
-def _make_hs256_token(audience: str = "authenticated") -> str:
+def _make_hs256_token(
+    audience: str = "authenticated",
+    *,
+    client_id: str | None = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    sub: str = "11111111-1111-1111-1111-111111111111",
+) -> str:
     issuer = f"{SUPABASE_URL}/auth/v1"
     payload = {
-        "sub": "user-123",
+        "sub": sub,
         "aud": audience,
         "iss": issuer,
         "exp": int(time.time()) + 3600,
     }
+    if client_id is not None:
+        payload["client_id"] = client_id
     token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
     return cast(str, token)
 
@@ -189,7 +211,7 @@ def test_decode_jwt_success() -> None:
     cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
     token = _make_token()
     payload = asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
-    assert payload["sub"] == "user-123"
+    assert payload["sub"] == "11111111-1111-1111-1111-111111111111"
 
 
 def test_decode_jwt_es256_success() -> None:
@@ -201,7 +223,7 @@ def test_decode_jwt_es256_success() -> None:
     cache = JWKSCache(fetcher=fetcher, ttl_seconds=60)
     token = _make_es256_token()
     payload = asyncio.run(decode_jwt(token, settings=_settings(), jwks_cache=cache))
-    assert payload["sub"] == "user-123"
+    assert payload["sub"] == "11111111-1111-1111-1111-111111111111"
 
 
 def test_decode_jwt_hs256_success() -> None:
@@ -213,7 +235,7 @@ def test_decode_jwt_hs256_success() -> None:
     payload = asyncio.run(
         decode_jwt(token, settings=_settings_with_secret(), jwks_cache=cache)
     )
-    assert payload["sub"] == "user-123"
+    assert payload["sub"] == "11111111-1111-1111-1111-111111111111"
 
 
 def test_decode_jwt_hs256_missing_secret() -> None:
@@ -377,6 +399,75 @@ def test_protected_endpoint_accepts_hs256_token(fastapi_app: FastAPI) -> None:
     assert response.json() == {"data": {"pong": True}, "error": None}
 
 
+def test_protected_endpoint_rejects_missing_client_id(fastapi_app: FastAPI) -> None:
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    fastapi_app.dependency_overrides[get_settings] = _settings
+    fastapi_app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+
+    token = _make_token(client_id=None)
+    client = TestClient(fastapi_app)
+    response = client.get(
+        "/api/v1/protected/ping",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["error"]["code"] == "missing_client_id_claim"
+
+
+def test_protected_endpoint_rejects_invalid_client_id(fastapi_app: FastAPI) -> None:
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    fastapi_app.dependency_overrides[get_settings] = _settings
+    fastapi_app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+
+    token = _make_token(client_id="not-a-uuid")
+    client = TestClient(fastapi_app)
+    response = client.get(
+        "/api/v1/protected/ping",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["error"]["code"] == "invalid_client_id_claim"
+
+
+def test_protected_endpoint_rejects_invalid_sub(fastapi_app: FastAPI) -> None:
+    jwks = _build_jwks()
+
+    async def fetcher() -> dict[str, object]:
+        return jwks
+
+    fastapi_app.dependency_overrides[get_settings] = _settings
+    fastapi_app.dependency_overrides[get_jwks_cache] = lambda: JWKSCache(
+        fetcher=fetcher,
+        ttl_seconds=60,
+    )
+
+    token = _make_token(sub="user-123")
+    client = TestClient(fastapi_app)
+    response = client.get(
+        "/api/v1/protected/ping",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["error"]["code"] == "invalid_sub_claim"
+
+
 def test_decode_jwt_missing_supabase_url() -> None:
     async def fetcher() -> dict[str, object]:
         return {"keys": []}
@@ -475,6 +566,25 @@ def test_fetch_jwks() -> None:
     assert result == jwks_payload
 
 
+def test_fetch_jwks_with_provided_client() -> None:
+    jwks_payload = {"keys": [{"kid": "provided-client"}]}
+
+    async def run() -> dict[str, object]:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/json"},
+                    json=jwks_payload,
+                )
+            )
+        ) as client:
+            return await _fetch_jwks(_settings(), client=client)
+
+    result = asyncio.run(run())
+    assert result == jwks_payload
+
+
 def test_get_jwks_cache_reuses_instance() -> None:
     reset_jwks_cache()
     settings = _settings()
@@ -492,3 +602,24 @@ def test_get_jwks_cache_reuses_instance() -> None:
     cache_three = asyncio.run(get_jwks_cache(settings_updated))
     assert cache_three is not cache_one
     reset_jwks_cache()
+
+
+def test_require_auth_context_rejects_non_string_claim() -> None:
+    from app.core.security import require_auth_context
+
+    with pytest.raises(AuthError) as exc:
+        asyncio.run(
+            require_auth_context(
+                claims={"client_id": 123, "sub": "11111111-1111-1111-1111-111111111111"}
+            )
+        )
+    assert exc.value.code == "invalid_client_id_claim"
+
+
+def test_require_auth_context_allows_missing_client_id() -> None:
+    from app.core.security import require_auth_context
+
+    user_id = "11111111-1111-1111-1111-111111111111"
+    context = asyncio.run(require_auth_context(claims={"sub": user_id}))
+    assert context.user_id == uuid.UUID(user_id)
+    assert context.client_id is None


### PR DESCRIPTION
## Summary
- add API-side auth context + client/user rate-limiting and audit support
- add books search/import routers and Open Library integration service
- add `/me` and `/library/items` routers with profile/library service layer
- add DB session helper + user model metadata updates for auth FK resolution
- add comprehensive API tests for new services/routers/middleware/security behavior

## Validation
- `make quality` (pass)

## Follow-up
- reintroduces the tests that were temporarily removed in #63, now paired with implementation modules in the same PR.

## Related issues
- Progresses #14
- Progresses #15
- Progresses #19
- Progresses #20
