### PR TITLE
Tests: make SUPABASE_URL fallback tests .env-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - development
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   api:

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -72,9 +72,13 @@ def test_get_settings_custom_cors_origins() -> None:
         config_module.reset_settings_cache()
 
 
-def test_get_settings_falls_back_supabase_url_for_prod_env() -> None:
+def test_get_settings_falls_back_supabase_url_for_prod_env(tmp_path: Path) -> None:
     original_env = os.environ.copy()
+    original_cwd = os.getcwd()
     try:
+        # Ensure .env does not re-introduce SUPABASE_URL during this test.
+        os.chdir(tmp_path)
+        os.environ["APP_CONFIG_DIR"] = str(tmp_path)
         os.environ.pop("SUPABASE_URL", None)
         os.environ["SUPABASE_ENV"] = "production"
         config_module.reset_settings_cache()
@@ -82,14 +86,19 @@ def test_get_settings_falls_back_supabase_url_for_prod_env() -> None:
         settings = config_module.get_settings()
         assert settings.supabase_url == "https://aaohmjvcsgyqqlxomegu.supabase.co"
     finally:
+        os.chdir(original_cwd)
         os.environ.clear()
         os.environ.update(original_env)
         config_module.reset_settings_cache()
 
 
-def test_get_settings_falls_back_supabase_url_for_staging_env() -> None:
+def test_get_settings_falls_back_supabase_url_for_staging_env(tmp_path: Path) -> None:
     original_env = os.environ.copy()
+    original_cwd = os.getcwd()
     try:
+        # Ensure .env does not re-introduce SUPABASE_URL during this test.
+        os.chdir(tmp_path)
+        os.environ["APP_CONFIG_DIR"] = str(tmp_path)
         os.environ.pop("SUPABASE_URL", None)
         os.environ["SUPABASE_ENV"] = "staging"
         config_module.reset_settings_cache()
@@ -97,6 +106,7 @@ def test_get_settings_falls_back_supabase_url_for_staging_env() -> None:
         settings = config_module.get_settings()
         assert settings.supabase_url == "https://kypwcksvicrbrrwscdze.supabase.co"
     finally:
+        os.chdir(original_cwd)
         os.environ.clear()
         os.environ.update(original_env)
         config_module.reset_settings_cache()


### PR DESCRIPTION
The `SUPABASE_URL` fallback tests were failing in the `main -> development` sync PR because CI creates a repo `.env` (via `make supabase-env`) and `get_settings()` loads it, re-introducing `SUPABASE_URL` even after the test removes it.

This change runs those fallback assertions from an empty temp config dir so the tests actually validate the fallback behavior.
