### PR TITLE
CI: run checks for main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - development
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   api:


### PR DESCRIPTION
This makes CI run for PRs targeting `main` (and on pushes to `main`) so branch protections can require the same `api` + `web` checks when promoting `development -> main`.

No behavior changes to the app.
