### PR TITLE
CI: fix Supabase DB Push Render CLI install

### DIFF
--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -62,11 +62,13 @@ jobs:
           # Source: https://render.com/docs/cli
           RENDER_CLI_VERSION="2.8.0"
           asset="cli_${RENDER_CLI_VERSION}_linux_amd64.zip"
+          tmpdir="$(mktemp -d)"
           curl -fsSL \
             "https://github.com/render-oss/cli/releases/download/v${RENDER_CLI_VERSION}/${asset}" \
-            -o render.zip
-          unzip -q render.zip
-          sudo mv "cli_v${RENDER_CLI_VERSION}" /usr/local/bin/render
+            -o "$tmpdir/render.zip"
+          # Avoid interactive prompts (zip contains README.md, etc.).
+          unzip -o -q "$tmpdir/render.zip" -d "$tmpdir"
+          sudo mv "$tmpdir/cli_v${RENDER_CLI_VERSION}" /usr/local/bin/render
           render --version
 
       - name: Verify Render API key is configured
@@ -137,11 +139,13 @@ jobs:
           # Source: https://render.com/docs/cli
           RENDER_CLI_VERSION="2.8.0"
           asset="cli_${RENDER_CLI_VERSION}_linux_amd64.zip"
+          tmpdir="$(mktemp -d)"
           curl -fsSL \
             "https://github.com/render-oss/cli/releases/download/v${RENDER_CLI_VERSION}/${asset}" \
-            -o render.zip
-          unzip -q render.zip
-          sudo mv "cli_v${RENDER_CLI_VERSION}" /usr/local/bin/render
+            -o "$tmpdir/render.zip"
+          # Avoid interactive prompts (zip contains README.md, etc.).
+          unzip -o -q "$tmpdir/render.zip" -d "$tmpdir"
+          sudo mv "$tmpdir/cli_v${RENDER_CLI_VERSION}" /usr/local/bin/render
           render --version
 
       - name: Verify Render API key is configured


### PR DESCRIPTION
Fixes the Supabase DB Push workflow failing before the Render deploy step.

Root cause
- The Render CLI zip includes README.md and the workflow was unzipping into the repo root, which triggered an interactive prompt in GitHub Actions.

Change
- Unzip into a temp dir with unzip -o -d (no prompt), then move the binary into /usr/local/bin.

Expected result
- Merges to development run: supabase db push -> Render deploy -> health smoke check.
