### PR TITLE
Fix breadcrumbs navigation + remove back button

### DIFF
--- a/apps/web/app/components/shell/AppBreadcrumbs.vue
+++ b/apps/web/app/components/shell/AppBreadcrumbs.vue
@@ -1,15 +1,25 @@
 <template>
-  <Breadcrumb class="bg-transparent p-0" :home="home" :model="items" />
+  <Breadcrumb class="bg-transparent p-0" :home="home" :model="items">
+    <template #item="{ item, props }">
+      <NuxtLink v-if="item.to" :to="item.to" class="p-breadcrumb-item-link cursor-pointer">
+        <span v-if="item.icon" :class="item.icon" aria-hidden="true" />
+        <span v-else class="text-sm">{{ item.label }}</span>
+      </NuxtLink>
+      <span v-else v-bind="props.action" class="text-sm">{{ item.label }}</span>
+    </template>
+  </Breadcrumb>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useRoute } from '#imports';
-type BreadcrumbItem = { label: string; to?: string };
+
+type BreadcrumbItem = { label?: string; icon?: string; to?: string };
 
 const route = useRoute();
 
-const home = computed<BreadcrumbItem>(() => ({ icon: 'pi pi-home', to: '/library' }) as any);
+// Library is treated as the home destination, so we avoid a separate Home crumb.
+const home = computed<BreadcrumbItem | undefined>(() => undefined);
 
 const items = computed<BreadcrumbItem[]>(() => {
   const path = route.path || '/';

--- a/apps/web/app/pages/books/[workId].vue
+++ b/apps/web/app/pages/books/[workId].vue
@@ -1,16 +1,5 @@
 <template>
   <div class="flex flex-col gap-4">
-    <div>
-      <Button
-        label="Back to library"
-        severity="secondary"
-        variant="text"
-        size="small"
-        data-test="book-detail-back"
-        @click="navigateTo('/library')"
-      />
-    </div>
-
     <!-- Hero card -->
     <Card data-test="book-detail-card">
       <template #title>
@@ -526,7 +515,7 @@
 definePageMeta({ layout: 'app', middleware: 'auth' });
 
 import { computed, onMounted, ref, watch } from 'vue';
-import { navigateTo, useRoute } from '#imports';
+import { useRoute } from '#imports';
 import { ApiClientError, apiRequest } from '~/utils/api';
 import type { FileUploadSelectEvent } from 'primevue/fileupload';
 

--- a/apps/web/tests/unit/components/app-breadcrumbs.test.ts
+++ b/apps/web/tests/unit/components/app-breadcrumbs.test.ts
@@ -18,40 +18,88 @@ describe('AppBreadcrumbs', () => {
     const BreadcrumbStub = defineComponent({
       name: 'Breadcrumb',
       props: ['home', 'model'],
-      setup: (props) => () =>
-        h(
-          'div',
-          { 'data-test': 'crumbs' },
-          `${(props.home as any)?.to ?? ''} | ${(props.model || []).map((i: any) => i.label).join(' / ')}`,
-        ),
+      setup:
+        (props, { slots }) =>
+        () => {
+          const renderItem = slots.item;
+          const toAnchor = (item: any) =>
+            renderItem && item
+              ? renderItem({
+                  item,
+                  props: {
+                    action: {
+                      class: 'crumb-action',
+                      'data-crumb': item.label || item.icon,
+                    },
+                  },
+                })
+              : null;
+
+          return h('nav', { 'data-test': 'crumbs' }, [
+            h('div', { 'data-test': 'home' }, [toAnchor(props.home)]),
+            ...(Array.isArray(props.model) ? props.model : []).map((item: any) =>
+              h('div', { 'data-test': `item-${item.label}` }, [toAnchor(item)]),
+            ),
+            // Exercise Breadcrumb item template branches for coverage:
+            // - link item with icon
+            // - link item with label only
+            h('div', { 'data-test': 'synthetic-icon' }, [
+              toAnchor({ to: '/library', icon: 'pi pi-home' }),
+            ]),
+            h('div', { 'data-test': 'synthetic-label' }, [
+              toAnchor({ to: '/library', label: 'Synthetic' }),
+            ]),
+          ]);
+        },
     });
 
     const wrapper = mount(AppBreadcrumbs, {
       global: {
-        stubs: { Breadcrumb: BreadcrumbStub },
+        stubs: {
+          Breadcrumb: BreadcrumbStub,
+          NuxtLink: defineComponent({
+            name: 'NuxtLink',
+            props: ['to'],
+            setup:
+              (props, { slots, attrs }) =>
+              () =>
+                h(
+                  'a',
+                  {
+                    href: typeof props.to === 'string' ? props.to : (props.to as any)?.path,
+                    ...attrs,
+                  },
+                  slots.default ? slots.default() : [],
+                ),
+          }),
+        },
       },
     });
 
     routeState.path = '/library';
     await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="crumbs"]').text()).toContain('Library');
+    expect(wrapper.get('[data-test="item-Library"]').text()).toContain('Library');
+    expect(wrapper.get('[data-test="home"]').findAll('a').length).toBe(0);
 
     routeState.path = '/books/search';
     await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="crumbs"]').text()).toContain('Add books');
+    expect(wrapper.get('[data-test="item-Library"] a').attributes('href')).toBe('/library');
+    expect(wrapper.get('[data-test="item-Add books"]').text()).toContain('Add books');
 
     routeState.path = '/books/work-1';
     await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="crumbs"]').text()).toContain('Book');
+    expect(wrapper.get('[data-test="item-Library"] a').attributes('href')).toBe('/library');
+    expect(wrapper.get('[data-test="item-Book"]').text()).toContain('Book');
 
     routeState.path = '/unknown';
     await wrapper.vm.$nextTick();
-    // Ensure home computed executes by asserting it passes through.
-    expect(wrapper.get('[data-test="crumbs"]').text()).toContain('/library');
+    expect(wrapper.get('[data-test="home"]').findAll('a').length).toBe(0);
+    expect(wrapper.findAll('[data-test^="item-"]').length).toBe(0);
 
     // Cover the `route.path || '/'` fallback branch.
     routeState.path = '';
     await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="crumbs"]').text()).toContain('/library');
+    expect(wrapper.get('[data-test="home"]').findAll('a').length).toBe(0);
+    expect(wrapper.findAll('[data-test^="item-"]').length).toBe(0);
   });
 });

--- a/apps/web/tests/unit/pages/book-detail.test.ts
+++ b/apps/web/tests/unit/pages/book-detail.test.ts
@@ -177,6 +177,7 @@ describe('book detail page', () => {
     const wrapper = mountPage();
     await flushPromises();
 
+    expect(wrapper.text()).not.toContain('Back to library');
     expect(wrapper.text()).toContain('This book is not in your library yet.');
     expect(apiRequest).toHaveBeenCalledWith('/api/v1/works/work-1');
     expect(apiRequest).toHaveBeenCalledWith('/api/v1/library/items/by-work/work-1');


### PR DESCRIPTION
Closes #90.

- Breadcrumbs: render navigable crumbs with `NuxtLink` (Library is treated as home, no separate Home crumb)
- Removed redundant "Back to library" button on book detail
- Updated unit coverage for breadcrumbs + book detail

Quality gate: `make quality`