### PR TITLE
Fix staging API CORS for hosted web origins

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -18,6 +18,9 @@ class Settings:
         "http://127.0.0.1:3000",
         "http://localhost:3001",
         "http://127.0.0.1:3001",
+        "https://staging.theseedbed.app",
+        "https://theseedbed.app",
+        "https://www.theseedbed.app",
     )
 
 
@@ -104,6 +107,9 @@ def _parse_cors_origins() -> tuple[str, ...]:
             "http://127.0.0.1:3000",
             "http://localhost:3001",
             "http://127.0.0.1:3001",
+            "https://staging.theseedbed.app",
+            "https://theseedbed.app",
+            "https://www.theseedbed.app",
         )
     return tuple(origin.strip() for origin in raw_origins.split(",") if origin.strip())
 

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -26,6 +26,9 @@ def test_get_settings_blank_audience_and_reset_cache() -> None:
             "http://127.0.0.1:3000",
             "http://localhost:3001",
             "http://127.0.0.1:3001",
+            "https://staging.theseedbed.app",
+            "https://theseedbed.app",
+            "https://www.theseedbed.app",
         )
         assert settings.api_version == "9.9.9"
     finally:

--- a/apps/api/tests/test_endpoints.py
+++ b/apps/api/tests/test_endpoints.py
@@ -28,3 +28,19 @@ def test_cors_preflight_for_library_endpoint() -> None:
     )
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+
+def test_cors_preflight_for_library_endpoint_staging_origin() -> None:
+    client = TestClient(create_app())
+    response = client.options(
+        "/api/v1/library/items?limit=10",
+        headers={
+            "Origin": "https://staging.theseedbed.app",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.headers["access-control-allow-origin"]
+        == "https://staging.theseedbed.app"
+    )

--- a/apps/api/tests/test_error_handlers.py
+++ b/apps/api/tests/test_error_handlers.py
@@ -95,3 +95,16 @@ def test_unhandled_exception_handler_sets_cors_header_for_allowed_origin() -> No
     )
     assert response.status_code == 500
     assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:3000"
+
+
+def test_unhandled_exception_handler_sets_cors_header_for_staging_origin() -> None:
+    exc = Exception("boom")
+    response = unhandled_exception_handler(
+        _request_with_origin("https://staging.theseedbed.app"),
+        exc,
+    )
+    assert response.status_code == 500
+    assert (
+        response.headers["Access-Control-Allow-Origin"]
+        == "https://staging.theseedbed.app"
+    )


### PR DESCRIPTION
Includes staging/prod web origins in API CORS defaults and adds regression tests.\n\nVerification: make quality