### PR TITLE
Enforce staging migrations (CI guard + runtime schema check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,27 @@ jobs:
         uses: supabase/setup-cli@v1
         with:
           version: latest
-      - name: Check required secrets
-        id: guard_secrets
+      - name: Verify required secrets are configured
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_STAGING_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
         run: |
           if [ -z "$SUPABASE_ACCESS_TOKEN" ] || [ -z "$SUPABASE_STAGING_DB_PASSWORD" ]; then
-            echo "::warning::staging-migration-guard is disabled because SUPABASE_ACCESS_TOKEN and/or SUPABASE_STAGING_DB_PASSWORD is not set in GitHub Actions secrets for this repo."
-            echo "enabled=0" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Missing required GitHub Actions secrets for staging migration guard. Set SUPABASE_ACCESS_TOKEN and SUPABASE_STAGING_DB_PASSWORD in repo settings."
+            exit 1
           fi
-          echo "enabled=1" >> "$GITHUB_OUTPUT"
       - name: Verify staging migrations are applied
-        if: steps.guard_secrets.outputs.enabled == '1'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_STAGING_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
         run: |
           supabase link --project-ref kypwcksvicrbrrwscdze --password "$SUPABASE_STAGING_DB_PASSWORD" --yes
-          supabase db push --dry-run --password "$SUPABASE_STAGING_DB_PASSWORD" --linked --yes
+          output="$(supabase db push --dry-run --password "$SUPABASE_STAGING_DB_PASSWORD" --linked --yes)"
+          printf '%s\n' "$output"
+          if printf '%s\n' "$output" | grep -q "Would push these migrations:"; then
+            echo "::error::Staging database has pending migrations. Apply migrations (supabase db push) before merging/deploying API changes."
+            exit 1
+          fi
 
   api:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   staging-migration-guard:
     runs-on: ubuntu-latest
+    environment: staging
     # Secrets are unavailable on forked PRs; skip in that case.
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'development' && github.event.pull_request.head.repo.fork == false
     steps:
@@ -27,7 +28,7 @@ jobs:
           SUPABASE_STAGING_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
         run: |
           if [ -z "$SUPABASE_ACCESS_TOKEN" ] || [ -z "$SUPABASE_STAGING_DB_PASSWORD" ]; then
-            echo "::error::Missing required GitHub Actions secrets for staging migration guard. Set SUPABASE_ACCESS_TOKEN and SUPABASE_STAGING_DB_PASSWORD in repo settings."
+            echo "::error::Missing required GitHub Actions secrets for staging migration guard. Set SUPABASE_ACCESS_TOKEN and SUPABASE_STAGING_DB_PASSWORD in the 'staging' GitHub Environment (or as repository secrets)."
             exit 1
           fi
       - name: Verify staging migrations are applied

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - development
       - main
+  pull_request_target:
+    branches:
+      - development
+      - main
   push:
     branches:
       - main
@@ -14,10 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     # Secrets are unavailable on forked PRs; skip in that case.
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'development' && github.event.pull_request.head.repo.fork == false
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'development' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # With pull_request_target, checkout defaults to the base branch; we need the PR's content
+          # (specifically supabase/migrations) to detect drift against staging.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -46,6 +55,7 @@ jobs:
 
   api:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_target'
     defaults:
       run:
         working-directory: apps/api
@@ -101,6 +111,7 @@ jobs:
 
   web:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_target'
     defaults:
       run:
         working-directory: apps/web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - development
       - main
-  pull_request_target:
-    branches:
-      - development
-      - main
   push:
     branches:
       - main
@@ -18,15 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     # Secrets are unavailable on forked PRs; skip in that case.
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'development' && github.event.pull_request.head.repo.fork == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'development' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # With pull_request_target, checkout defaults to the base branch; we need the PR's content
-          # (specifically supabase/migrations) to detect drift against staging.
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -37,7 +28,7 @@ jobs:
           SUPABASE_STAGING_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
         run: |
           if [ -z "$SUPABASE_ACCESS_TOKEN" ] || [ -z "$SUPABASE_STAGING_DB_PASSWORD" ]; then
-            echo "::error::Missing required GitHub Actions secrets for staging migration guard. Set SUPABASE_ACCESS_TOKEN and SUPABASE_STAGING_DB_PASSWORD in the 'staging' GitHub Environment (or as repository secrets)."
+            echo "::error::Missing required GitHub Actions secrets for staging migration guard. Set SUPABASE_ACCESS_TOKEN and SUPABASE_STAGING_DB_PASSWORD as repository secrets (Environment secrets may not be available to pull_request workflows)."
             exit 1
           fi
       - name: Verify staging migrations are applied
@@ -55,7 +46,6 @@ jobs:
 
   api:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     defaults:
       run:
         working-directory: apps/api
@@ -111,7 +101,6 @@ jobs:
 
   web:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     defaults:
       run:
         working-directory: apps/web

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 
 # macOS
 .DS_Store
+
+# Local worktree helper dirs (should never be committed)
+.worktrees/

--- a/apps/api/app/core/schema_guard.py
+++ b/apps/api/app/core/schema_guard.py
@@ -25,6 +25,13 @@ _REQUIRED_COLUMNS: tuple[tuple[str, str], ...] = (
     ("highlights", "ap_uri"),
     ("reviews", "ap_uri"),
     ("users", "actor_uri"),
+    # Cover provenance columns: if these aren't present, basic work fetches can 500.
+    ("editions", "cover_set_by"),
+    ("editions", "cover_set_at"),
+    ("editions", "cover_storage_path"),
+    ("works", "default_cover_set_by"),
+    ("works", "default_cover_set_at"),
+    ("works", "default_cover_storage_path"),
 )
 
 

--- a/apps/api/tests/test_schema_guard.py
+++ b/apps/api/tests/test_schema_guard.py
@@ -64,6 +64,7 @@ def test_schema_guard_raises_with_actionable_message(
     assert "Missing requirements" in message
     assert "content_visibility" in message
     assert "public.notes.ap_uri" in message
+    assert "public.works.default_cover_set_by" in message
 
 
 def test_schema_guard_passes_when_schema_is_present(


### PR DESCRIPTION
Stops staging breakages caused by API deploying ahead of Supabase migrations.

Changes:
- CI: add strict staging-migration-guard job that fails if staging has pending Supabase migrations (parses `supabase db push --dry-run` output) and fails if required secrets are missing.
- API: extend runtime schema guard required columns to include cover provenance fields that previously caused book detail 500s.
- Repo hygiene: ignore local .worktrees/ helper dir.

Fixes/implements: #81 (and prevents recurrence of the works.default_cover_set_by missing-column outage).
