### PR TITLE
Add PATCH/DELETE library item endpoints and filter support

### DIFF
--- a/apps/api/app/routers/library.py
+++ b/apps/api/app/routers/library.py
@@ -11,11 +11,24 @@ from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
-from app.services.user_library import create_or_get_library_item, list_library_items
+from app.services.user_library import (
+    create_or_get_library_item,
+    delete_library_item,
+    list_library_items,
+    update_library_item,
+)
 
 
 class CreateLibraryItemRequest(BaseModel):
     work_id: uuid.UUID
+    preferred_edition_id: uuid.UUID | None = None
+    status: str | None = Field(default=None, max_length=32)
+    visibility: str | None = Field(default=None, max_length=32)
+    rating: int | None = Field(default=None, ge=0, le=10)
+    tags: list[str] | None = None
+
+
+class UpdateLibraryItemRequest(BaseModel):
     preferred_edition_id: uuid.UUID | None = None
     status: str | None = Field(default=None, max_length=32)
     visibility: str | None = Field(default=None, max_length=32)
@@ -37,6 +50,8 @@ def list_items(
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
     cursor: str | None = None,
     status: str | None = None,
+    tag: str | None = None,
+    visibility: str | None = None,
 ) -> dict[str, object]:
     try:
         result = list_library_items(
@@ -45,6 +60,8 @@ def list_items(
             limit=limit,
             cursor=cursor,
             status=status,
+            tag=tag,
+            visibility=visibility,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -82,3 +99,53 @@ def create_item(
             "created": created,
         }
     )
+
+
+@router.patch("/{item_id}")
+def patch_item(
+    item_id: uuid.UUID,
+    payload: UpdateLibraryItemRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    updates = payload.model_dump(exclude_unset=True)
+    try:
+        item = update_library_item(
+            session,
+            user_id=auth.user_id,
+            item_id=item_id,
+            updates=updates,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return ok(
+        {
+            "id": str(item.id),
+            "work_id": str(item.work_id),
+            "status": item.status,
+            "visibility": item.visibility,
+            "rating": item.rating,
+            "tags": item.tags or [],
+        }
+    )
+
+
+@router.delete("/{item_id}")
+def remove_item(
+    item_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        delete_library_item(
+            session,
+            user_id=auth.user_id,
+            item_id=item_id,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return ok({"deleted": True})

--- a/apps/api/tests/test_me_library_router.py
+++ b/apps/api/tests/test_me_library_router.py
@@ -53,7 +53,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
 
     monkeypatch.setattr(
         "app.routers.library.list_library_items",
-        lambda session, *, user_id, limit, cursor, status: {
+        lambda session, *, user_id, limit, cursor, status, tag, visibility: {
             "items": [
                 {
                     "id": str(uuid.uuid4()),
@@ -82,6 +82,21 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
             ),
             True,
         ),
+    )
+    monkeypatch.setattr(
+        "app.routers.library.update_library_item",
+        lambda session, *, user_id, item_id, updates: SimpleNamespace(
+            id=item_id,
+            work_id=uuid.uuid4(),
+            status=updates.get("status", "to_read"),
+            visibility=updates.get("visibility", "private"),
+            rating=updates.get("rating"),
+            tags=updates.get("tags"),
+        ),
+    )
+    monkeypatch.setattr(
+        "app.routers.library.delete_library_item",
+        lambda session, *, user_id, item_id: None,
     )
 
     yield app
@@ -115,7 +130,10 @@ def test_patch_me_returns_400_on_validation_error(
 
 def test_list_library_items(app: FastAPI) -> None:
     client = TestClient(app)
-    response = client.get("/api/v1/library/items", params={"status": "reading"})
+    response = client.get(
+        "/api/v1/library/items",
+        params={"status": "reading", "tag": "tag-a", "visibility": "public"},
+    )
     assert response.status_code == 200
     assert response.json()["data"]["items"][0]["status"] == "reading"
 
@@ -155,3 +173,61 @@ def test_list_library_items_returns_400_for_bad_cursor(
     client = TestClient(app)
     response = client.get("/api/v1/library/items", params={"cursor": "bad"})
     assert response.status_code == 400
+
+
+def test_patch_library_item(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.patch(
+        f"/api/v1/library/items/{uuid.uuid4()}",
+        json={"status": "reading", "tags": ["memoir"]},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["status"] == "reading"
+    assert payload["tags"] == ["memoir"]
+
+
+def test_patch_library_item_returns_400(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.update_library_item",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad update")),
+    )
+    client = TestClient(app)
+    response = client.patch(f"/api/v1/library/items/{uuid.uuid4()}", json={})
+    assert response.status_code == 400
+
+
+def test_patch_library_item_returns_404(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.update_library_item",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(LookupError("missing item")),
+    )
+    client = TestClient(app)
+    response = client.patch(
+        f"/api/v1/library/items/{uuid.uuid4()}",
+        json={"status": "reading"},
+    )
+    assert response.status_code == 404
+
+
+def test_delete_library_item(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.delete(f"/api/v1/library/items/{uuid.uuid4()}")
+    assert response.status_code == 200
+    assert response.json()["data"]["deleted"] is True
+
+
+def test_delete_library_item_returns_404(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.delete_library_item",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(LookupError("missing item")),
+    )
+    client = TestClient(app)
+    response = client.delete(f"/api/v1/library/items/{uuid.uuid4()}")
+    assert response.status_code == 404

--- a/apps/api/tests/test_user_library_service.py
+++ b/apps/api/tests/test_user_library_service.py
@@ -12,8 +12,10 @@ from app.services.user_library import (
     _default_handle,
     _encode_cursor,
     create_or_get_library_item,
+    delete_library_item,
     get_or_create_profile,
     list_library_items,
+    update_library_item,
     update_profile,
 )
 
@@ -32,6 +34,7 @@ class FakeSession:
         self.scalar_values: list[Any] = []
         self.added: list[Any] = []
         self.execute_rows: list[tuple[Any, str]] = []
+        self.deleted: list[Any] = []
         self.committed = False
 
     def get(self, model: type[Any], key: Any) -> Any:
@@ -54,6 +57,9 @@ class FakeSession:
 
     def execute(self, _stmt: Any) -> FakeExecuteResult:
         return FakeExecuteResult(self.execute_rows)
+
+    def delete(self, obj: Any) -> None:
+        self.deleted.append(obj)
 
 
 def test_cursor_encode_decode_roundtrip() -> None:
@@ -230,6 +236,8 @@ def test_list_library_items_invalid_cursor() -> None:
             limit=10,
             cursor="bad",
             status=None,
+            tag=None,
+            visibility=None,
         )
 
 
@@ -270,6 +278,88 @@ def test_list_library_items_returns_cursor() -> None:
         limit=1,
         cursor=None,
         status="reading",
+        tag=None,
+        visibility=None,
     )
     assert len(result["items"]) == 1
     assert result["next_cursor"] is not None
+
+
+def test_update_library_item_requires_at_least_one_field() -> None:
+    session = FakeSession()
+    with pytest.raises(ValueError):
+        update_library_item(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            item_id=uuid.uuid4(),
+            updates={},
+        )
+
+
+def test_update_library_item_requires_ownership() -> None:
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        update_library_item(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            item_id=uuid.uuid4(),
+            updates={"status": "reading"},
+        )
+
+
+def test_update_library_item_applies_requested_fields() -> None:
+    session = FakeSession()
+    item = type(
+        "Item",
+        (),
+        {
+            "id": uuid.uuid4(),
+            "work_id": uuid.uuid4(),
+            "status": "to_read",
+            "visibility": "private",
+            "rating": None,
+            "tags": [],
+            "preferred_edition_id": None,
+        },
+    )()
+    session.scalar_values = [item]
+
+    updated = update_library_item(
+        cast(Any, session),
+        user_id=uuid.uuid4(),
+        item_id=item.id,
+        updates={"status": "reading", "rating": 9, "tags": ["memoir"]},
+    )
+
+    assert updated is item
+    assert item.status == "reading"
+    assert item.rating == 9
+    assert item.tags == ["memoir"]
+    assert session.committed is True
+
+
+def test_delete_library_item_requires_ownership() -> None:
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        delete_library_item(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            item_id=uuid.uuid4(),
+        )
+
+
+def test_delete_library_item_deletes_and_commits() -> None:
+    session = FakeSession()
+    item = object()
+    session.scalar_values = [item]
+
+    delete_library_item(
+        cast(Any, session),
+        user_id=uuid.uuid4(),
+        item_id=uuid.uuid4(),
+    )
+
+    assert session.deleted == [item]
+    assert session.committed is True


### PR DESCRIPTION
## Summary
- add `PATCH /api/v1/library/items/{id}` for partial updates (`status`, `visibility`, `rating`, `tags`, `preferred_edition_id`)
- add `DELETE /api/v1/library/items/{id}`
- enforce ownership in update/delete service queries (`item_id` + `user_id`)
- extend list filtering to support `tag` and `visibility` in addition to `status`
- add router/service tests covering success + 400/404 error paths

## Validation
- `make quality` (pass)

## Issue
- Advances #20
