### PR TITLE
Fix staging cover upload config + support Supabase secret key

### DIFF
--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -58,8 +58,16 @@ jobs:
 
       - name: Install Render CLI
         run: |
-          curl -fsSL https://cli.render.com/install.sh | sh
-          echo "$HOME/.render/bin" >> "$GITHUB_PATH"
+          # Install a pinned Render CLI binary (more reliable than curl|sh).
+          # Source: https://render.com/docs/cli
+          RENDER_CLI_VERSION="2.8.0"
+          asset="cli_${RENDER_CLI_VERSION}_linux_amd64.zip"
+          curl -fsSL \
+            "https://github.com/render-oss/cli/releases/download/v${RENDER_CLI_VERSION}/${asset}" \
+            -o render.zip
+          unzip -q render.zip
+          sudo mv "cli_v${RENDER_CLI_VERSION}" /usr/local/bin/render
+          render --version
 
       - name: Verify Render API key is configured
         run: |
@@ -125,8 +133,16 @@ jobs:
 
       - name: Install Render CLI
         run: |
-          curl -fsSL https://cli.render.com/install.sh | sh
-          echo "$HOME/.render/bin" >> "$GITHUB_PATH"
+          # Install a pinned Render CLI binary (more reliable than curl|sh).
+          # Source: https://render.com/docs/cli
+          RENDER_CLI_VERSION="2.8.0"
+          asset="cli_${RENDER_CLI_VERSION}_linux_amd64.zip"
+          curl -fsSL \
+            "https://github.com/render-oss/cli/releases/download/v${RENDER_CLI_VERSION}/${asset}" \
+            -o render.zip
+          unzip -q render.zip
+          sudo mv "cli_v${RENDER_CLI_VERSION}" /usr/local/bin/render
+          render --version
 
       - name: Verify Render API key is configured
         run: |

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -165,7 +165,13 @@ def get_settings() -> Settings:
     jwt_secret: str | None = os.getenv("SUPABASE_JWT_SECRET", "").strip()
     if not jwt_secret:
         jwt_secret = None
-    service_role_key: str | None = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    # Supabase legacy: "service_role" key.
+    # Supabase current: "secret" key (sb_secret_...), which should be used server-side only.
+    # Support both env vars to avoid Render/GHA/env drift.
+    service_role_key: str | None = (
+        os.getenv("SUPABASE_SECRET_KEY", "").strip()
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    )
     if not service_role_key:
         service_role_key = None
     ttl_seconds = _parse_ttl_seconds()

--- a/apps/api/app/routers/books.py
+++ b/apps/api/app/routers/books.py
@@ -18,6 +18,7 @@ from app.services.catalog import import_openlibrary_bundle
 from app.services.covers import cache_edition_cover_from_url
 from app.services.manual_books import create_manual_book
 from app.services.open_library import OpenLibraryClient
+from app.services.storage import StorageNotConfiguredError
 
 
 class ImportBookRequest(BaseModel):
@@ -161,5 +162,13 @@ async def create_manual(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except StorageNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "cover_upload_unavailable",
+                "message": "Cover uploads are temporarily unavailable. Please try again later.",
+            },
+        ) from exc
 
     return ok(result)

--- a/apps/api/app/routers/editions.py
+++ b/apps/api/app/routers/editions.py
@@ -17,6 +17,7 @@ from app.services.manual_covers import (
     cache_edition_cover_from_source_url,
     set_edition_cover_from_upload,
 )
+from app.services.storage import StorageNotConfiguredError
 
 router = APIRouter(
     prefix="/api/v1/editions",
@@ -55,6 +56,14 @@ async def upload_cover(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except PermissionError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except StorageNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "cover_upload_unavailable",
+                "message": "Cover uploads are temporarily unavailable. Please try again later.",
+            },
+        ) from exc
     return ok(result)
 
 
@@ -80,4 +89,12 @@ async def cache_cover(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except PermissionError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except StorageNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "cover_upload_unavailable",
+                "message": "Cover uploads are temporarily unavailable. Please try again later.",
+            },
+        ) from exc
     return ok(result)

--- a/apps/api/app/routers/works.py
+++ b/apps/api/app/routers/works.py
@@ -13,6 +13,7 @@ from app.core.responses import ok
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.services.open_library import OpenLibraryClient
+from app.services.storage import StorageNotConfiguredError
 from app.services.work_covers import (
     list_openlibrary_cover_candidates,
     select_openlibrary_cover,
@@ -106,6 +107,14 @@ async def select_cover(
             detail={
                 "code": "cover_cache_failed",
                 "message": "Unable to cache cover image right now. Please try again shortly.",
+            },
+        ) from exc
+    except StorageNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "cover_upload_unavailable",
+                "message": "Cover uploads are temporarily unavailable. Please try again later.",
             },
         ) from exc
 

--- a/apps/api/app/services/storage.py
+++ b/apps/api/app/services/storage.py
@@ -15,6 +15,10 @@ class StorageUploadResult:
     path: str
 
 
+class StorageNotConfiguredError(RuntimeError):
+    """Raised when required Supabase storage settings are missing."""
+
+
 def _public_object_url(*, supabase_url: str, bucket: str, path: str) -> str:
     # Public bucket/object access URL pattern.
     # Note: access depends on bucket/public policy in Supabase.
@@ -34,9 +38,9 @@ async def upload_storage_object(
     transport: httpx.AsyncBaseTransport | None = None,
 ) -> StorageUploadResult:
     if not settings.supabase_url:
-        raise RuntimeError("SUPABASE_URL is not configured")
+        raise StorageNotConfiguredError("SUPABASE_URL is not configured")
     if not settings.supabase_service_role_key:
-        raise RuntimeError("SUPABASE_SERVICE_ROLE_KEY is not configured")
+        raise StorageNotConfiguredError("SUPABASE_SERVICE_ROLE_KEY is not configured")
 
     safe_bucket = quote(bucket, safe="")
     safe_path = quote(path, safe="/._-")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,7 +63,7 @@ Service settings (API):
 - Build command: `pip install uv && uv sync --frozen --no-dev`
 - Start command: `uv run uvicorn main:app --host 0.0.0.0 --port $PORT`
 - Health check path: `/api/v1/health`
-- Env vars (staging/prod): `SUPABASE_URL`, `SUPABASE_JWT_AUDIENCE=authenticated`
+- Env vars (staging/prod): `SUPABASE_URL`, `SUPABASE_JWT_AUDIENCE=authenticated`, `SUPABASE_SERVICE_ROLE_KEY` (required for cover uploads/caching)
 
 CLI examples:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,7 +63,7 @@ Service settings (API):
 - Build command: `pip install uv && uv sync --frozen --no-dev`
 - Start command: `uv run uvicorn main:app --host 0.0.0.0 --port $PORT`
 - Health check path: `/api/v1/health`
-- Env vars (staging/prod): `SUPABASE_URL`, `SUPABASE_JWT_AUDIENCE=authenticated`, `SUPABASE_SERVICE_ROLE_KEY` (required for cover uploads/caching)
+- Env vars (staging/prod): `SUPABASE_URL`, `SUPABASE_JWT_AUDIENCE=authenticated`, `SUPABASE_SECRET_KEY` (preferred) or `SUPABASE_SERVICE_ROLE_KEY` (legacy; required for cover uploads/caching)
 
 CLI examples:
 


### PR DESCRIPTION
Follow-up to PR #108 and the staging drift incidents tracked in #100.

Changes:
- Support the Supabase server-side "Secret key" via SUPABASE_SECRET_KEY (preferred), falling back to legacy SUPABASE_SERVICE_ROLE_KEY.
- Return HTTP 503 (not 500) with a clear error code when cover uploads are unavailable due to missing storage key.
- Add/adjust tests and docs.

Notes:
- This PR does not change RLS/policies; it fixes the remaining staging 500 in cover selection/upload caused by missing/renamed Supabase secret key env vars.
