### PR TITLE
feat(web): progressive book detail loading + retries

### DIFF
--- a/apps/api/alembic/versions/0008_cover_provenance.py
+++ b/apps/api/alembic/versions/0008_cover_provenance.py
@@ -18,38 +18,48 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "editions",
-        sa.Column("cover_set_by", sa.UUID(as_uuid=True)),
-    )
-    op.add_column(
-        "editions",
-        sa.Column("cover_set_at", sa.DateTime(timezone=True)),
-    )
-    op.add_column(
-        "editions",
-        sa.Column("cover_storage_path", sa.Text),
-    )
+    # CI starts Supabase (which applies supabase/migrations) and then runs Alembic.
+    # Make this migration safe when the columns were already created by Supabase SQL.
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
 
-    op.add_column(
-        "works",
-        sa.Column("default_cover_set_by", sa.UUID(as_uuid=True)),
-    )
-    op.add_column(
-        "works",
-        sa.Column("default_cover_set_at", sa.DateTime(timezone=True)),
-    )
-    op.add_column(
-        "works",
-        sa.Column("default_cover_storage_path", sa.Text),
-    )
+    editions_cols = {c["name"] for c in insp.get_columns("editions")}
+    works_cols = {c["name"] for c in insp.get_columns("works")}
+
+    if "cover_set_by" not in editions_cols:
+        op.add_column("editions", sa.Column("cover_set_by", sa.UUID(as_uuid=True)))
+    if "cover_set_at" not in editions_cols:
+        op.add_column("editions", sa.Column("cover_set_at", sa.DateTime(timezone=True)))
+    if "cover_storage_path" not in editions_cols:
+        op.add_column("editions", sa.Column("cover_storage_path", sa.Text))
+
+    if "default_cover_set_by" not in works_cols:
+        op.add_column("works", sa.Column("default_cover_set_by", sa.UUID(as_uuid=True)))
+    if "default_cover_set_at" not in works_cols:
+        op.add_column(
+            "works", sa.Column("default_cover_set_at", sa.DateTime(timezone=True))
+        )
+    if "default_cover_storage_path" not in works_cols:
+        op.add_column("works", sa.Column("default_cover_storage_path", sa.Text))
 
 
 def downgrade() -> None:
-    op.drop_column("works", "default_cover_storage_path")
-    op.drop_column("works", "default_cover_set_at")
-    op.drop_column("works", "default_cover_set_by")
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
 
-    op.drop_column("editions", "cover_storage_path")
-    op.drop_column("editions", "cover_set_at")
-    op.drop_column("editions", "cover_set_by")
+    editions_cols = {c["name"] for c in insp.get_columns("editions")}
+    works_cols = {c["name"] for c in insp.get_columns("works")}
+
+    if "default_cover_storage_path" in works_cols:
+        op.drop_column("works", "default_cover_storage_path")
+    if "default_cover_set_at" in works_cols:
+        op.drop_column("works", "default_cover_set_at")
+    if "default_cover_set_by" in works_cols:
+        op.drop_column("works", "default_cover_set_by")
+
+    if "cover_storage_path" in editions_cols:
+        op.drop_column("editions", "cover_storage_path")
+    if "cover_set_at" in editions_cols:
+        op.drop_column("editions", "cover_set_at")
+    if "cover_set_by" in editions_cols:
+        op.drop_column("editions", "cover_set_by")

--- a/apps/web/app/pages/books/[workId].vue
+++ b/apps/web/app/pages/books/[workId].vue
@@ -1,416 +1,439 @@
 <template>
-  <div class="min-h-screen bg-slate-950/5 text-slate-900">
-    <section class="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-12">
-      <NuxtLink to="/library" class="text-sm font-medium text-emerald-700 hover:underline">
-        Back to library
-      </NuxtLink>
+  <PageShell>
+    <NuxtLink to="/library" class="text-sm font-medium text-emerald-700 hover:underline">
+      Back to library
+    </NuxtLink>
 
-      <Card class="shadow-lg" data-test="book-detail-card">
-        <template #title>
-          <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div class="flex items-center gap-3">
-              <i class="pi pi-book text-emerald-600" aria-hidden="true"></i>
-              <span class="text-2xl font-semibold">
-                {{ work?.title || 'Book detail' }}
-              </span>
-            </div>
-            <span
-              v-if="libraryItem"
-              class="rounded bg-slate-100 px-2 py-1 text-xs uppercase text-slate-600"
-            >
-              {{ libraryItem.status }}
+    <Card class="shadow-lg" data-test="book-detail-card">
+      <template #title>
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div class="flex items-center gap-3">
+            <i class="pi pi-book text-emerald-600" aria-hidden="true"></i>
+            <span class="text-2xl font-semibold">
+              {{ work?.title || 'Book detail' }}
             </span>
           </div>
-        </template>
-        <template #content>
-          <div class="flex flex-col gap-6">
-            <p
-              v-if="error"
-              class="rounded-md bg-rose-50 px-3 py-2 text-sm text-rose-700"
-              data-test="book-detail-error"
-            >
-              {{ error }}
-            </p>
+          <span
+            v-if="libraryItem"
+            class="rounded bg-slate-100 px-2 py-1 text-xs uppercase text-slate-600"
+          >
+            {{ libraryItem.status }}
+          </span>
+        </div>
+      </template>
+      <template #content>
+        <div class="flex flex-col gap-6">
+          <InlineAlert v-if="error" tone="error" :message="error" data-test="book-detail-error" />
 
-            <div v-if="loading" class="text-sm text-slate-600">Loading...</div>
+          <div v-if="coreLoading" class="text-sm text-slate-600">Loading...</div>
 
-            <div v-else class="grid gap-6 md:grid-cols-[160px_1fr]">
-              <div class="flex flex-col gap-3">
-                <img
-                  v-if="work?.cover_url"
-                  :src="work.cover_url"
-                  alt=""
-                  class="h-56 w-40 rounded-md border border-slate-200/70 object-cover shadow-sm"
+          <div v-else class="grid gap-6 md:grid-cols-[160px_1fr]">
+            <div class="flex flex-col gap-3">
+              <img
+                v-if="work?.cover_url"
+                :src="work.cover_url"
+                alt=""
+                class="h-56 w-40 rounded-md border border-slate-200/70 object-cover shadow-sm"
+              />
+              <div
+                v-else
+                class="flex h-56 w-40 items-center justify-center rounded-md bg-slate-100"
+              >
+                <span class="text-xs text-slate-500">No cover</span>
+              </div>
+
+              <div v-if="libraryItem" class="flex flex-wrap items-center gap-2">
+                <Button
+                  label="Set cover"
+                  size="small"
+                  severity="secondary"
+                  data-test="set-cover"
+                  @click="openCoverDialog"
                 />
-                <div
-                  v-else
-                  class="flex h-56 w-40 items-center justify-center rounded-md bg-slate-100"
-                >
-                  <span class="text-xs text-slate-500">No cover</span>
-                </div>
+              </div>
+            </div>
 
-                <div v-if="libraryItem" class="flex flex-wrap items-center gap-2">
+            <div class="flex flex-col gap-3">
+              <p v-if="work?.authors?.length" class="text-sm text-slate-700">
+                <span class="font-medium">Authors:</span>
+                {{ work.authors.map((a) => a.name).join(', ') }}
+              </p>
+              <p v-if="work?.description" class="text-sm text-slate-700">
+                {{ work.description }}
+              </p>
+
+              <div v-if="!libraryItem" class="flex flex-col gap-2">
+                <p class="text-sm text-slate-600">This book is not in your library yet.</p>
+                <NuxtLink
+                  to="/books/search"
+                  class="text-sm font-medium text-emerald-700 hover:underline"
+                >
+                  Search and import it
+                </NuxtLink>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </Card>
+
+    <Card v-if="libraryItem" class="shadow-sm">
+      <template #title>
+        <div class="flex items-center gap-3 text-lg font-semibold">
+          <i class="pi pi-clock text-emerald-600" aria-hidden="true"></i>
+          <span>Reading sessions</span>
+        </div>
+      </template>
+      <template #content>
+        <div class="flex flex-col gap-4">
+          <div v-if="sessionsError" class="flex flex-col gap-2">
+            <InlineAlert tone="error" :message="sessionsError" />
+            <div>
+              <Button
+                label="Retry"
+                size="small"
+                severity="secondary"
+                data-test="sessions-retry"
+                @click="loadSessions"
+              />
+            </div>
+          </div>
+          <div v-else-if="sessionsLoading" class="text-sm text-slate-600">Loading sessions...</div>
+
+          <div class="grid gap-3 md:grid-cols-3">
+            <InputText v-model="sessionPagesRead" placeholder="Pages read" />
+            <InputText v-model="sessionProgressPercent" placeholder="Progress % (0-100)" />
+            <Button
+              label="Log session"
+              :loading="savingSession"
+              data-test="log-session"
+              @click="logSession"
+            />
+          </div>
+          <Textarea v-model="sessionNote" rows="2" auto-resize placeholder="Session note" />
+
+          <div v-if="sessions.length" class="grid gap-2">
+            <div
+              v-for="s in sessions"
+              :key="s.id"
+              class="rounded-md border border-slate-200/70 bg-white px-3 py-2"
+            >
+              <p class="text-sm font-medium text-slate-900">
+                {{ formatDate(s.started_at) }}
+              </p>
+              <p class="text-xs text-slate-600">
+                Pages: {{ s.pages_read ?? '-' }} | Progress: {{ s.progress_percent ?? '-' }}
+              </p>
+              <p v-if="s.note" class="text-xs text-slate-600">{{ s.note }}</p>
+            </div>
+          </div>
+          <p v-else class="text-sm text-slate-600">No sessions yet.</p>
+        </div>
+      </template>
+    </Card>
+
+    <Card v-if="libraryItem" class="shadow-sm">
+      <template #title>
+        <div class="flex items-center gap-3 text-lg font-semibold">
+          <i class="pi pi-pencil text-emerald-600" aria-hidden="true"></i>
+          <span>Notes</span>
+        </div>
+      </template>
+      <template #content>
+        <div class="flex flex-col gap-4">
+          <div v-if="notesError" class="flex flex-col gap-2">
+            <InlineAlert tone="error" :message="notesError" />
+            <div>
+              <Button
+                label="Retry"
+                size="small"
+                severity="secondary"
+                data-test="notes-retry"
+                @click="loadNotes"
+              />
+            </div>
+          </div>
+          <div v-else-if="notesLoading" class="text-sm text-slate-600">Loading notes...</div>
+
+          <div class="grid gap-3 md:grid-cols-3">
+            <InputText v-model="newNoteTitle" placeholder="Title (optional)" />
+            <Select
+              v-model="newNoteVisibility"
+              :options="visibilityOptions"
+              option-label="label"
+              option-value="value"
+            />
+            <Button label="Add note" :loading="savingNote" @click="addNote" />
+          </div>
+          <Textarea v-model="newNoteBody" rows="3" auto-resize placeholder="Write a note..." />
+
+          <div v-if="notes.length" class="grid gap-2">
+            <div
+              v-for="n in notes"
+              :key="n.id"
+              class="rounded-md border border-slate-200/70 bg-white px-3 py-2"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <p v-if="n.title" class="text-sm font-semibold text-slate-900">
+                    {{ n.title }}
+                  </p>
+                  <p class="text-xs text-slate-500">
+                    {{ n.visibility }} | {{ formatDate(n.created_at) }}
+                  </p>
+                </div>
+                <div class="flex items-center gap-2">
                   <Button
-                    label="Set cover"
+                    label="Edit"
                     size="small"
+                    text
                     severity="secondary"
-                    data-test="set-cover"
-                    @click="openCoverDialog"
+                    @click="openEditNote(n)"
+                  />
+                  <Button
+                    label="Delete"
+                    size="small"
+                    text
+                    severity="danger"
+                    :loading="deletingNoteId === n.id"
+                    @click="deleteNote(n)"
                   />
                 </div>
               </div>
-
-              <div class="flex flex-col gap-3">
-                <p v-if="work?.authors?.length" class="text-sm text-slate-700">
-                  <span class="font-medium">Authors:</span>
-                  {{ work.authors.map((a) => a.name).join(', ') }}
-                </p>
-                <p v-if="work?.description" class="text-sm text-slate-700">
-                  {{ work.description }}
-                </p>
-
-                <div v-if="!libraryItem" class="flex flex-col gap-2">
-                  <p class="text-sm text-slate-600">This book is not in your library yet.</p>
-                  <NuxtLink
-                    to="/books/search"
-                    class="text-sm font-medium text-emerald-700 hover:underline"
-                  >
-                    Search and import it
-                  </NuxtLink>
-                </div>
-              </div>
+              <p class="mt-2 text-sm text-slate-700">{{ n.body }}</p>
             </div>
           </div>
-        </template>
-      </Card>
-
-      <Card v-if="libraryItem" class="shadow-sm">
-        <template #title>
-          <div class="flex items-center gap-3 text-lg font-semibold">
-            <i class="pi pi-clock text-emerald-600" aria-hidden="true"></i>
-            <span>Reading sessions</span>
-          </div>
-        </template>
-        <template #content>
-          <div class="flex flex-col gap-4">
-            <div class="grid gap-3 md:grid-cols-3">
-              <InputText v-model="sessionPagesRead" placeholder="Pages read" />
-              <InputText v-model="sessionProgressPercent" placeholder="Progress % (0-100)" />
-              <Button
-                label="Log session"
-                :loading="savingSession"
-                data-test="log-session"
-                @click="logSession"
-              />
-            </div>
-            <Textarea v-model="sessionNote" rows="2" auto-resize placeholder="Session note" />
-
-            <div v-if="sessions.length" class="grid gap-2">
-              <div
-                v-for="s in sessions"
-                :key="s.id"
-                class="rounded-md border border-slate-200/70 bg-white px-3 py-2"
-              >
-                <p class="text-sm font-medium text-slate-900">
-                  {{ formatDate(s.started_at) }}
-                </p>
-                <p class="text-xs text-slate-600">
-                  Pages: {{ s.pages_read ?? '-' }} | Progress: {{ s.progress_percent ?? '-' }}
-                </p>
-                <p v-if="s.note" class="text-xs text-slate-600">{{ s.note }}</p>
-              </div>
-            </div>
-            <p v-else class="text-sm text-slate-600">No sessions yet.</p>
-          </div>
-        </template>
-      </Card>
-
-      <Card v-if="libraryItem" class="shadow-sm">
-        <template #title>
-          <div class="flex items-center gap-3 text-lg font-semibold">
-            <i class="pi pi-pencil text-emerald-600" aria-hidden="true"></i>
-            <span>Notes</span>
-          </div>
-        </template>
-        <template #content>
-          <div class="flex flex-col gap-4">
-            <div class="grid gap-3 md:grid-cols-3">
-              <InputText v-model="newNoteTitle" placeholder="Title (optional)" />
-              <Select
-                v-model="newNoteVisibility"
-                :options="visibilityOptions"
-                option-label="label"
-                option-value="value"
-              />
-              <Button label="Add note" :loading="savingNote" @click="addNote" />
-            </div>
-            <Textarea v-model="newNoteBody" rows="3" auto-resize placeholder="Write a note..." />
-
-            <div v-if="notes.length" class="grid gap-2">
-              <div
-                v-for="n in notes"
-                :key="n.id"
-                class="rounded-md border border-slate-200/70 bg-white px-3 py-2"
-              >
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <p v-if="n.title" class="text-sm font-semibold text-slate-900">
-                      {{ n.title }}
-                    </p>
-                    <p class="text-xs text-slate-500">
-                      {{ n.visibility }} | {{ formatDate(n.created_at) }}
-                    </p>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <Button
-                      label="Edit"
-                      size="small"
-                      text
-                      severity="secondary"
-                      @click="openEditNote(n)"
-                    />
-                    <Button
-                      label="Delete"
-                      size="small"
-                      text
-                      severity="danger"
-                      :loading="deletingNoteId === n.id"
-                      @click="deleteNote(n)"
-                    />
-                  </div>
-                </div>
-                <p class="mt-2 text-sm text-slate-700">{{ n.body }}</p>
-              </div>
-            </div>
-            <p v-else class="text-sm text-slate-600">No notes yet.</p>
-          </div>
-        </template>
-      </Card>
-
-      <Dialog
-        v-model:visible="editNoteVisible"
-        modal
-        header="Edit note"
-        :style="{ width: '36rem' }"
-      >
-        <div class="flex flex-col gap-3">
-          <InputText v-model="editNoteTitle" placeholder="Title (optional)" />
-          <Select
-            v-model="editNoteVisibility"
-            :options="visibilityOptions"
-            option-label="label"
-            option-value="value"
-          />
-          <Textarea v-model="editNoteBody" rows="6" auto-resize />
-          <div class="flex justify-end gap-2">
-            <Button label="Cancel" severity="secondary" text @click="editNoteVisible = false" />
-            <Button label="Save" :loading="savingNote" @click="saveEditNote" />
-          </div>
+          <p v-else class="text-sm text-slate-600">No notes yet.</p>
         </div>
-      </Dialog>
+      </template>
+    </Card>
 
-      <Card v-if="libraryItem" class="shadow-sm">
-        <template #title>
-          <div class="flex items-center gap-3 text-lg font-semibold">
-            <i class="pi pi-quote-right text-emerald-600" aria-hidden="true"></i>
-            <span>Highlights</span>
-          </div>
-        </template>
-        <template #content>
-          <div class="flex flex-col gap-4">
-            <div class="grid gap-3 md:grid-cols-3">
-              <Select
-                v-model="newHighlightVisibility"
-                :options="visibilityOptions"
-                option-label="label"
-                option-value="value"
-              />
-              <InputText v-model="highlightLocationSort" placeholder="Location (optional)" />
-              <Button label="Add highlight" :loading="savingHighlight" @click="addHighlight" />
-            </div>
-            <Textarea
-              v-model="newHighlightQuote"
-              rows="3"
-              auto-resize
-              placeholder="Paste a short excerpt..."
-            />
-
-            <div v-if="highlights.length" class="grid gap-2">
-              <div
-                v-for="h in highlights"
-                :key="h.id"
-                class="rounded-md border border-slate-200/70 bg-white px-3 py-2"
-              >
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <p class="text-xs text-slate-500">
-                      {{ h.visibility }} | {{ formatDate(h.created_at) }}
-                    </p>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <Button
-                      label="Edit"
-                      size="small"
-                      text
-                      severity="secondary"
-                      @click="openEditHighlight(h)"
-                    />
-                    <Button
-                      label="Delete"
-                      size="small"
-                      text
-                      severity="danger"
-                      :loading="deletingHighlightId === h.id"
-                      @click="deleteHighlight(h)"
-                    />
-                  </div>
-                </div>
-                <p class="mt-2 text-sm text-slate-700">{{ h.quote }}</p>
-              </div>
-            </div>
-            <p v-else class="text-sm text-slate-600">No highlights yet.</p>
-          </div>
-        </template>
-      </Card>
-
-      <Dialog
-        v-model:visible="editHighlightVisible"
-        modal
-        header="Edit highlight"
-        :style="{ width: '36rem' }"
-      >
-        <div class="flex flex-col gap-3">
-          <Select
-            v-model="editHighlightVisibility"
-            :options="visibilityOptions"
-            option-label="label"
-            option-value="value"
-          />
-          <InputText v-model="editHighlightLocationSort" placeholder="Location (optional)" />
-          <Textarea v-model="editHighlightQuote" rows="6" auto-resize />
-          <div class="flex justify-end gap-2">
-            <Button
-              label="Cancel"
-              severity="secondary"
-              text
-              @click="editHighlightVisible = false"
-            />
-            <Button label="Save" :loading="savingHighlight" @click="saveEditHighlight" />
-          </div>
+    <Dialog v-model:visible="editNoteVisible" modal header="Edit note" :style="{ width: '36rem' }">
+      <div class="flex flex-col gap-3">
+        <InputText v-model="editNoteTitle" placeholder="Title (optional)" />
+        <Select
+          v-model="editNoteVisibility"
+          :options="visibilityOptions"
+          option-label="label"
+          option-value="value"
+        />
+        <Textarea v-model="editNoteBody" rows="6" auto-resize />
+        <div class="flex justify-end gap-2">
+          <Button label="Cancel" severity="secondary" text @click="editNoteVisible = false" />
+          <Button label="Save" :loading="savingNote" @click="saveEditNote" />
         </div>
-      </Dialog>
+      </div>
+    </Dialog>
 
-      <Dialog
-        v-model:visible="coverDialogVisible"
-        modal
-        header="Set cover"
-        :style="{ width: '44rem' }"
-      >
+    <Card v-if="libraryItem" class="shadow-sm">
+      <template #title>
+        <div class="flex items-center gap-3 text-lg font-semibold">
+          <i class="pi pi-quote-right text-emerald-600" aria-hidden="true"></i>
+          <span>Highlights</span>
+        </div>
+      </template>
+      <template #content>
         <div class="flex flex-col gap-4">
-          <p v-if="coverError" class="rounded-md bg-rose-50 px-3 py-2 text-sm text-rose-700">
-            {{ coverError }}
-          </p>
+          <div v-if="highlightsError" class="flex flex-col gap-2">
+            <InlineAlert tone="error" :message="highlightsError" />
+            <div>
+              <Button
+                label="Retry"
+                size="small"
+                severity="secondary"
+                data-test="highlights-retry"
+                @click="loadHighlights"
+              />
+            </div>
+          </div>
+          <div v-else-if="highlightsLoading" class="text-sm text-slate-600">
+            Loading highlights...
+          </div>
 
-          <div v-if="needsEditionSelection" class="grid gap-3 md:grid-cols-2">
+          <div class="grid gap-3 md:grid-cols-3">
             <Select
-              v-model="selectedEditionId"
-              :options="editionOptions"
+              v-model="newHighlightVisibility"
+              :options="visibilityOptions"
               option-label="label"
               option-value="value"
-              :disabled="editionsLoading"
             />
-            <div class="flex items-center gap-2">
-              <input id="preferred" v-model="setPreferredEdition" type="checkbox" />
-              <label class="text-sm text-slate-700" for="preferred">Set as preferred edition</label>
+            <InputText v-model="highlightLocationSort" placeholder="Location (optional)" />
+            <Button label="Add highlight" :loading="savingHighlight" @click="addHighlight" />
+          </div>
+          <Textarea
+            v-model="newHighlightQuote"
+            rows="3"
+            auto-resize
+            placeholder="Paste a short excerpt..."
+          />
+
+          <div v-if="highlights.length" class="grid gap-2">
+            <div
+              v-for="h in highlights"
+              :key="h.id"
+              class="rounded-md border border-slate-200/70 bg-white px-3 py-2"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <p class="text-xs text-slate-500">
+                    {{ h.visibility }} | {{ formatDate(h.created_at) }}
+                  </p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <Button
+                    label="Edit"
+                    size="small"
+                    text
+                    severity="secondary"
+                    @click="openEditHighlight(h)"
+                  />
+                  <Button
+                    label="Delete"
+                    size="small"
+                    text
+                    severity="danger"
+                    :loading="deletingHighlightId === h.id"
+                    @click="deleteHighlight(h)"
+                  />
+                </div>
+              </div>
+              <p class="mt-2 text-sm text-slate-700">{{ h.quote }}</p>
             </div>
           </div>
-          <div v-else class="text-xs text-slate-500">
-            Using your preferred edition for this book.
-          </div>
+          <p v-else class="text-sm text-slate-600">No highlights yet.</p>
+        </div>
+      </template>
+    </Card>
 
-          <div class="flex flex-wrap gap-2">
-            <Button
-              label="Upload image"
-              size="small"
-              :severity="coverMode === 'upload' ? 'primary' : 'secondary'"
-              @click="coverMode = 'upload'"
-            />
-            <Button
-              label="Use image URL"
-              size="small"
-              :severity="coverMode === 'url' ? 'primary' : 'secondary'"
-              @click="coverMode = 'url'"
-            />
-          </div>
+    <Dialog
+      v-model:visible="editHighlightVisible"
+      modal
+      header="Edit highlight"
+      :style="{ width: '36rem' }"
+    >
+      <div class="flex flex-col gap-3">
+        <Select
+          v-model="editHighlightVisibility"
+          :options="visibilityOptions"
+          option-label="label"
+          option-value="value"
+        />
+        <InputText v-model="editHighlightLocationSort" placeholder="Location (optional)" />
+        <Textarea v-model="editHighlightQuote" rows="6" auto-resize />
+        <div class="flex justify-end gap-2">
+          <Button label="Cancel" severity="secondary" text @click="editHighlightVisible = false" />
+          <Button label="Save" :loading="savingHighlight" @click="saveEditHighlight" />
+        </div>
+      </div>
+    </Dialog>
 
-          <div v-if="coverMode === 'upload'" class="flex flex-col gap-3">
-            <input type="file" accept="image/*" @change="onCoverFileChange" />
-            <div class="flex justify-end gap-2">
-              <Button
-                label="Cancel"
-                severity="secondary"
-                text
-                @click="coverDialogVisible = false"
-              />
-              <Button label="Upload" :loading="coverBusy" @click="uploadCover" />
-            </div>
-          </div>
+    <Dialog
+      v-model:visible="coverDialogVisible"
+      modal
+      header="Set cover"
+      :style="{ width: '44rem' }"
+    >
+      <div class="flex flex-col gap-4">
+        <p v-if="coverError" class="rounded-md bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {{ coverError }}
+        </p>
 
-          <div v-else class="flex flex-col gap-3">
-            <InputText v-model="coverSourceUrl" placeholder="https://covers.openlibrary.org/..." />
-            <div class="flex justify-end gap-2">
-              <Button
-                label="Cancel"
-                severity="secondary"
-                text
-                @click="coverDialogVisible = false"
-              />
-              <Button label="Cache from URL" :loading="coverBusy" @click="cacheCover" />
-            </div>
+        <div v-if="needsEditionSelection" class="grid gap-3 md:grid-cols-2">
+          <Select
+            v-model="selectedEditionId"
+            :options="editionOptions"
+            option-label="label"
+            option-value="value"
+            :disabled="editionsLoading"
+          />
+          <div class="flex items-center gap-2">
+            <input id="preferred" v-model="setPreferredEdition" type="checkbox" />
+            <label class="text-sm text-slate-700" for="preferred">Set as preferred edition</label>
           </div>
         </div>
-      </Dialog>
+        <div v-else class="text-xs text-slate-500">Using your preferred edition for this book.</div>
 
-      <Card class="shadow-sm">
-        <template #title>
-          <div class="flex items-center gap-3 text-lg font-semibold">
-            <i class="pi pi-star text-emerald-600" aria-hidden="true"></i>
-            <span>Your review</span>
+        <div class="flex flex-wrap gap-2">
+          <Button
+            label="Upload image"
+            size="small"
+            :severity="coverMode === 'upload' ? 'primary' : 'secondary'"
+            @click="coverMode = 'upload'"
+          />
+          <Button
+            label="Use image URL"
+            size="small"
+            :severity="coverMode === 'url' ? 'primary' : 'secondary'"
+            @click="coverMode = 'url'"
+          />
+        </div>
+
+        <div v-if="coverMode === 'upload'" class="flex flex-col gap-3">
+          <input type="file" accept="image/*" @change="onCoverFileChange" />
+          <div class="flex justify-end gap-2">
+            <Button label="Cancel" severity="secondary" text @click="coverDialogVisible = false" />
+            <Button label="Upload" :loading="coverBusy" @click="uploadCover" />
           </div>
-        </template>
-        <template #content>
-          <div class="flex flex-col gap-4">
-            <div class="grid gap-3 md:grid-cols-3">
-              <Select
-                v-model="reviewVisibility"
-                :options="visibilityOptions"
-                option-label="label"
-                option-value="value"
+        </div>
+
+        <div v-else class="flex flex-col gap-3">
+          <InputText v-model="coverSourceUrl" placeholder="https://covers.openlibrary.org/..." />
+          <div class="flex justify-end gap-2">
+            <Button label="Cancel" severity="secondary" text @click="coverDialogVisible = false" />
+            <Button label="Cache from URL" :loading="coverBusy" @click="cacheCover" />
+          </div>
+        </div>
+      </div>
+    </Dialog>
+
+    <Card v-if="libraryItem" class="shadow-sm">
+      <template #title>
+        <div class="flex items-center gap-3 text-lg font-semibold">
+          <i class="pi pi-star text-emerald-600" aria-hidden="true"></i>
+          <span>Your review</span>
+        </div>
+      </template>
+      <template #content>
+        <div class="flex flex-col gap-4">
+          <div v-if="reviewError" class="flex flex-col gap-2">
+            <InlineAlert tone="error" :message="reviewError" />
+            <div>
+              <Button
+                label="Retry"
+                size="small"
+                severity="secondary"
+                data-test="review-retry"
+                @click="loadReview"
               />
-              <Select
-                v-model="reviewRating"
-                :options="ratingOptions"
-                option-label="label"
-                option-value="value"
-              />
-              <Button label="Save review" :loading="savingReview" @click="saveReview" />
             </div>
-            <InputText v-model="reviewTitle" placeholder="Title (optional)" />
-            <Textarea
-              v-model="reviewBody"
-              rows="5"
-              auto-resize
-              placeholder="Write your review..."
-            />
           </div>
-        </template>
-      </Card>
-    </section>
-  </div>
+          <div v-else-if="reviewLoading" class="text-sm text-slate-600">Loading review...</div>
+
+          <div class="grid gap-3 md:grid-cols-3">
+            <Select
+              v-model="reviewVisibility"
+              :options="visibilityOptions"
+              option-label="label"
+              option-value="value"
+            />
+            <Select
+              v-model="reviewRating"
+              :options="ratingOptions"
+              option-label="label"
+              option-value="value"
+            />
+            <Button label="Save review" :loading="savingReview" @click="saveReview" />
+          </div>
+          <InputText v-model="reviewTitle" placeholder="Title (optional)" />
+          <Textarea v-model="reviewBody" rows="5" auto-resize placeholder="Write your review..." />
+        </div>
+      </template>
+    </Card>
+  </PageShell>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from '#imports';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
@@ -419,6 +442,8 @@ import InputText from 'primevue/inputtext';
 import Select from 'primevue/select';
 import Textarea from 'primevue/textarea';
 import { ApiClientError, apiRequest } from '~/utils/api';
+import InlineAlert from '~/components/InlineAlert.vue';
+import PageShell from '~/components/PageShell.vue';
 
 type WorkDetail = {
   id: string;
@@ -463,7 +488,7 @@ type Highlight = {
 const route = useRoute();
 const workId = computed(() => String(route.params.workId || ''));
 
-const loading = ref(true);
+const coreLoading = ref(true);
 const error = ref('');
 
 const work = ref<WorkDetail | null>(null);
@@ -471,6 +496,15 @@ const libraryItem = ref<LibraryItem | null>(null);
 const sessions = ref<ReadingSession[]>([]);
 const notes = ref<Note[]>([]);
 const highlights = ref<Highlight[]>([]);
+
+const sessionsLoading = ref(false);
+const sessionsError = ref('');
+const notesLoading = ref(false);
+const notesError = ref('');
+const highlightsLoading = ref(false);
+const highlightsError = ref('');
+const reviewLoading = ref(false);
+const reviewError = ref('');
 
 const savingSession = ref(false);
 const sessionPagesRead = ref('');
@@ -519,6 +553,8 @@ const editions = ref<any[]>([]);
 const selectedEditionId = ref<string>('');
 const setPreferredEdition = ref(true);
 
+const runId = ref(0);
+
 const needsEditionSelection = computed(
   () => Boolean(libraryItem.value) && !libraryItem.value?.preferred_edition_id,
 );
@@ -565,42 +601,47 @@ const formatDate = (value: string) => {
   }
 };
 
-const fetchAll = async () => {
-  loading.value = true;
+const resetSectionState = () => {
+  sessions.value = [];
+  notes.value = [];
+  highlights.value = [];
+
+  sessionsLoading.value = false;
+  sessionsError.value = '';
+  notesLoading.value = false;
+  notesError.value = '';
+  highlightsLoading.value = false;
+  highlightsError.value = '';
+  reviewLoading.value = false;
+  reviewError.value = '';
+
+  reviewTitle.value = '';
+  reviewBody.value = '';
+  reviewVisibility.value = 'private';
+  reviewRating.value = null;
+};
+
+const fetchCore = async (id: number) => {
+  coreLoading.value = true;
   error.value = '';
   try {
-    work.value = await apiRequest<WorkDetail>(`/api/v1/works/${workId.value}`);
+    resetSectionState();
+
+    const nextWork = await apiRequest<WorkDetail>(`/api/v1/works/${workId.value}`);
+    if (id !== runId.value) return;
+    work.value = nextWork;
 
     try {
-      libraryItem.value = await apiRequest<LibraryItem>(
+      const nextLibraryItem = await apiRequest<LibraryItem>(
         `/api/v1/library/items/by-work/${workId.value}`,
       );
+      if (id !== runId.value) return;
+      libraryItem.value = nextLibraryItem;
     } catch (err) {
       if (err instanceof ApiClientError && err.status === 404) {
         libraryItem.value = null;
       } else {
         throw err;
-      }
-    }
-
-    if (libraryItem.value) {
-      const itemId = libraryItem.value.id;
-      const [sessionPayload, notePayload, highlightPayload] = await Promise.all([
-        apiRequest<{ items: ReadingSession[] }>(`/api/v1/library/items/${itemId}/sessions`),
-        apiRequest<{ items: Note[] }>(`/api/v1/library/items/${itemId}/notes`),
-        apiRequest<{ items: Highlight[] }>(`/api/v1/library/items/${itemId}/highlights`),
-      ]);
-      sessions.value = sessionPayload.items;
-      notes.value = notePayload.items;
-      highlights.value = highlightPayload.items;
-
-      const myReviews = await apiRequest<{ items: any[] }>('/api/v1/me/reviews');
-      const existing = myReviews.items.find((r) => r.work_id === workId.value) || null;
-      if (existing) {
-        reviewTitle.value = existing.title || '';
-        reviewBody.value = existing.body || '';
-        reviewVisibility.value = existing.visibility;
-        reviewRating.value = existing.rating ?? null;
       }
     }
   } catch (err) {
@@ -610,8 +651,117 @@ const fetchAll = async () => {
       error.value = 'Unable to load book details right now.';
     }
   } finally {
-    loading.value = false;
+    if (id === runId.value) {
+      coreLoading.value = false;
+    }
   }
+};
+
+const loadSessions = async () => {
+  if (!libraryItem.value) return;
+  const id = runId.value;
+  sessionsLoading.value = true;
+  sessionsError.value = '';
+  try {
+    const payload = await apiRequest<{ items: ReadingSession[] }>(
+      `/api/v1/library/items/${libraryItem.value.id}/sessions`,
+    );
+    if (id !== runId.value) return;
+    sessions.value = payload.items;
+  } catch (err) {
+    if (id !== runId.value) return;
+    sessionsError.value = err instanceof ApiClientError ? err.message : 'Unable to load sessions.';
+  } finally {
+    if (id === runId.value) {
+      sessionsLoading.value = false;
+    }
+  }
+};
+
+const loadNotes = async () => {
+  if (!libraryItem.value) return;
+  const id = runId.value;
+  notesLoading.value = true;
+  notesError.value = '';
+  try {
+    const payload = await apiRequest<{ items: Note[] }>(
+      `/api/v1/library/items/${libraryItem.value.id}/notes`,
+    );
+    if (id !== runId.value) return;
+    notes.value = payload.items;
+  } catch (err) {
+    if (id !== runId.value) return;
+    notesError.value = err instanceof ApiClientError ? err.message : 'Unable to load notes.';
+  } finally {
+    if (id === runId.value) {
+      notesLoading.value = false;
+    }
+  }
+};
+
+const loadHighlights = async () => {
+  if (!libraryItem.value) return;
+  const id = runId.value;
+  highlightsLoading.value = true;
+  highlightsError.value = '';
+  try {
+    const payload = await apiRequest<{ items: Highlight[] }>(
+      `/api/v1/library/items/${libraryItem.value.id}/highlights`,
+    );
+    if (id !== runId.value) return;
+    highlights.value = payload.items;
+  } catch (err) {
+    if (id !== runId.value) return;
+    highlightsError.value =
+      err instanceof ApiClientError ? err.message : 'Unable to load highlights.';
+  } finally {
+    if (id === runId.value) {
+      highlightsLoading.value = false;
+    }
+  }
+};
+
+const loadReview = async () => {
+  if (!libraryItem.value) return;
+  const id = runId.value;
+  reviewLoading.value = true;
+  reviewError.value = '';
+  try {
+    const myReviews = await apiRequest<{ items: any[] }>('/api/v1/me/reviews');
+    if (id !== runId.value) return;
+    const existing = myReviews.items.find((r) => r.work_id === workId.value) || null;
+    if (existing) {
+      reviewTitle.value = existing.title || '';
+      reviewBody.value = existing.body || '';
+      reviewVisibility.value = existing.visibility;
+      reviewRating.value = existing.rating ?? null;
+    } else {
+      reviewTitle.value = '';
+      reviewBody.value = '';
+      reviewVisibility.value = 'private';
+      reviewRating.value = null;
+    }
+  } catch (err) {
+    if (id !== runId.value) return;
+    reviewError.value = err instanceof ApiClientError ? err.message : 'Unable to load review.';
+  } finally {
+    if (id === runId.value) {
+      reviewLoading.value = false;
+    }
+  }
+};
+
+const refresh = async () => {
+  runId.value += 1;
+  const id = runId.value;
+  await fetchCore(id);
+  if (id !== runId.value) return;
+  if (!libraryItem.value) return;
+
+  void loadSessions();
+  void loadNotes();
+  void loadHighlights();
+  void loadReview();
 };
 
 const openCoverDialog = async () => {
@@ -734,10 +884,7 @@ const logSession = async () => {
     sessionPagesRead.value = '';
     sessionProgressPercent.value = '';
     sessionNote.value = '';
-    const payload = await apiRequest<{ items: ReadingSession[] }>(
-      `/api/v1/library/items/${libraryItem.value.id}/sessions`,
-    );
-    sessions.value = payload.items;
+    await loadSessions();
   } catch (err) {
     error.value = err instanceof ApiClientError ? err.message : 'Unable to log session.';
   } finally {
@@ -761,10 +908,7 @@ const addNote = async () => {
     });
     newNoteTitle.value = '';
     newNoteBody.value = '';
-    const payload = await apiRequest<{ items: Note[] }>(
-      `/api/v1/library/items/${libraryItem.value.id}/notes`,
-    );
-    notes.value = payload.items;
+    await loadNotes();
   } catch (err) {
     error.value = err instanceof ApiClientError ? err.message : 'Unable to add note.';
   } finally {
@@ -794,12 +938,7 @@ const saveEditNote = async () => {
       },
     });
     editNoteVisible.value = false;
-    if (libraryItem.value) {
-      const payload = await apiRequest<{ items: Note[] }>(
-        `/api/v1/library/items/${libraryItem.value.id}/notes`,
-      );
-      notes.value = payload.items;
-    }
+    await loadNotes();
   } catch (err) {
     error.value = err instanceof ApiClientError ? err.message : 'Unable to update note.';
   } finally {
@@ -837,10 +976,7 @@ const addHighlight = async () => {
     });
     newHighlightQuote.value = '';
     highlightLocationSort.value = '';
-    const payload = await apiRequest<{ items: Highlight[] }>(
-      `/api/v1/library/items/${libraryItem.value.id}/highlights`,
-    );
-    highlights.value = payload.items;
+    await loadHighlights();
   } catch (err) {
     error.value = err instanceof ApiClientError ? err.message : 'Unable to add highlight.';
   } finally {
@@ -874,12 +1010,7 @@ const saveEditHighlight = async () => {
       },
     });
     editHighlightVisible.value = false;
-    if (libraryItem.value) {
-      const payload = await apiRequest<{ items: Highlight[] }>(
-        `/api/v1/library/items/${libraryItem.value.id}/highlights`,
-      );
-      highlights.value = payload.items;
-    }
+    await loadHighlights();
   } catch (err) {
     error.value = err instanceof ApiClientError ? err.message : 'Unable to update highlight.';
   } finally {
@@ -921,6 +1052,10 @@ const saveReview = async () => {
 };
 
 onMounted(() => {
-  void fetchAll();
+  void refresh();
+});
+
+watch(workId, () => {
+  void refresh();
 });
 </script>


### PR DESCRIPTION
Implements issue #83.

- /books/{workId}: core work+library item renders first
- Sessions/notes/highlights/review load independently with per-panel errors + Retry
- Avoids blocking Promise.all on initial render; ignores stale responses on route changes
- Tests: expanded unit coverage for progressive loading and retry behavior

Note: This PR assumes #80 and #82 land first (shared history) to keep the diff small after merges.

Closes #83.