### PR TITLE
Issue #93: cover selection + per-user cover overrides

### DIFF
--- a/apps/api/alembic/versions/0009_library_item_cover_overrides.py
+++ b/apps/api/alembic/versions/0009_library_item_cover_overrides.py
@@ -1,0 +1,58 @@
+"""Add per-user cover override columns to library_items.
+
+Revision ID: 0009_library_item_cover_overrides
+Revises: 0008_cover_provenance
+Create Date: 2026-02-10 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0009_library_item_cover_overrides"
+down_revision = "0008_cover_provenance"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # CI starts Supabase (which applies supabase/migrations) and then runs Alembic.
+    # Make this migration safe when the columns were already created by Supabase SQL.
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    cols = {c["name"] for c in insp.get_columns("library_items")}
+
+    if "cover_override_url" not in cols:
+        op.add_column("library_items", sa.Column("cover_override_url", sa.Text))
+    if "cover_override_storage_path" not in cols:
+        op.add_column(
+            "library_items", sa.Column("cover_override_storage_path", sa.Text)
+        )
+    if "cover_override_set_by" not in cols:
+        op.add_column(
+            "library_items", sa.Column("cover_override_set_by", sa.UUID(as_uuid=True))
+        )
+    if "cover_override_set_at" not in cols:
+        op.add_column(
+            "library_items",
+            sa.Column("cover_override_set_at", sa.DateTime(timezone=True)),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    cols = {c["name"] for c in insp.get_columns("library_items")}
+
+    if "cover_override_set_at" in cols:
+        op.drop_column("library_items", "cover_override_set_at")
+    if "cover_override_set_by" in cols:
+        op.drop_column("library_items", "cover_override_set_by")
+    if "cover_override_storage_path" in cols:
+        op.drop_column("library_items", "cover_override_storage_path")
+    if "cover_override_url" in cols:
+        op.drop_column("library_items", "cover_override_url")

--- a/apps/api/alembic/versions/0009_library_item_cover_overrides.py
+++ b/apps/api/alembic/versions/0009_library_item_cover_overrides.py
@@ -1,6 +1,6 @@
 """Add per-user cover override columns to library_items.
 
-Revision ID: 0009_library_item_cover_overrides
+Revision ID: 0009_cover_overrides
 Revises: 0008_cover_provenance
 Create Date: 2026-02-10 00:00:00
 """
@@ -11,7 +11,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision = "0009_library_item_cover_overrides"
+# Alembic's default alembic_version.version_num is VARCHAR(32); keep revision <= 32 chars.
+revision = "0009_cover_overrides"
 down_revision = "0008_cover_provenance"
 branch_labels = None
 depends_on = None

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -103,6 +103,14 @@ class LibraryItem(Base):
     )
     rating: Mapped[int | None] = mapped_column(sa.SmallInteger)
     tags: Mapped[list[str] | None] = mapped_column(ARRAY(sa.String(64)))
+    cover_override_url: Mapped[str | None] = mapped_column(sa.Text)
+    cover_override_storage_path: Mapped[str | None] = mapped_column(sa.Text)
+    cover_override_set_by: Mapped[uuid.UUID | None] = mapped_column(
+        sa.UUID(as_uuid=True)
+    )
+    cover_override_set_at: Mapped[dt.datetime | None] = mapped_column(
+        sa.DateTime(timezone=True)
+    )
     created_at: Mapped[dt.datetime] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=False,

--- a/apps/api/app/routers/library.py
+++ b/apps/api/app/routers/library.py
@@ -14,7 +14,7 @@ from app.db.session import get_db_session
 from app.services.user_library import (
     create_or_get_library_item,
     delete_library_item,
-    get_library_item_by_work,
+    get_library_item_by_work_detail,
     list_library_items,
     update_library_item,
 )
@@ -161,20 +161,9 @@ def get_item_by_work(
     auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
-    item = get_library_item_by_work(session, user_id=auth.user_id, work_id=work_id)
-    if item is None:
-        raise HTTPException(status_code=404, detail="library item not found")
-    return ok(
-        {
-            "id": str(item.id),
-            "work_id": str(item.work_id),
-            "preferred_edition_id": (
-                str(item.preferred_edition_id) if item.preferred_edition_id else None
-            ),
-            "status": item.status,
-            "visibility": item.visibility,
-            "rating": item.rating,
-            "tags": item.tags or [],
-            "created_at": item.created_at.isoformat(),
-        }
+    detail = get_library_item_by_work_detail(
+        session, user_id=auth.user_id, work_id=work_id
     )
+    if detail is None:
+        raise HTTPException(status_code=404, detail="library item not found")
+    return ok(detail)

--- a/apps/api/app/routers/works.py
+++ b/apps/api/app/routers/works.py
@@ -3,15 +3,27 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from app.core.config import Settings, get_settings
 from app.core.responses import ok
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
+from app.services.open_library import OpenLibraryClient
+from app.services.work_covers import (
+    list_openlibrary_cover_candidates,
+    select_openlibrary_cover,
+)
 from app.services.works import get_work_detail, list_work_editions
 
 router = APIRouter(tags=["works"])
+
+
+def get_open_library_client() -> OpenLibraryClient:
+    return OpenLibraryClient()
 
 
 @router.get("/api/v1/works/{work_id}")
@@ -38,3 +50,63 @@ def list_editions(
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return ok({"items": items})
+
+
+@router.get("/api/v1/works/{work_id}/covers")
+async def list_work_covers(
+    work_id: uuid.UUID,
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+) -> dict[str, object]:
+    try:
+        items = await list_openlibrary_cover_candidates(
+            session, work_id=work_id, open_library=open_library
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "open_library_unavailable",
+                "message": "Open Library is unavailable. Please try again shortly.",
+            },
+        ) from exc
+    return ok({"items": items})
+
+
+class SelectCoverRequest(BaseModel):
+    cover_id: int = Field(ge=1)
+
+
+@router.post("/api/v1/works/{work_id}/covers/select")
+async def select_cover(
+    work_id: uuid.UUID,
+    payload: SelectCoverRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> dict[str, object]:
+    try:
+        result = await select_openlibrary_cover(
+            session,
+            settings=settings,
+            user_id=auth.user_id,
+            work_id=work_id,
+            cover_id=payload.cover_id,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "cover_cache_failed",
+                "message": "Unable to cache cover image right now. Please try again shortly.",
+            },
+        ) from exc
+
+    return ok(result)

--- a/apps/api/app/services/covers.py
+++ b/apps/api/app/services/covers.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
+import ipaddress
+import socket
 import uuid
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+import anyio
 import httpx
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from app.core.config import Settings
 from app.db.models.bibliography import Edition, Work
+from app.services.images import ImageValidationError, normalize_cover_image
 from app.services.storage import StorageUploadResult, upload_storage_object
 
 
@@ -20,6 +24,10 @@ class CoverCacheResult:
     cached: bool
     cover_url: str | None
     storage: StorageUploadResult | None = None
+
+
+_MAX_CACHED_COVER_BYTES = 10 * 1024 * 1024
+_MAX_CACHED_COVER_DIMENSION = 4000
 
 
 def _is_supabase_storage_url(*, settings: Settings, url: str) -> bool:
@@ -34,6 +42,163 @@ def _guess_extension(url: str) -> str:
         if path.endswith(ext):
             return ext
     return ".jpg"
+
+
+def _parse_public_storage_object_url(
+    *, settings: Settings, url: str
+) -> StorageUploadResult | None:
+    if not settings.supabase_url:
+        return None
+    base = settings.supabase_url.rstrip("/")
+    if not url.startswith(f"{base}/storage/v1/object/public/"):
+        return None
+    path = url[len(f"{base}/storage/v1/object/public/") :]
+    # Path format: {bucket}/{object_path}
+    bucket, sep, object_path = path.partition("/")
+    if not sep or not bucket or not object_path:
+        return None
+    return StorageUploadResult(public_url=url, bucket=bucket, path=object_path)
+
+
+def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    # ip.is_global is the closest thing to "public routable" in stdlib.
+    return bool(getattr(ip, "is_global", False))
+
+
+def _is_blocked_hostname(host: str) -> bool:
+    host = host.lower().strip(".")
+    if not host:
+        return True
+    if host in {"localhost", "localhost.localdomain"}:
+        return True
+    if host.endswith(".local"):
+        return True
+    return False
+
+
+def _resolve_host_ips(host: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    ips: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+    for family, _type, _proto, _canonname, sockaddr in socket.getaddrinfo(host, None):
+        if family == socket.AF_INET:
+            ip_str = sockaddr[0]
+        elif family == socket.AF_INET6:
+            ip_str = sockaddr[0]
+        else:
+            continue
+        try:
+            ips.add(ipaddress.ip_address(ip_str))
+        except ValueError:
+            continue
+    return ips
+
+
+async def _require_safe_public_http_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("source_url must be an http(s) URL")
+
+    host = (parsed.hostname or "").strip()
+    if _is_blocked_hostname(host):
+        raise ValueError("source_url must be a public http(s) URL")
+
+    # Literal IPs: validate directly without DNS.
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+
+    if ip is not None:
+        if not _is_public_ip(ip):
+            raise ValueError("source_url must be a public http(s) URL")
+        return
+
+    # DNS resolve in a worker thread, then ensure every resolved address is public.
+    ips = await anyio.to_thread.run_sync(_resolve_host_ips, host)
+    if not ips:
+        raise ValueError("source_url must be a public http(s) URL")
+    if any(not _is_public_ip(ip) for ip in ips):
+        raise ValueError("source_url must be a public http(s) URL")
+
+
+async def cache_cover_to_storage(
+    *,
+    settings: Settings,
+    source_url: str,
+    transport: httpx.AsyncBaseTransport | None = None,
+    storage_transport: httpx.AsyncBaseTransport | None = None,
+) -> StorageUploadResult:
+    """Cache an external cover image into Supabase storage and return the public URL.
+
+    This does not mutate Work/Edition/LibraryItem rows; callers own DB writes.
+    """
+    if _is_supabase_storage_url(settings=settings, url=source_url):
+        parsed = _parse_public_storage_object_url(settings=settings, url=source_url)
+        if parsed is not None:
+            return parsed
+        # Fallback: it's a Supabase storage URL but doesn't match the public pattern.
+        # Still treat it as "already cached".
+        return StorageUploadResult(
+            public_url=source_url,
+            bucket=settings.supabase_storage_covers_bucket,
+            path="",
+        )
+
+    await _require_safe_public_http_url(source_url)
+
+    async with httpx.AsyncClient(
+        timeout=20.0, transport=transport, follow_redirects=True
+    ) as client:
+        async with client.stream(
+            "GET", source_url, headers={"User-Agent": "TheSeedbed/0.1"}
+        ) as response:
+            response.raise_for_status()
+
+            # Validate redirect chain targets too.
+            for hop in [*response.history, response]:
+                await _require_safe_public_http_url(str(hop.url))
+
+            declared_len = response.headers.get("Content-Length")
+            if declared_len is not None:
+                try:
+                    declared_int = int(declared_len)
+                except ValueError:
+                    declared_int = None
+                if declared_int is not None and declared_int > _MAX_CACHED_COVER_BYTES:
+                    raise ValueError("image is too large")
+
+            raw = bytearray()
+            async for chunk in response.aiter_bytes():
+                raw += chunk
+                if len(raw) > _MAX_CACHED_COVER_BYTES:
+                    raise ValueError("image is too large")
+
+            content_type = (
+                response.headers.get("Content-Type", "").split(";", 1)[0].strip()
+            ) or None
+
+    try:
+        normalized, out_content_type = normalize_cover_image(
+            content=bytes(raw),
+            content_type=content_type,
+            max_bytes=_MAX_CACHED_COVER_BYTES,
+            max_dimension=_MAX_CACHED_COVER_DIMENSION,
+        )
+    except ImageValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+    ext = _guess_extension(source_url)
+    digest = hashlib.sha256(source_url.encode("utf-8")).hexdigest()[:32]
+    path = f"openlibrary/{digest}{ext}"
+
+    return await upload_storage_object(
+        settings=settings,
+        bucket=settings.supabase_storage_covers_bucket,
+        path=path,
+        content=normalized,
+        content_type=out_content_type,
+        upsert=True,
+        transport=storage_transport,
+    )
 
 
 async def cache_edition_cover_from_url(
@@ -51,6 +216,9 @@ async def cache_edition_cover_from_url(
     if _is_supabase_storage_url(settings=settings, url=source_url):
         return CoverCacheResult(cached=False, cover_url=source_url)
 
+    # Reject unsafe URLs early, before any DB lookup.
+    await _require_safe_public_http_url(source_url)
+
     edition = session.scalar(sa.select(Edition).where(Edition.id == edition_id))
     if edition is None:
         raise LookupError("edition not found")
@@ -60,25 +228,11 @@ async def cache_edition_cover_from_url(
     ):
         return CoverCacheResult(cached=False, cover_url=edition.cover_url)
 
-    async with httpx.AsyncClient(timeout=20.0, transport=transport) as client:
-        response = await client.get(
-            source_url, headers={"User-Agent": "TheSeedbed/0.1"}
-        )
-    response.raise_for_status()
-
-    content_type = response.headers.get("Content-Type", "image/jpeg").split(";")[0]
-    ext = _guess_extension(source_url)
-    digest = hashlib.sha256(source_url.encode("utf-8")).hexdigest()[:32]
-    path = f"openlibrary/{digest}{ext}"
-
-    upload = await upload_storage_object(
+    upload = await cache_cover_to_storage(
         settings=settings,
-        bucket=settings.supabase_storage_covers_bucket,
-        path=path,
-        content=response.content,
-        content_type=content_type,
-        upsert=True,
-        transport=storage_transport,
+        source_url=source_url,
+        transport=transport,
+        storage_transport=storage_transport,
     )
 
     edition.cover_url = upload.public_url

--- a/apps/api/app/services/manual_covers.py
+++ b/apps/api/app/services/manual_covers.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from app.core.config import Settings
 from app.db.models.bibliography import Edition, Work
 from app.db.models.users import LibraryItem
-from app.services.covers import cache_edition_cover_from_url
+from app.services.covers import cache_cover_to_storage, cache_edition_cover_from_url
 from app.services.images import ImageValidationError, normalize_cover_image
 from app.services.storage import upload_storage_object
 
@@ -35,21 +35,40 @@ def _require_library_membership(
         raise PermissionError("book must be in your library to set a cover")
 
 
+def _work_has_global_cover(session: Session, *, work_id: uuid.UUID) -> bool:
+    work = session.get(Work, work_id)
+    if work is not None and work.default_cover_url:
+        return True
+    any_edition_cover = session.scalar(
+        sa.select(Edition.id)
+        .where(Edition.work_id == work_id, Edition.cover_url.is_not(None))
+        .limit(1)
+    )
+    return any_edition_cover is not None
+
+
+def _require_library_item(
+    session: Session, *, user_id: uuid.UUID, work_id: uuid.UUID
+) -> LibraryItem:
+    item = session.scalar(
+        sa.select(LibraryItem).where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.work_id == work_id,
+        )
+    )
+    if item is None:
+        raise PermissionError("book must be in your library to set a cover")
+    return item
+
+
 def _is_allowed_cover_source(*, settings: Settings, source_url: str) -> bool:
     parsed = urlparse(source_url)
     if parsed.scheme not in {"http", "https"}:
         return False
 
-    host = (parsed.hostname or "").lower()
-    if host == "covers.openlibrary.org":
-        return True
-
-    if settings.supabase_url:
-        supabase_host = urlparse(settings.supabase_url).hostname or ""
-        if supabase_host and host == supabase_host:
-            return True
-
-    return False
+    # Host allowlists are brittle in practice; safety checks are enforced centrally
+    # when we fetch/cache the image (see cache_cover_to_storage()).
+    return bool(parsed.hostname)
 
 
 async def set_edition_cover_from_upload(
@@ -74,6 +93,26 @@ async def set_edition_cover_from_upload(
         max_dimension=_MAX_COVER_DIMENSION,
     )
     digest = hashlib.sha256(content).hexdigest()[:16]
+    now = dt.datetime.now(tz=dt.UTC)
+
+    if _work_has_global_cover(session, work_id=edition.work_id):
+        item = _require_library_item(session, user_id=user_id, work_id=edition.work_id)
+        path = f"manual-overrides/{user_id}/{edition.work_id}/{digest}.jpg"
+        upload = await upload_storage_object(
+            settings=settings,
+            bucket=settings.supabase_storage_covers_bucket,
+            path=path,
+            content=normalized_bytes,
+            content_type=out_content_type,
+            upsert=True,
+        )
+        item.cover_override_url = upload.public_url
+        item.cover_override_storage_path = upload.path
+        item.cover_override_set_by = user_id
+        item.cover_override_set_at = now
+        session.commit()
+        return {"cover_url": upload.public_url}
+
     path = f"manual/{edition.work_id}/{edition.id}/{digest}.jpg"
 
     upload = await upload_storage_object(
@@ -84,8 +123,6 @@ async def set_edition_cover_from_upload(
         content_type=out_content_type,
         upsert=True,
     )
-
-    now = dt.datetime.now(tz=dt.UTC)
 
     edition.cover_url = upload.public_url
     edition.cover_storage_path = upload.path
@@ -112,13 +149,24 @@ async def cache_edition_cover_from_source_url(
     source_url: str,
 ) -> dict[str, str | bool | None]:
     if not _is_allowed_cover_source(settings=settings, source_url=source_url):
-        raise ValueError("source_url must be an http(s) URL from an approved host")
+        raise ValueError("source_url must be an http(s) URL")
 
     edition = session.get(Edition, edition_id)
     if edition is None:
         raise LookupError("edition not found")
 
     _require_library_membership(session, user_id=user_id, work_id=edition.work_id)
+
+    if _work_has_global_cover(session, work_id=edition.work_id):
+        item = _require_library_item(session, user_id=user_id, work_id=edition.work_id)
+        upload = await cache_cover_to_storage(settings=settings, source_url=source_url)
+        now = dt.datetime.now(tz=dt.UTC)
+        item.cover_override_url = upload.public_url
+        item.cover_override_storage_path = upload.path or None
+        item.cover_override_set_by = user_id
+        item.cover_override_set_at = now
+        session.commit()
+        return {"cached": True, "cover_url": upload.public_url}
 
     result = await cache_edition_cover_from_url(
         session,

--- a/apps/api/app/services/storage.py
+++ b/apps/api/app/services/storage.py
@@ -43,6 +43,8 @@ async def upload_storage_object(
     url = f"{settings.supabase_url}/storage/v1/object/{safe_bucket}/{safe_path}"
     headers = {
         "Authorization": f"Bearer {settings.supabase_service_role_key}",
+        # Supabase storage expects apikey even when using Authorization.
+        "apikey": settings.supabase_service_role_key,
         "Content-Type": content_type,
         "x-upsert": "true" if upsert else "false",
     }

--- a/apps/api/app/services/work_covers.py
+++ b/apps/api/app/services/work_covers.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings
+from app.db.models.bibliography import Edition, Work
+from app.db.models.external_provider import ExternalId, SourceRecord
+from app.db.models.users import LibraryItem
+from app.services.covers import cache_cover_to_storage, cache_edition_cover_from_url
+from app.services.open_library import OpenLibraryClient
+
+
+def _work_has_global_cover(session: Session, *, work_id: uuid.UUID) -> bool:
+    work = session.get(Work, work_id)
+    if work is not None and work.default_cover_url:
+        return True
+    any_edition_cover = session.scalar(
+        sa.select(Edition.id)
+        .where(Edition.work_id == work_id, Edition.cover_url.is_not(None))
+        .limit(1)
+    )
+    return any_edition_cover is not None
+
+
+async def list_openlibrary_cover_candidates(
+    session: Session,
+    *,
+    work_id: uuid.UUID,
+    open_library: OpenLibraryClient,
+) -> list[dict[str, object]]:
+    provider_id = session.scalar(
+        sa.select(ExternalId.provider_id).where(
+            ExternalId.entity_type == "work",
+            ExternalId.entity_id == work_id,
+            ExternalId.provider == "openlibrary",
+        )
+    )
+    if provider_id is None:
+        return []
+
+    cover_ids: list[int] = []
+    source = session.scalar(
+        sa.select(SourceRecord).where(
+            SourceRecord.provider == "openlibrary",
+            SourceRecord.entity_type == "work",
+            SourceRecord.provider_id == provider_id,
+        )
+    )
+    if source is not None and isinstance(source.raw, dict):
+        covers = source.raw.get("covers")
+        if isinstance(covers, list):
+            for c in covers:
+                if isinstance(c, int) and c > 0:
+                    cover_ids.append(c)
+
+    if not cover_ids:
+        # Fall back to Open Library directly. Some works have covers only on editions.
+        cover_ids = await open_library.fetch_cover_ids_for_work(
+            work_key=provider_id, editions_limit=50
+        )
+
+    # Stable, de-duped ordering.
+    seen: set[int] = set()
+    items: list[dict[str, object]] = []
+    for cover_id in cover_ids:
+        if cover_id in seen:
+            continue
+        seen.add(cover_id)
+        items.append(
+            {
+                "cover_id": cover_id,
+                "thumbnail_url": f"https://covers.openlibrary.org/b/id/{cover_id}-M.jpg",
+                "image_url": f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg",
+            }
+        )
+    return items
+
+
+async def select_openlibrary_cover(
+    session: Session,
+    *,
+    settings: Settings,
+    user_id: uuid.UUID,
+    work_id: uuid.UUID,
+    cover_id: int,
+) -> dict[str, object]:
+    item = session.scalar(
+        sa.select(LibraryItem).where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.work_id == work_id,
+        )
+    )
+    if item is None:
+        raise PermissionError("book must be in your library to set a cover")
+
+    source_url = f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
+    now = dt.datetime.now(tz=dt.UTC)
+
+    if not _work_has_global_cover(session, work_id=work_id):
+        edition_id = item.preferred_edition_id
+        if edition_id is None:
+            edition_id = session.scalar(
+                sa.select(Edition.id)
+                .where(Edition.work_id == work_id)
+                .order_by(Edition.created_at.desc(), Edition.id.desc())
+                .limit(1)
+            )
+
+        if edition_id is not None:
+            result = await cache_edition_cover_from_url(
+                session,
+                settings=settings,
+                edition_id=edition_id,
+                source_url=source_url,
+                user_id=user_id,
+            )
+            return {"scope": "global", "cover_url": result.cover_url}
+
+        upload = await cache_cover_to_storage(settings=settings, source_url=source_url)
+        work = session.get(Work, work_id)
+        if work is None:
+            raise LookupError("work not found")
+        work.default_cover_url = upload.public_url
+        work.default_cover_storage_path = upload.path
+        work.default_cover_set_by = user_id
+        work.default_cover_set_at = now
+        session.commit()
+        return {"scope": "global", "cover_url": upload.public_url}
+
+    upload = await cache_cover_to_storage(settings=settings, source_url=source_url)
+    item.cover_override_url = upload.public_url
+    item.cover_override_storage_path = upload.path or None
+    item.cover_override_set_by = user_id
+    item.cover_override_set_at = now
+    session.commit()
+    return {"scope": "override", "cover_url": upload.public_url}

--- a/apps/api/tests/test_covers_service.py
+++ b/apps/api/tests/test_covers_service.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import asyncio
+import io
+import socket
 import uuid
 from typing import Any
 
 import httpx
+import pytest
 import sqlalchemy as sa
+from PIL import Image
 
 from app.core.config import Settings
 from app.db.models.bibliography import Edition, Work
-from app.services.covers import cache_edition_cover_from_url
+from app.services import covers as covers_service
+from app.services.covers import cache_cover_to_storage, cache_edition_cover_from_url
 
 
 class FakeSession:
@@ -45,6 +50,13 @@ def _settings() -> Settings:
     )
 
 
+def _jpeg_bytes() -> bytes:
+    img = Image.new("RGB", (20, 30), (10, 20, 30))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
 def test_cache_cover_noops_when_already_supabase_url() -> None:
     session = FakeSession()
     edition_id = uuid.uuid4()
@@ -59,6 +71,30 @@ def test_cache_cover_noops_when_already_supabase_url() -> None:
     assert result.cached is False
     assert result.cover_url is not None
     assert session.committed is False
+
+
+def test_cache_cover_to_storage_parses_public_object_url() -> None:
+    upload = asyncio.run(
+        cache_cover_to_storage(
+            settings=_settings(),
+            source_url="https://example.supabase.co/storage/v1/object/public/covers/x.jpg",
+        )
+    )
+    assert upload.bucket == "covers"
+    assert upload.path == "x.jpg"
+    assert upload.public_url.endswith("/covers/x.jpg")
+
+
+def test_cache_cover_to_storage_handles_unknown_supabase_storage_url() -> None:
+    upload = asyncio.run(
+        cache_cover_to_storage(
+            settings=_settings(),
+            source_url="https://example.supabase.co/storage/v1/signed/covers/x.jpg",
+        )
+    )
+    assert upload.public_url.endswith("/storage/v1/signed/covers/x.jpg")
+    assert upload.bucket == "covers"
+    assert upload.path == ""
 
 
 def test_cache_cover_downloads_uploads_and_updates_edition() -> None:
@@ -88,12 +124,13 @@ def test_cache_cover_downloads_uploads_and_updates_edition() -> None:
         return httpx.Response(
             200,
             headers={"Content-Type": "image/jpeg"},
-            content=b"img",
+            content=_jpeg_bytes(),
         )
 
     def upload_handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "PUT"
         assert request.headers["authorization"] == "Bearer service-role"
+        assert request.headers["apikey"] == "service-role"
         return httpx.Response(200, json={"Key": "ok"})
 
     result = asyncio.run(
@@ -157,3 +194,323 @@ def test_cache_cover_noops_when_edition_cover_already_cached() -> None:
     )
     assert result.cached is False
     assert result.cover_url == edition.cover_url
+
+
+def test_cache_cover_to_storage_follows_redirects() -> None:
+    requested: list[str] = []
+
+    def download_handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        if str(request.url) == "https://covers.openlibrary.org/b/id/1-L.jpg":
+            return httpx.Response(
+                302,
+                headers={"Location": "https://archive.org/covers/1-L.jpg"},
+            )
+        if str(request.url) == "https://archive.org/covers/1-L.jpg":
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "image/jpeg"},
+                content=_jpeg_bytes(),
+            )
+        return httpx.Response(404, json={"error": "unexpected"})
+
+    def upload_handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        return httpx.Response(200, json={"Key": "ok"})
+
+    upload = asyncio.run(
+        cache_cover_to_storage(
+            settings=_settings(),
+            source_url="https://covers.openlibrary.org/b/id/1-L.jpg",
+            transport=httpx.MockTransport(download_handler),
+            storage_transport=httpx.MockTransport(upload_handler),
+        )
+    )
+
+    assert requested[:2] == [
+        "https://covers.openlibrary.org/b/id/1-L.jpg",
+        "https://archive.org/covers/1-L.jpg",
+    ]
+    assert upload.public_url.startswith(
+        "https://example.supabase.co/storage/v1/object/public/covers/openlibrary/"
+    )
+
+
+def test_cache_cover_to_storage_rejects_localhost_url() -> None:
+    with pytest.raises(ValueError, match="public http\\(s\\) URL"):
+        asyncio.run(
+            cache_cover_to_storage(
+                settings=_settings(),
+                source_url="http://localhost/x.jpg",
+            )
+        )
+
+
+def test_cache_cover_to_storage_rejects_private_ip_url() -> None:
+    with pytest.raises(ValueError, match="public http\\(s\\) URL"):
+        asyncio.run(
+            cache_cover_to_storage(
+                settings=_settings(),
+                source_url="http://127.0.0.1/x.jpg",
+            )
+        )
+
+
+def test_guess_extension_defaults_to_jpg() -> None:
+    assert covers_service._guess_extension("https://example.com/image") == ".jpg"
+
+
+def test_parse_public_storage_object_url_returns_none_when_invalid() -> None:
+    assert (
+        covers_service._parse_public_storage_object_url(
+            settings=_settings(),
+            url="https://example.supabase.co/storage/v1/object/public/covers",
+        )
+        is None
+    )
+
+
+def test_is_supabase_storage_url_returns_false_when_supabase_url_empty() -> None:
+    settings = Settings(
+        supabase_url="",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
+    assert (
+        covers_service._is_supabase_storage_url(
+            settings=settings,
+            url="https://example.supabase.co/storage/v1/object/public/covers/x.jpg",
+        )
+        is False
+    )
+
+
+def test_require_safe_public_http_url_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValueError, match="http\\(s\\)"):
+        asyncio.run(covers_service._require_safe_public_http_url("ftp://example.com/x"))
+
+
+def test_cache_cover_to_storage_allows_unparsable_content_length() -> None:
+    def download_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "image/jpeg", "Content-Length": "abc"},
+            content=_jpeg_bytes(),
+        )
+
+    def upload_handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        return httpx.Response(200, json={"Key": "ok"})
+
+    upload = asyncio.run(
+        cache_cover_to_storage(
+            settings=_settings(),
+            source_url="https://example.com/image",
+            transport=httpx.MockTransport(download_handler),
+            storage_transport=httpx.MockTransport(upload_handler),
+        )
+    )
+    assert upload.public_url.startswith(
+        "https://example.supabase.co/storage/v1/object/public/covers/openlibrary/"
+    )
+
+
+def test_cache_cover_to_storage_rejects_invalid_image_content() -> None:
+    def download_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "image/jpeg"},
+            content=b"not an image",
+        )
+
+    def upload_handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not upload")
+
+    with pytest.raises(ValueError, match="invalid image upload"):
+        asyncio.run(
+            cache_cover_to_storage(
+                settings=_settings(),
+                source_url="https://example.com/bad.jpg",
+                transport=httpx.MockTransport(download_handler),
+                storage_transport=httpx.MockTransport(upload_handler),
+            )
+        )
+
+
+def test_cache_cover_updates_edition_without_touching_work_when_work_missing() -> None:
+    edition_id = uuid.uuid4()
+    edition = Edition(
+        id=edition_id,
+        work_id=uuid.uuid4(),
+        publisher=None,
+        publish_date=None,
+        language=None,
+        format=None,
+        cover_url=None,
+    )
+    session = FakeSession()
+    session.scalar_values = [edition]
+    session.get_values = [None]
+
+    def download_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "image/jpeg"},
+            content=_jpeg_bytes(),
+        )
+
+    def upload_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"Key": "ok"})
+
+    result = asyncio.run(
+        cache_edition_cover_from_url(
+            session,  # type: ignore[arg-type]
+            settings=_settings(),
+            edition_id=edition_id,
+            source_url="https://covers.openlibrary.org/b/id/2-L.jpg",
+            transport=httpx.MockTransport(download_handler),
+            storage_transport=httpx.MockTransport(upload_handler),
+        )
+    )
+    assert result.cached is True
+    assert edition.cover_url is not None
+
+
+def test_parse_public_storage_object_url_returns_none_when_supabase_url_empty() -> None:
+    settings = Settings(
+        supabase_url="",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
+    assert (
+        covers_service._parse_public_storage_object_url(
+            settings=settings,
+            url="https://example.supabase.co/storage/v1/object/public/covers/x.jpg",
+        )
+        is None
+    )
+
+
+def test_blocked_hostname_helpers() -> None:
+    assert covers_service._is_blocked_hostname("") is True
+    assert covers_service._is_blocked_hostname("foo.local") is True
+    assert covers_service._is_blocked_hostname("example.com") is False
+
+
+def test_require_safe_public_http_url_accepts_public_ip_literal() -> None:
+    # Should not raise; we only validate the URL host here.
+    asyncio.run(covers_service._require_safe_public_http_url("http://8.8.8.8/x.jpg"))
+
+
+def test_require_safe_public_http_url_rejects_when_dns_resolution_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(covers_service, "_resolve_host_ips", lambda _host: set())
+    with pytest.raises(ValueError, match="public http\\(s\\) URL"):
+        asyncio.run(
+            covers_service._require_safe_public_http_url("https://example.com/x")
+        )
+
+
+def test_require_safe_public_http_url_rejects_when_dns_resolves_private_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ipaddress
+
+    monkeypatch.setattr(
+        covers_service,
+        "_resolve_host_ips",
+        lambda _host: {ipaddress.ip_address("10.0.0.1")},
+    )
+    with pytest.raises(ValueError, match="public http\\(s\\) URL"):
+        asyncio.run(
+            covers_service._require_safe_public_http_url("https://example.com/x")
+        )
+
+
+def test_resolve_host_ips_ignores_unknown_families_and_invalid_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_getaddrinfo(_host: str, _port: object) -> list[object]:
+        return [
+            (9999, 0, 0, "", ("not-an-ip", 0)),
+            (socket.AF_INET, 0, 0, "", ("256.256.256.256", 0)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    assert covers_service._resolve_host_ips("example.com") == set()
+
+
+def test_cache_cover_to_storage_rejects_large_content_length() -> None:
+    def download_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "Content-Type": "image/jpeg",
+                "Content-Length": str(10 * 1024 * 1024 + 1),
+            },
+            content=_jpeg_bytes(),
+        )
+
+    def upload_handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not upload")
+
+    with pytest.raises(ValueError, match="image is too large"):
+        asyncio.run(
+            cache_cover_to_storage(
+                settings=_settings(),
+                source_url="https://example.com/big.jpg",
+                transport=httpx.MockTransport(download_handler),
+                storage_transport=httpx.MockTransport(upload_handler),
+            )
+        )
+
+
+def test_cache_cover_to_storage_rejects_large_body_even_without_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(covers_service, "_MAX_CACHED_COVER_BYTES", 4)
+
+    def download_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "image/jpeg"},
+            content=b"12345",
+        )
+
+    def upload_handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not upload")
+
+    with pytest.raises(ValueError, match="image is too large"):
+        asyncio.run(
+            cache_cover_to_storage(
+                settings=_settings(),
+                source_url="https://example.com/big2.jpg",
+                transport=httpx.MockTransport(download_handler),
+                storage_transport=httpx.MockTransport(upload_handler),
+            )
+        )
+
+
+def test_cache_edition_cover_noops_when_source_url_missing() -> None:
+    session = FakeSession()
+    result = asyncio.run(
+        cache_edition_cover_from_url(
+            session,  # type: ignore[arg-type]
+            settings=_settings(),
+            edition_id=uuid.uuid4(),
+            source_url=None,
+        )
+    )
+    assert result.cached is False
+    assert result.cover_url is None

--- a/apps/api/tests/test_library_by_work_router.py
+++ b/apps/api/tests/test_library_by_work_router.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime as dt
 import uuid
 from collections.abc import Generator
-from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -34,17 +33,18 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
     app.dependency_overrides[get_db_session] = _fake_session
 
     monkeypatch.setattr(
-        "app.routers.library.get_library_item_by_work",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            id=uuid.uuid4(),
-            work_id=uuid.uuid4(),
-            preferred_edition_id=None,
-            status="to_read",
-            visibility="private",
-            rating=None,
-            tags=None,
-            created_at=dt.datetime.now(tz=dt.UTC),
-        ),
+        "app.routers.library.get_library_item_by_work_detail",
+        lambda *_args, **_kwargs: {
+            "id": str(uuid.uuid4()),
+            "work_id": str(uuid.uuid4()),
+            "preferred_edition_id": None,
+            "cover_url": "https://example.com/cover.jpg",
+            "status": "to_read",
+            "visibility": "private",
+            "rating": None,
+            "tags": [],
+            "created_at": dt.datetime.now(tz=dt.UTC).isoformat(),
+        },
     )
 
     yield app
@@ -61,7 +61,8 @@ def test_get_library_item_by_work_returns_404(
     app: FastAPI, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
-        "app.routers.library.get_library_item_by_work", lambda *_args, **_kwargs: None
+        "app.routers.library.get_library_item_by_work_detail",
+        lambda *_args, **_kwargs: None,
     )
     client = TestClient(app)
     response = client.get(f"/api/v1/library/items/by-work/{uuid.uuid4()}")

--- a/apps/api/tests/test_storage_service.py
+++ b/apps/api/tests/test_storage_service.py
@@ -26,6 +26,7 @@ def test_upload_storage_object_puts_bytes_and_returns_public_url() -> None:
         assert request.method == "PUT"
         assert request.url.path == "/storage/v1/object/covers/a/b.txt"
         assert request.headers["authorization"] == "Bearer service-role"
+        assert request.headers["apikey"] == "service-role"
         assert request.headers["x-upsert"] == "true"
         assert request.headers["content-type"] == "text/plain"
         return httpx.Response(200, json={"Key": "ok"})

--- a/apps/api/tests/test_user_library_models.py
+++ b/apps/api/tests/test_user_library_models.py
@@ -72,6 +72,10 @@ def test_library_items_table_schema() -> None:
         "visibility",
         "rating",
         "tags",
+        "cover_override_url",
+        "cover_override_storage_path",
+        "cover_override_set_by",
+        "cover_override_set_at",
         "created_at",
         "updated_at",
     }

--- a/apps/api/tests/test_work_covers_service.py
+++ b/apps/api/tests/test_work_covers_service.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+
+from app.core.config import Settings
+from app.db.models.bibliography import Work
+from app.db.models.external_provider import SourceRecord
+from app.db.models.users import LibraryItem
+from app.services import work_covers
+from app.services.covers import CoverCacheResult
+from app.services.storage import StorageUploadResult
+from app.services.work_covers import (
+    list_openlibrary_cover_candidates,
+    select_openlibrary_cover,
+)
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.scalar_values: list[Any] = []
+        self.get_map: dict[tuple[type[Any], Any], Any] = {}
+        self.committed = False
+
+    def scalar(self, _stmt: Any) -> Any:
+        if self.scalar_values:
+            return self.scalar_values.pop(0)
+        return None
+
+    def get(self, model: type[Any], key: Any) -> Any:
+        return self.get_map.get((model, key))
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def _settings() -> Settings:
+    return Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
+
+
+def test_list_openlibrary_cover_candidates_parses_source_record() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+
+    session.scalar_values = [
+        "/works/OL1W",
+        SourceRecord(
+            provider="openlibrary",
+            entity_type="work",
+            provider_id="/works/OL1W",
+            raw={"covers": [10, 11, 10]},
+        ),
+    ]
+
+    class _OL:
+        async def fetch_cover_ids_for_work(self, **_kwargs: Any) -> list[int]:
+            raise AssertionError("should not be called when SourceRecord has covers")
+
+    items = asyncio.run(
+        list_openlibrary_cover_candidates(
+            session, work_id=work_id, open_library=_OL()  # type: ignore[arg-type]
+        )
+    )
+    assert [i["cover_id"] for i in items] == [10, 11]
+    assert "thumbnail_url" in items[0]
+    assert "image_url" in items[0]
+
+
+def test_list_openlibrary_cover_candidates_returns_empty_when_missing() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    session.scalar_values = [None]
+
+    class _OL:
+        async def fetch_cover_ids_for_work(self, **_kwargs: Any) -> list[int]:
+            raise AssertionError(
+                "should not be called when work has no Open Library id"
+            )
+
+    assert (
+        asyncio.run(
+            list_openlibrary_cover_candidates(
+                session, work_id=work_id, open_library=_OL()  # type: ignore[arg-type]
+            )
+        )
+        == []
+    )
+
+
+def test_list_openlibrary_cover_candidates_returns_empty_when_source_missing() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    session.scalar_values = ["/works/OL1W", None]
+
+    class _OL:
+        async def fetch_cover_ids_for_work(self, **_kwargs: Any) -> list[int]:
+            return [99]
+
+    items = asyncio.run(
+        list_openlibrary_cover_candidates(
+            session, work_id=work_id, open_library=_OL()  # type: ignore[arg-type]
+        )
+    )
+    assert [i["cover_id"] for i in items] == [99]
+
+
+def test_list_openlibrary_cover_candidates_returns_empty_when_covers_invalid() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    session.scalar_values = [
+        "/works/OL1W",
+        SourceRecord(
+            provider="openlibrary",
+            entity_type="work",
+            provider_id="/works/OL1W",
+            raw={"covers": "nope"},
+        ),
+    ]
+
+    class _OL:
+        async def fetch_cover_ids_for_work(self, **_kwargs: Any) -> list[int]:
+            return [10, 11]
+
+    items = asyncio.run(
+        list_openlibrary_cover_candidates(
+            session, work_id=work_id, open_library=_OL()  # type: ignore[arg-type]
+        )
+    )
+    assert [i["cover_id"] for i in items] == [10, 11]
+
+
+def test_select_openlibrary_cover_sets_override_when_global_cover_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    user_id = uuid.uuid4()
+    work_id = uuid.uuid4()
+
+    item = LibraryItem(
+        user_id=user_id,
+        work_id=work_id,
+        preferred_edition_id=None,
+        status="to_read",
+        visibility="private",
+        rating=None,
+        tags=None,
+    )
+    session.scalar_values = [item]
+    session.get_map[(Work, work_id)] = Work(
+        id=work_id,
+        title="Book",
+        description=None,
+        first_publish_year=None,
+        default_cover_url="https://example.supabase.co/storage/v1/object/public/covers/existing.jpg",
+    )
+
+    async def fake_cache_cover_to_storage(**_kwargs: Any) -> StorageUploadResult:
+        return StorageUploadResult(
+            public_url="https://example.supabase.co/storage/v1/object/public/covers/openlibrary/abc.jpg",
+            bucket="covers",
+            path="openlibrary/abc.jpg",
+        )
+
+    monkeypatch.setattr(
+        work_covers, "cache_cover_to_storage", fake_cache_cover_to_storage
+    )
+
+    result = asyncio.run(
+        select_openlibrary_cover(
+            session,  # type: ignore[arg-type]
+            settings=_settings(),
+            user_id=user_id,
+            work_id=work_id,
+            cover_id=123,
+        )
+    )
+
+    assert result["scope"] == "override"
+    assert item.cover_override_url is not None
+    assert session.committed is True
+
+
+def test_select_openlibrary_cover_sets_global_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    user_id = uuid.uuid4()
+    work_id = uuid.uuid4()
+    edition_id = uuid.uuid4()
+
+    item = LibraryItem(
+        user_id=user_id,
+        work_id=work_id,
+        preferred_edition_id=edition_id,
+        status="to_read",
+        visibility="private",
+        rating=None,
+        tags=None,
+    )
+    # First scalar: find item, then global cover check queries any edition cover -> None
+    session.scalar_values = [item, None]
+    session.get_map[(Work, work_id)] = Work(
+        id=work_id,
+        title="Book",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+
+    async def fake_cache_edition_cover_from_url(
+        *_args: Any, **_kwargs: Any
+    ) -> CoverCacheResult:
+        return CoverCacheResult(
+            cached=True,
+            cover_url="https://example.supabase.co/storage/v1/object/public/covers/openlibrary/x.jpg",
+            storage=StorageUploadResult(
+                public_url="https://example.supabase.co/storage/v1/object/public/covers/openlibrary/x.jpg",
+                bucket="covers",
+                path="openlibrary/x.jpg",
+            ),
+        )
+
+    monkeypatch.setattr(
+        work_covers, "cache_edition_cover_from_url", fake_cache_edition_cover_from_url
+    )
+
+    result = asyncio.run(
+        select_openlibrary_cover(
+            session,  # type: ignore[arg-type]
+            settings=_settings(),
+            user_id=user_id,
+            work_id=work_id,
+            cover_id=10,
+        )
+    )
+    assert result["scope"] == "global"
+    assert result["cover_url"] is not None
+
+
+def test_select_openlibrary_cover_sets_global_on_work_when_no_edition_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    user_id = uuid.uuid4()
+    work_id = uuid.uuid4()
+
+    item = LibraryItem(
+        user_id=user_id,
+        work_id=work_id,
+        preferred_edition_id=None,
+        status="to_read",
+        visibility="private",
+        rating=None,
+        tags=None,
+    )
+    # scalar sequence:
+    # - find item
+    # - _work_has_global_cover -> any_edition_cover -> None
+    # - edition lookup for latest edition -> None
+    session.scalar_values = [item, None, None]
+    work = Work(
+        id=work_id,
+        title="Book",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    session.get_map[(Work, work_id)] = work
+
+    async def fake_cache_cover_to_storage(**_kwargs: Any) -> StorageUploadResult:
+        return StorageUploadResult(
+            public_url="https://example.supabase.co/storage/v1/object/public/covers/openlibrary/x.jpg",
+            bucket="covers",
+            path="openlibrary/x.jpg",
+        )
+
+    monkeypatch.setattr(
+        work_covers, "cache_cover_to_storage", fake_cache_cover_to_storage
+    )
+
+    result = asyncio.run(
+        select_openlibrary_cover(
+            session,  # type: ignore[arg-type]
+            settings=_settings(),
+            user_id=user_id,
+            work_id=work_id,
+            cover_id=1,
+        )
+    )
+    assert result["scope"] == "global"
+    assert work.default_cover_url is not None
+    assert session.committed is True

--- a/apps/api/tests/test_works_router.py
+++ b/apps/api/tests/test_works_router.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import uuid
 from collections.abc import Generator
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.core.config import Settings, get_settings
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.routers.works import router as works_router
@@ -28,6 +30,16 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
         yield object()
 
     app.dependency_overrides[get_db_session] = _fake_session
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
 
     monkeypatch.setattr(
         "app.routers.works.get_work_detail",
@@ -37,6 +49,21 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
         "app.routers.works.list_work_editions",
         lambda *_args, **_kwargs: [{"id": str(uuid.uuid4())}],
     )
+
+    async def _fake_list_covers(
+        *_args: object, **_kwargs: object
+    ) -> list[dict[str, object]]:
+        return [{"cover_id": 1, "thumbnail_url": "t", "image_url": "i"}]
+
+    monkeypatch.setattr(
+        "app.routers.works.list_openlibrary_cover_candidates",
+        _fake_list_covers,
+    )
+
+    async def _fake_select(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {"scope": "override", "cover_url": "https://example.com/x.jpg"}
+
+    monkeypatch.setattr("app.routers.works.select_openlibrary_cover", _fake_select)
 
     yield app
 
@@ -74,3 +101,59 @@ def test_list_editions_returns_404(
     client = TestClient(app)
     response = client.get(f"/api/v1/works/{uuid.uuid4()}/editions")
     assert response.status_code == 404
+
+
+def test_list_work_covers(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{uuid.uuid4()}/covers")
+    assert response.status_code == 200
+    assert response.json()["data"]["items"][0]["cover_id"] == 1
+
+
+def test_list_work_covers_returns_502_on_open_library_failure(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _boom(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        raise httpx.ConnectError("nope")
+
+    monkeypatch.setattr("app.routers.works.list_openlibrary_cover_candidates", _boom)
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{uuid.uuid4()}/covers")
+    assert response.status_code == 502
+
+
+def test_select_work_cover(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{uuid.uuid4()}/covers/select", json={"cover_id": 123}
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["scope"] in {"global", "override"}
+
+
+def test_select_work_cover_returns_403(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _deny(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise PermissionError("nope")
+
+    monkeypatch.setattr("app.routers.works.select_openlibrary_cover", _deny)
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{uuid.uuid4()}/covers/select", json={"cover_id": 123}
+    )
+    assert response.status_code == 403
+
+
+def test_select_work_cover_returns_502_on_cache_failure(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _boom(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise httpx.ConnectError("nope")
+
+    monkeypatch.setattr("app.routers.works.select_openlibrary_cover", _boom)
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{uuid.uuid4()}/covers/select", json={"cover_id": 123}
+    )
+    assert response.status_code == 502

--- a/supabase/migrations/20260210100000_add_library_item_cover_overrides.sql
+++ b/supabase/migrations/20260210100000_add_library_item_cover_overrides.sql
@@ -1,0 +1,23 @@
+-- Add per-user cover override columns to library_items.
+-- Safe to run even if columns already exist (CI runs Supabase migrations then Alembic).
+
+alter table public.library_items
+  add column if not exists cover_override_url text,
+  add column if not exists cover_override_storage_path text,
+  add column if not exists cover_override_set_by uuid,
+  add column if not exists cover_override_set_at timestamptz;
+
+-- Ensure the bucket used for caching cover images exists.
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.schemata
+    where schema_name = 'storage'
+  ) then
+    insert into storage.buckets (id, name, public)
+    values ('covers', 'covers', true)
+    on conflict (id) do update
+      set public = excluded.public;
+  end if;
+end $$;


### PR DESCRIPTION
Closes #93.

## What
- Add per-user cover overrides on `library_items` (override URL + provenance)
- Resolve cover precedence: override > edition > work default
- Add endpoints:
  - `GET /api/v1/works/:work_id/covers` (Open Library candidates)
  - `POST /api/v1/works/:work_id/covers/select` (set global if missing, else per-user override)
- Update book detail “Set cover” dialog to support choosing from Open Library covers and reflect overrides

## DB
- Supabase migration adds `library_items.cover_override_*` columns and ensures a public `covers` storage bucket exists
- Alembic migration mirrors the same columns

## Safety
- “Use image URL” no longer depends on a brittle host allowlist.
- Instead we accept public http(s) URLs with SSRF-safe checks (no localhost/private IPs), max size enforcement, redirect validation, and image normalization.

## Testing
- `make quality` passes locally (API + web + e2e)