### PR TITLE
Format read status labels + fix library filter row overflow

### DIFF
--- a/apps/web/app/pages/books/[workId].vue
+++ b/apps/web/app/pages/books/[workId].vue
@@ -21,7 +21,11 @@
               {{ work?.title || 'Book detail' }}
             </span>
           </div>
-          <Tag v-if="libraryItem" :value="libraryItem.status" severity="secondary" />
+          <Tag
+            v-if="libraryItem"
+            :value="libraryStatusLabel(libraryItem.status)"
+            severity="secondary"
+          />
         </div>
       </template>
       <template #content>
@@ -528,6 +532,7 @@ definePageMeta({ layout: 'app', middleware: 'auth' });
 import { computed, onMounted, ref, watch } from 'vue';
 import { navigateTo, useRoute } from '#imports';
 import { ApiClientError, apiRequest } from '~/utils/api';
+import { libraryStatusLabel } from '~/utils/libraryStatus';
 import type { FileUploadSelectEvent } from 'primevue/fileupload';
 
 type WorkDetail = {

--- a/apps/web/app/pages/library/index.vue
+++ b/apps/web/app/pages/library/index.vue
@@ -20,18 +20,20 @@
       <div class="flex flex-col gap-4">
         <Card>
           <template #content>
-            <div class="grid w-full gap-3 md:grid-cols-[240px_220px_220px]">
+            <div class="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               <Select
                 v-model="statusFilter"
                 :options="statusFilters"
                 option-label="label"
                 option-value="value"
                 data-test="library-status-filter"
+                class="min-w-0 w-full"
               />
               <InputText
                 v-model="tagFilter"
                 placeholder="Filter by tag"
                 data-test="library-tag-filter"
+                class="min-w-0 w-full"
               />
               <Select
                 v-model="sortMode"
@@ -39,6 +41,7 @@
                 option-label="label"
                 option-value="value"
                 data-test="library-sort-select"
+                class="min-w-0 w-full"
               />
             </div>
           </template>
@@ -108,7 +111,7 @@
                       {{ item.author_names.join(', ') }}
                     </p>
                     <div class="mt-3 flex flex-wrap items-center gap-2">
-                      <Tag :value="statusLabel(item.status)" severity="secondary" />
+                      <Tag :value="libraryStatusLabel(item.status)" severity="secondary" />
                       <Tag
                         v-for="tag in (item.tags || []).slice(0, 3)"
                         :key="tag"
@@ -158,6 +161,7 @@ definePageMeta({ layout: 'app', middleware: 'auth' });
 
 import { computed, onMounted, ref, watch } from 'vue';
 import { ApiClientError, apiRequest } from '~/utils/api';
+import { libraryStatusLabel } from '~/utils/libraryStatus';
 import EmptyState from '~/components/EmptyState.vue';
 
 type LibraryItem = {
@@ -213,16 +217,6 @@ const displayItems = computed(() => {
   }
   return sorted;
 });
-
-const statusLabel = (value: string): string => {
-  const map: Record<string, string> = {
-    to_read: 'To read',
-    reading: 'Reading',
-    completed: 'Completed',
-    abandoned: 'Abandoned',
-  };
-  return map[value] || value;
-};
 
 const fetchPage = async (append = false) => {
   error.value = '';

--- a/apps/web/app/utils/libraryStatus.ts
+++ b/apps/web/app/utils/libraryStatus.ts
@@ -1,0 +1,18 @@
+const KNOWN_STATUS_LABELS: Record<string, string> = {
+  to_read: 'To read',
+  reading: 'Reading',
+  completed: 'Completed',
+  abandoned: 'Abandoned',
+};
+
+const titleCaseFromSnake = (value: string): string =>
+  value
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ');
+
+export const libraryStatusLabel = (status: string): string => {
+  if (!status) return '';
+  return KNOWN_STATUS_LABELS[status] ?? titleCaseFromSnake(status);
+};

--- a/apps/web/tests/unit/pages/book-detail.test.ts
+++ b/apps/web/tests/unit/pages/book-detail.test.ts
@@ -298,6 +298,7 @@ describe('book detail page', () => {
     // Initial render exercises not-loaded -> loaded states and seeded review.
     expect(wrapper.text()).toContain('Book A');
     expect(wrapper.text()).toContain('Author A');
+    expect(wrapper.text()).toContain('Reading');
     expect(wrapper.text()).toContain('No sessions yet.');
     expect(wrapper.text()).toContain('No notes yet.');
     expect(wrapper.text()).toContain('No highlights yet.');

--- a/apps/web/tests/unit/utils/libraryStatus.test.ts
+++ b/apps/web/tests/unit/utils/libraryStatus.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { libraryStatusLabel } from '../../../app/utils/libraryStatus';
+
+describe('libraryStatusLabel', () => {
+  it('formats known statuses', () => {
+    expect(libraryStatusLabel('to_read')).toBe('To read');
+    expect(libraryStatusLabel('reading')).toBe('Reading');
+    expect(libraryStatusLabel('completed')).toBe('Completed');
+    expect(libraryStatusLabel('abandoned')).toBe('Abandoned');
+  });
+
+  it('falls back to a reasonable title case for unknown snake_case', () => {
+    expect(libraryStatusLabel('in_progress')).toBe('In Progress');
+    expect(libraryStatusLabel('two__words')).toBe('Two Words');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(libraryStatusLabel('')).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #91.

- Centralize library status label formatting in `libraryStatusLabel()`
- Use formatted labels on Library and Book Detail pages
- Add unit coverage for util + ensure book detail shows human-readable label
- Fix Library filter/sort row so Selects do not overflow on narrow widths

Quality gate: `make quality`