### PR TITLE
Issue #92: Show 'No cover' placeholder

### DIFF
--- a/apps/web/app/components/CoverPlaceholder.vue
+++ b/apps/web/app/components/CoverPlaceholder.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue';
+
+defineOptions({ inheritAttrs: false });
+
+const attrs = useAttrs();
+
+const dataTest = computed(() => (attrs['data-test'] as string | undefined) ?? 'cover-placeholder');
+const passthroughAttrs = computed(() => {
+  const rest = { ...(attrs as Record<string, unknown>) };
+  delete rest['data-test'];
+  return rest;
+});
+</script>
+
+<template>
+  <div
+    v-bind="passthroughAttrs"
+    class="flex h-full w-full flex-col items-center justify-center gap-1 text-[var(--p-text-muted-color)]"
+    role="img"
+    aria-label="No cover"
+    :data-test="dataTest"
+  >
+    <i class="pi pi-book text-lg" aria-hidden="true"></i>
+    <span class="text-xs font-medium">No cover</span>
+  </div>
+</template>

--- a/apps/web/app/pages/books/[workId].vue
+++ b/apps/web/app/pages/books/[workId].vue
@@ -48,12 +48,7 @@
                   image-class="h-full w-full object-cover"
                   data-test="book-detail-cover-image"
                 />
-                <Skeleton
-                  v-else
-                  class="h-full w-full"
-                  borderRadius="0.75rem"
-                  data-test="book-detail-cover-skeleton"
-                />
+                <CoverPlaceholder v-else data-test="book-detail-cover-placeholder" />
               </div>
 
               <div v-if="libraryItem" class="flex flex-wrap items-center gap-2">
@@ -522,6 +517,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from '#imports';
 import { ApiClientError, apiRequest } from '~/utils/api';
 import { libraryStatusLabel } from '~/utils/libraryStatus';
+import CoverPlaceholder from '~/components/CoverPlaceholder.vue';
 import type { FileUploadSelectEvent } from 'primevue/fileupload';
 
 type WorkDetail = {

--- a/apps/web/app/pages/library/index.vue
+++ b/apps/web/app/pages/library/index.vue
@@ -92,12 +92,7 @@
                       image-class="h-full w-full object-cover"
                       data-test="library-item-cover"
                     />
-                    <Skeleton
-                      v-else
-                      class="h-full w-full"
-                      borderRadius="0.5rem"
-                      data-test="library-item-cover-skeleton"
-                    />
+                    <CoverPlaceholder v-else data-test="library-item-cover-placeholder" />
                   </div>
 
                   <div class="min-w-0 pt-1">
@@ -162,6 +157,7 @@ definePageMeta({ layout: 'app', middleware: 'auth' });
 import { computed, onMounted, ref, watch } from 'vue';
 import { ApiClientError, apiRequest } from '~/utils/api';
 import { libraryStatusLabel } from '~/utils/libraryStatus';
+import CoverPlaceholder from '~/components/CoverPlaceholder.vue';
 import EmptyState from '~/components/EmptyState.vue';
 
 type LibraryItem = {

--- a/apps/web/tests/unit/components/cover-placeholder.test.ts
+++ b/apps/web/tests/unit/components/cover-placeholder.test.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import CoverPlaceholder from '../../../app/components/CoverPlaceholder.vue';
+
+describe('CoverPlaceholder', () => {
+  it('defaults data-test when not provided', () => {
+    const wrapper = mount(CoverPlaceholder);
+    expect(wrapper.attributes('data-test')).toBe('cover-placeholder');
+  });
+
+  it('uses provided data-test and passes other attrs through', () => {
+    const wrapper = mount(CoverPlaceholder, { attrs: { 'data-test': 'custom', id: 'x' } });
+    expect(wrapper.attributes('data-test')).toBe('custom');
+    expect(wrapper.attributes('id')).toBe('x');
+  });
+});

--- a/apps/web/tests/unit/pages/book-detail.test.ts
+++ b/apps/web/tests/unit/pages/book-detail.test.ts
@@ -179,6 +179,8 @@ describe('book detail page', () => {
 
     expect(wrapper.text()).not.toContain('Back to library');
     expect(wrapper.text()).toContain('This book is not in your library yet.');
+    // When a book has no cover, show an explicit placeholder (not a skeleton).
+    expect(wrapper.findAll('[data-test="book-detail-cover-placeholder"]').length).toBe(1);
     expect(apiRequest).toHaveBeenCalledWith('/api/v1/works/work-1');
     expect(apiRequest).toHaveBeenCalledWith('/api/v1/library/items/by-work/work-1');
   });

--- a/apps/web/tests/unit/pages/library.test.ts
+++ b/apps/web/tests/unit/pages/library.test.ts
@@ -144,7 +144,9 @@ describe('library page', () => {
       query: { limit: 10, cursor: 'cursor-1', status: undefined },
     });
     expect(wrapper.text()).toContain('Book B');
-    expect(wrapper.findAll('[data-test="library-item-cover-skeleton"]').length).toBeGreaterThan(0);
+    expect(wrapper.findAll('[data-test="library-item-cover-placeholder"]').length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('shows empty state when no items are returned', async () => {


### PR DESCRIPTION
Implements #92.

- Adds `CoverPlaceholder` component
- Uses placeholder in loaded state when `cover_url` is missing (Library + Book Detail)
- Updates/extends unit tests

`make quality` passes locally.
