### PR TITLE
Revoke alembic_version privileges from client roles

### DIFF
--- a/apps/api/alembic/versions/0011_revoke_alembic_privs.py
+++ b/apps/api/alembic/versions/0011_revoke_alembic_privs.py
@@ -1,6 +1,6 @@
 """Revoke client-role privileges on alembic_version.
 
-Revision ID: 0011_revoke_alembic_version_privileges
+Revision ID: 0011_revoke_alembic_privs
 Revises: 0010_rls_hardening
 Create Date: 2026-02-10
 """
@@ -8,7 +8,7 @@ Create Date: 2026-02-10
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "0011_revoke_alembic_version_privileges"
+revision = "0011_revoke_alembic_privs"
 down_revision = "0010_rls_hardening"
 branch_labels = None
 depends_on = None

--- a/apps/api/alembic/versions/0011_revoke_alembic_version_privileges.py
+++ b/apps/api/alembic/versions/0011_revoke_alembic_version_privileges.py
@@ -1,0 +1,26 @@
+"""Revoke client-role privileges on alembic_version.
+
+Revision ID: 0011_revoke_alembic_version_privileges
+Revises: 0010_rls_hardening
+Create Date: 2026-02-10
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0011_revoke_alembic_version_privileges"
+down_revision = "0010_rls_hardening"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Alembic's internal table should not be accessible from client roles.
+    op.execute("REVOKE ALL ON TABLE public.alembic_version FROM anon;")
+    op.execute("REVOKE ALL ON TABLE public.alembic_version FROM authenticated;")
+
+
+def downgrade() -> None:
+    # We intentionally keep these revoked; re-granting would reintroduce the
+    # original security warning condition.
+    pass

--- a/supabase/migrations/20260210211500_revoke_alembic_version_privileges.sql
+++ b/supabase/migrations/20260210211500_revoke_alembic_version_privileges.sql
@@ -1,0 +1,8 @@
+-- Revoke access to Alembic's internal version table from client roles.
+--
+-- `public.alembic_version` is not user data and should not be readable or
+-- writable by `anon`/`authenticated`.
+
+REVOKE ALL ON TABLE public.alembic_version FROM anon;
+REVOKE ALL ON TABLE public.alembic_version FROM authenticated;
+


### PR DESCRIPTION
Revoke all privileges on public.alembic_version from anon/authenticated to clear security warnings.

Includes:
- Supabase migration to REVOKE privileges.
- Matching Alembic revision.
- Test asserting no grants for anon/authenticated once the Supabase migration is applied.