### PR TITLE
Enforce client_id for protected API routes and rate limiting

### DIFF
--- a/apps/api/app/core/rate_limit.py
+++ b/apps/api/app/core/rate_limit.py
@@ -11,7 +11,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request
 
-from app.core.security import AuthContext, require_auth_context
+from app.core.security import AuthContext, require_client_auth_context
 
 
 @dataclass(frozen=True)
@@ -119,17 +119,25 @@ def _resolve_limit(config: RateLimitConfig, request: Request) -> int:
 
 def enforce_client_user_rate_limit(
     request: Request,
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     config: Annotated[RateLimitConfig, Depends(get_rate_limit_config)],
 ) -> None:
+    if auth.client_id is None:
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "missing_client_id_claim",
+                "message": "JWT 'client_id' claim is required.",
+            },
+        )
+
     if config.default_limit <= 0:
         return
 
     endpoint_key = f"{request.method.upper()} {request.url.path}"
     limit = _resolve_limit(config, request)
-    effective_client_id = auth.client_id or auth.user_id
     retry_after = _rate_limiter.check(
-        key=(effective_client_id, auth.user_id, endpoint_key),
+        key=(auth.client_id, auth.user_id, endpoint_key),
         limit=limit,
         window_seconds=config.window_seconds,
     )
@@ -137,7 +145,7 @@ def enforce_client_user_rate_limit(
         return
 
     request.state.rate_limit_event = {
-        "client_id": effective_client_id,
+        "client_id": auth.client_id,
         "user_id": auth.user_id,
         "method": request.method.upper(),
         "path": request.url.path,
@@ -152,7 +160,7 @@ def enforce_client_user_rate_limit(
             "code": "rate_limited",
             "message": "Rate limit exceeded.",
             "details": {
-                "client_id": str(effective_client_id),
+                "client_id": str(auth.client_id),
                 "user_id": str(auth.user_id),
                 "limit": limit,
                 "window_seconds": config.window_seconds,

--- a/apps/api/app/routers/books.py
+++ b/apps/api/app/routers/books.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import AuthContext, require_auth_context
+from app.core.security import AuthContext, require_client_auth_context
 from app.db.session import get_db_session
 from app.services.catalog import import_openlibrary_bundle
 from app.services.open_library import OpenLibraryClient
@@ -34,7 +34,7 @@ router = APIRouter(
 @router.get("/search")
 async def search_books(
     query: Annotated[str, Query(min_length=1)],
-    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    _auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
     limit: Annotated[int, Query(ge=1, le=50)] = 10,
     page: Annotated[int, Query(ge=1)] = 1,
@@ -69,7 +69,7 @@ async def search_books(
 @router.post("/import")
 async def import_book(
     payload: ImportBookRequest,
-    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    _auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
     open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
 ) -> dict[str, object]:

--- a/apps/api/app/routers/library.py
+++ b/apps/api/app/routers/library.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import AuthContext, require_auth_context
+from app.core.security import AuthContext, require_client_auth_context
 from app.db.session import get_db_session
 from app.services.user_library import (
     create_or_get_library_item,
@@ -45,7 +45,7 @@ router = APIRouter(
 
 @router.get("")
 def list_items(
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
     cursor: str | None = None,
@@ -71,7 +71,7 @@ def list_items(
 @router.post("")
 def create_item(
     payload: CreateLibraryItemRequest,
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:
@@ -105,7 +105,7 @@ def create_item(
 def patch_item(
     item_id: uuid.UUID,
     payload: UpdateLibraryItemRequest,
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     updates = payload.model_dump(exclude_unset=True)
@@ -136,7 +136,7 @@ def patch_item(
 @router.delete("/{item_id}")
 def remove_item(
     item_id: uuid.UUID,
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:

--- a/apps/api/app/routers/me.py
+++ b/apps/api/app/routers/me.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import AuthContext, require_auth_context
+from app.core.security import AuthContext, require_client_auth_context
 from app.db.session import get_db_session
 from app.services.user_library import get_or_create_profile, update_profile
 
@@ -28,7 +28,7 @@ router = APIRouter(
 
 @router.get("")
 def get_me(
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     profile = get_or_create_profile(session, user_id=auth.user_id)
@@ -45,7 +45,7 @@ def get_me(
 @router.patch("")
 def patch_me(
     payload: UpdateProfileRequest,
-    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:

--- a/apps/api/tests/test_books_router.py
+++ b/apps/api/tests/test_books_router.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.core.rate_limit import enforce_client_user_rate_limit
-from app.core.security import AuthContext, require_auth_context
+from app.core.security import AuthContext, require_client_auth_context
 from app.db.session import get_db_session
 from app.routers.books import get_open_library_client, router
 from app.routers.library import router as library_router
@@ -67,7 +67,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
     app = FastAPI()
     app.include_router(router)
 
-    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+    app.dependency_overrides[require_client_auth_context] = lambda: AuthContext(
         claims={},
         client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         user_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
@@ -168,7 +168,7 @@ def test_import_then_add_library_item_happy_path(
     app.include_router(library_router)
 
     user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+    app.dependency_overrides[require_client_auth_context] = lambda: AuthContext(
         claims={},
         client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         user_id=user_id,

--- a/apps/api/tests/test_me_library_router.py
+++ b/apps/api/tests/test_me_library_router.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.core.rate_limit import enforce_client_user_rate_limit
-from app.core.security import AuthContext, require_auth_context
+from app.core.security import AuthContext, require_client_auth_context
 from app.db.session import get_db_session
 from app.routers.library import router as library_router
 from app.routers.me import router as me_router
@@ -23,7 +23,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
     app.include_router(library_router)
 
     user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+    app.dependency_overrides[require_client_auth_context] = lambda: AuthContext(
         claims={},
         client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         user_id=user_id,


### PR DESCRIPTION
## Summary
- require `client_id` JWT claim on books, library, and me routers by switching to `require_client_auth_context`
- make rate limiting depend on strict client auth and key limits/audit metadata by `(client_id, user_id, endpoint)` without fallback
- update router tests to override `require_client_auth_context`

## Validation
- `make quality`

Closes #27
