### PR TITLE
Fix staging login flow blocked by strict client_id claim

### DIFF
--- a/apps/api/app/routers/books.py
+++ b/apps/api/app/routers/books.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import AuthContext, require_client_auth_context
+from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.services.catalog import import_openlibrary_bundle
 from app.services.open_library import OpenLibraryClient
@@ -34,7 +34,7 @@ router = APIRouter(
 @router.get("/search")
 async def search_books(
     query: Annotated[str, Query(min_length=1)],
-    _auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
     open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
     limit: Annotated[int, Query(ge=1, le=50)] = 10,
     page: Annotated[int, Query(ge=1)] = 1,
@@ -69,7 +69,7 @@ async def search_books(
 @router.post("/import")
 async def import_book(
     payload: ImportBookRequest,
-    _auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
     open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
 ) -> dict[str, object]:

--- a/apps/api/app/routers/library.py
+++ b/apps/api/app/routers/library.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import AuthContext, require_client_auth_context
+from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.services.user_library import (
     create_or_get_library_item,
@@ -45,7 +45,7 @@ router = APIRouter(
 
 @router.get("")
 def list_items(
-    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
     cursor: str | None = None,
@@ -71,7 +71,7 @@ def list_items(
 @router.post("")
 def create_item(
     payload: CreateLibraryItemRequest,
-    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:
@@ -105,7 +105,7 @@ def create_item(
 def patch_item(
     item_id: uuid.UUID,
     payload: UpdateLibraryItemRequest,
-    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     updates = payload.model_dump(exclude_unset=True)
@@ -136,7 +136,7 @@ def patch_item(
 @router.delete("/{item_id}")
 def remove_item(
     item_id: uuid.UUID,
-    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:

--- a/apps/api/app/routers/me.py
+++ b/apps/api/app/routers/me.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rate_limit import enforce_client_user_rate_limit
 from app.core.responses import ok
-from app.core.security import AuthContext, require_client_auth_context
+from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.services.user_library import get_or_create_profile, update_profile
 
@@ -28,7 +28,7 @@ router = APIRouter(
 
 @router.get("")
 def get_me(
-    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     profile = get_or_create_profile(session, user_id=auth.user_id)
@@ -45,7 +45,7 @@ def get_me(
 @router.patch("")
 def patch_me(
     payload: UpdateProfileRequest,
-    auth: Annotated[AuthContext, Depends(require_client_auth_context)],
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:

--- a/apps/api/tests/test_books_router.py
+++ b/apps/api/tests/test_books_router.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.core.rate_limit import enforce_client_user_rate_limit
-from app.core.security import AuthContext, require_client_auth_context
+from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.routers.books import get_open_library_client, router
 from app.routers.library import router as library_router
@@ -67,7 +67,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
     app = FastAPI()
     app.include_router(router)
 
-    app.dependency_overrides[require_client_auth_context] = lambda: AuthContext(
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
         claims={},
         client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         user_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
@@ -168,7 +168,7 @@ def test_import_then_add_library_item_happy_path(
     app.include_router(library_router)
 
     user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    app.dependency_overrides[require_client_auth_context] = lambda: AuthContext(
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
         claims={},
         client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         user_id=user_id,

--- a/apps/api/tests/test_me_library_router.py
+++ b/apps/api/tests/test_me_library_router.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.core.rate_limit import enforce_client_user_rate_limit
-from app.core.security import AuthContext, require_client_auth_context
+from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.routers.library import router as library_router
 from app.routers.me import router as me_router
@@ -23,7 +23,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
     app.include_router(library_router)
 
     user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    app.dependency_overrides[require_client_auth_context] = lambda: AuthContext(
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
         claims={},
         client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         user_id=user_id,

--- a/apps/api/tests/test_rate_limit_unit.py
+++ b/apps/api/tests/test_rate_limit_unit.py
@@ -91,3 +91,16 @@ def test_enforce_rate_limit_noop_when_default_limit_disabled() -> None:
 
     enforce_client_user_rate_limit(request=request, auth=auth, config=config)
     assert not hasattr(request.state, "rate_limit_event")
+
+
+def test_enforce_rate_limit_allows_missing_client_id_with_fallback() -> None:
+    request = _request("GET", "/api/v1/library/items")
+    auth = AuthContext(
+        claims={},
+        client_id=None,
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+    )
+    config = RateLimitConfig(default_limit=1, window_seconds=60, endpoint_limits={})
+
+    enforce_client_user_rate_limit(request=request, auth=auth, config=config)
+    assert not hasattr(request.state, "rate_limit_event")


### PR DESCRIPTION
Allows first-party signed-in web users to call books/library/me endpoints without a JWT client_id claim while keeping strict client enforcement on /api/v1/protected.\n\nVerification: make quality