### PR TITLE
Fix auth redirect flash by bootstrapping Supabase session

### DIFF
--- a/apps/web/app/composables/useAuthBootstrap.ts
+++ b/apps/web/app/composables/useAuthBootstrap.ts
@@ -1,0 +1,76 @@
+import { useState, useSupabaseClient, useSupabaseUser } from '#imports';
+import type { User } from '@supabase/supabase-js';
+
+const AUTH_READY_STATE_KEY = 'auth:ready';
+const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 3000;
+
+let bootstrapPromise: Promise<void> | null = null;
+
+export function useAuthReady() {
+  return useState<boolean>(AUTH_READY_STATE_KEY, () => false);
+}
+
+/**
+ * Waits until the initial Supabase auth state is known on the client.
+ *
+ * This prevents route middleware from treating a signed-in user as signed-out
+ * during the brief window where Supabase restores the session from storage.
+ */
+export async function ensureAuthReady(options?: { timeoutMs?: number }): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  const authReady = useAuthReady();
+  if (authReady.value) return;
+
+  if (bootstrapPromise) {
+    await bootstrapPromise;
+    return;
+  }
+
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
+
+  bootstrapPromise = new Promise<void>((resolve) => {
+    const supabase = useSupabaseClient();
+    const user = useSupabaseUser();
+
+    let settled = false;
+    let subscription: { unsubscribe: () => void } | null = null;
+
+    const timeoutId: ReturnType<typeof setTimeout> = globalThis.setTimeout(() => {
+      // Avoid navigation deadlocks if INITIAL_SESSION doesn't arrive for some reason.
+      try {
+        subscription?.unsubscribe();
+      } catch {
+        // ignore
+      }
+      settle(undefined);
+    }, timeoutMs);
+
+    const settle = (nextUser: User | null | undefined) => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout(timeoutId);
+
+      if (nextUser !== undefined) {
+        user.value = nextUser ?? null;
+      }
+
+      authReady.value = true;
+      resolve();
+    };
+
+    const { data } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'INITIAL_SESSION') {
+        try {
+          subscription?.unsubscribe();
+        } catch {
+          // ignore
+        }
+        settle(session?.user ?? null);
+      }
+    });
+    subscription = data.subscription;
+  });
+
+  await bootstrapPromise;
+}

--- a/apps/web/app/layouts/app.vue
+++ b/apps/web/app/layouts/app.vue
@@ -17,7 +17,18 @@
         <div class="mb-5 flex items-center justify-between gap-4">
           <AppBreadcrumbs />
         </div>
-        <slot />
+        <div
+          v-if="isClient && !authReady"
+          class="flex min-h-[30vh] flex-col items-center justify-center gap-3"
+          data-test="auth-bootstrap-loading"
+        >
+          <div
+            class="h-10 w-10 animate-spin rounded-full border-4 border-[var(--p-surface-300)] border-t-[var(--p-primary-color)]"
+            aria-hidden="true"
+          />
+          <p class="text-sm text-[var(--p-text-muted-color)]">Loading your session...</p>
+        </div>
+        <slot v-else />
       </main>
     </div>
 
@@ -32,5 +43,8 @@ import AppBreadcrumbs from '~/components/shell/AppBreadcrumbs.vue';
 import AppNavMenu from '~/components/shell/AppNavMenu.vue';
 import AppSidebar from '~/components/shell/AppSidebar.vue';
 import AppTopBar from '~/components/shell/AppTopBar.vue';
+import { useAuthReady } from '~/composables/useAuthBootstrap';
 const sidebarVisible = ref(false);
+const authReady = useAuthReady();
+const isClient = typeof window !== 'undefined';
 </script>

--- a/apps/web/app/middleware/auth.ts
+++ b/apps/web/app/middleware/auth.ts
@@ -1,6 +1,15 @@
 import { defineNuxtRouteMiddleware, navigateTo, useSupabaseUser } from '#imports';
+import { ensureAuthReady, useAuthReady } from '~/composables/useAuthBootstrap';
 
-export default defineNuxtRouteMiddleware((to) => {
+export default defineNuxtRouteMiddleware(async (to) => {
+  const authReady = useAuthReady();
+  if (!authReady.value) {
+    await ensureAuthReady();
+  }
+
+  // If auth isn't known yet (e.g. SSR), do not redirect.
+  if (!authReady.value) return;
+
   const user = useSupabaseUser();
 
   if (!user.value) {

--- a/apps/web/app/middleware/guest-only.client.ts
+++ b/apps/web/app/middleware/guest-only.client.ts
@@ -1,6 +1,8 @@
 import { defineNuxtRouteMiddleware, navigateTo, useSupabaseUser } from '#imports';
+import { ensureAuthReady } from '~/composables/useAuthBootstrap';
 
-export default defineNuxtRouteMiddleware(() => {
+export default defineNuxtRouteMiddleware(async () => {
+  await ensureAuthReady();
   const user = useSupabaseUser();
   if (user.value) {
     return navigateTo('/library');

--- a/apps/web/app/plugins/auth-bootstrap.client.ts
+++ b/apps/web/app/plugins/auth-bootstrap.client.ts
@@ -1,0 +1,8 @@
+import { defineNuxtPlugin } from '#imports';
+import { ensureAuthReady } from '~/composables/useAuthBootstrap';
+
+export default defineNuxtPlugin(() => {
+  // Kick off auth bootstrap as early as possible on the client so layouts/middleware
+  // can reliably gate redirects/UX on "auth is known".
+  void ensureAuthReady();
+});

--- a/apps/web/tests/unit/composables/useAuthBootstrap.test.ts
+++ b/apps/web/tests/unit/composables/useAuthBootstrap.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const userRef = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return ref<any>(null);
+});
+
+const stateStore = vi.hoisted(() => new Map<string, any>());
+
+const onAuthStateChangeMock = vi.hoisted(() => vi.fn());
+const unsubscribeMock = vi.hoisted(() => vi.fn());
+const supabaseClientMock = vi.hoisted(() => ({
+  auth: {
+    onAuthStateChange: onAuthStateChangeMock,
+  },
+}));
+
+vi.mock('#imports', async () => {
+  const actual = await vi.importActual<any>('#imports');
+  return {
+    ...actual,
+    useState: (key: string, init: () => any) => {
+      const { ref } = require('vue');
+      if (!stateStore.has(key)) {
+        stateStore.set(key, ref(init()));
+      }
+      return stateStore.get(key);
+    },
+    useSupabaseUser: () => userRef,
+    useSupabaseClient: () => supabaseClientMock,
+  };
+});
+
+describe('useAuthBootstrap', () => {
+  beforeEach(() => {
+    stateStore.clear();
+    userRef.value = null;
+    onAuthStateChangeMock.mockReset();
+    unsubscribeMock.mockReset();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('returns immediately when window is not available (server environment)', async () => {
+    vi.stubGlobal('window', undefined as any);
+    onAuthStateChangeMock.mockImplementation(() => ({
+      data: { subscription: { unsubscribe: unsubscribeMock } },
+    }));
+
+    const { ensureAuthReady } = await import('../../../app/composables/useAuthBootstrap');
+    await ensureAuthReady();
+
+    expect(onAuthStateChangeMock).not.toHaveBeenCalled();
+  });
+
+  it('sets authReady and user after INITIAL_SESSION', async () => {
+    const unsubThatThrows = vi.fn(() => {
+      throw new Error('boom');
+    });
+
+    let authCb: any;
+    onAuthStateChangeMock.mockImplementation((cb: any) => {
+      authCb = cb;
+      return { data: { subscription: { unsubscribe: unsubThatThrows } } };
+    });
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    const pending = ensureAuthReady();
+
+    authCb('INITIAL_SESSION', { user: { id: 'u1' } });
+    await pending;
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value?.id).toBe('u1');
+  });
+
+  it('reuses the same bootstrap promise for concurrent callers', async () => {
+    let authCb: any;
+    onAuthStateChangeMock.mockImplementation((cb: any) => {
+      authCb = cb;
+      return { data: { subscription: { unsubscribe: unsubscribeMock } } };
+    });
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+
+    const p1 = ensureAuthReady({ timeoutMs: 1000 });
+    const p2 = ensureAuthReady({ timeoutMs: 1000 });
+
+    expect(onAuthStateChangeMock).toHaveBeenCalledTimes(1);
+    expect(useAuthReady().value).toBe(false);
+
+    authCb('INITIAL_SESSION', { user: { id: 'u2' } });
+    await Promise.all([p1, p2]);
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value?.id).toBe('u2');
+  });
+
+  it('ignores non-initial auth events and resolves on timeout', async () => {
+    vi.useFakeTimers();
+
+    let authCb: any;
+    onAuthStateChangeMock.mockImplementation((cb: any) => {
+      authCb = cb;
+      return { data: { subscription: { unsubscribe: unsubscribeMock } } };
+    });
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    const pending = ensureAuthReady({ timeoutMs: 10 });
+
+    authCb('SIGNED_IN', { user: { id: 'ignored' } });
+    expect(useAuthReady().value).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await pending;
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value).toBeNull();
+  });
+
+  it('treats INITIAL_SESSION with no session as signed out', async () => {
+    let authCb: any;
+    onAuthStateChangeMock.mockImplementation((cb: any) => {
+      authCb = cb;
+      return { data: { subscription: { unsubscribe: unsubscribeMock } } };
+    });
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    const pending = ensureAuthReady({ timeoutMs: 1000 });
+
+    authCb('INITIAL_SESSION', null);
+    await pending;
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value).toBeNull();
+  });
+
+  it('handles INITIAL_SESSION arriving before subscription is stored', async () => {
+    onAuthStateChangeMock.mockImplementation((cb: any) => {
+      cb('INITIAL_SESSION', { user: { id: 'early' } });
+      return { data: { subscription: { unsubscribe: unsubscribeMock } } };
+    });
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    await ensureAuthReady({ timeoutMs: 1000 });
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value?.id).toBe('early');
+  });
+
+  it('resolves on timeout without mutating user', async () => {
+    vi.useFakeTimers();
+    const unsubThatThrows = vi.fn(() => {
+      throw new Error('boom');
+    });
+    onAuthStateChangeMock.mockImplementation(() => ({
+      data: { subscription: { unsubscribe: unsubThatThrows } },
+    }));
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    const pending = ensureAuthReady({ timeoutMs: 10 });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await pending;
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value).toBeNull();
+  });
+
+  it('ignores late INITIAL_SESSION events after timing out', async () => {
+    vi.useFakeTimers();
+    let authCb: any;
+    onAuthStateChangeMock.mockImplementation((cb: any) => {
+      authCb = cb;
+      return {
+        data: {
+          subscription: {
+            unsubscribe: unsubscribeMock,
+          },
+        },
+      };
+    });
+
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    const pending = ensureAuthReady({ timeoutMs: 10 });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await pending;
+
+    expect(useAuthReady().value).toBe(true);
+    expect(userRef.value).toBeNull();
+
+    // If Supabase emits an INITIAL_SESSION after we've already settled, it should be ignored.
+    authCb('INITIAL_SESSION', { user: { id: 'late' } });
+    expect(userRef.value).toBeNull();
+  });
+
+  it('does not subscribe when auth is already ready', async () => {
+    const { ensureAuthReady, useAuthReady } =
+      await import('../../../app/composables/useAuthBootstrap');
+    useAuthReady().value = true;
+
+    await ensureAuthReady();
+
+    expect(onAuthStateChangeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/layouts/layouts.test.ts
+++ b/apps/web/tests/unit/layouts/layouts.test.ts
@@ -13,8 +13,18 @@ const routeState = vi.hoisted(() => {
   return reactive({ path: '/library' });
 });
 
+const authReadyRef = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return ref<boolean>(true);
+});
+
 vi.mock('#imports', () => ({
   useRoute: () => routeState,
+  useState: (key: string, init: () => any) => {
+    const { ref } = require('vue');
+    if (key === 'auth:ready') return authReadyRef;
+    return ref(init());
+  },
 }));
 
 const SlotContent = defineComponent({
@@ -35,6 +45,7 @@ describe('layouts', () => {
   });
 
   it('renders app layout and includes the sidebar shell components', async () => {
+    authReadyRef.value = true;
     const AppSidebarStub = defineComponent({
       name: 'AppSidebar',
       props: ['visible'],
@@ -74,5 +85,25 @@ describe('layouts', () => {
     wrapper.findComponent(AppSidebarStub).vm.$emit('update:visible', false);
     await wrapper.vm.$nextTick();
     expect(wrapper.get('[data-test="sidebar"]').text()).toContain('visible=false');
+  });
+
+  it('shows an auth bootstrap loading state while auth is unknown', () => {
+    authReadyRef.value = false;
+
+    const wrapper = mount(AppLayout as any, {
+      slots: { default: SlotContent },
+      global: {
+        stubs: {
+          AppTopBar: { template: '<div data-test="topbar" />' },
+          AppSidebar: { template: '<div data-test="sidebar" />' },
+          AppBreadcrumbs: { template: '<div data-test="crumbs" />' },
+          AppNavMenu: { template: '<div data-test="navmenu" />' },
+          Card: { template: '<div data-test="card"><slot name="content" /></div>' },
+        },
+      },
+    });
+
+    expect(wrapper.get('[data-test="auth-bootstrap-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="slot"]').exists()).toBe(false);
   });
 });

--- a/apps/web/tests/unit/middleware/auth.test.ts
+++ b/apps/web/tests/unit/middleware/auth.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const navigateToMock = vi.hoisted(() => vi.fn((to: string) => to));
+const ensureAuthReadyMock = vi.hoisted(() => vi.fn(async () => {}));
+const authReadyRef = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return ref<boolean>(false);
+});
 const userRef = vi.hoisted(() => {
   const { ref } = require('vue');
   return ref<any>(null);
 });
+
+vi.mock('~/composables/useAuthBootstrap', () => ({
+  ensureAuthReady: ensureAuthReadyMock,
+  useAuthReady: () => authReadyRef,
+}));
 
 vi.mock('#imports', () => ({
   defineNuxtRouteMiddleware: (fn: any) => fn,
@@ -15,21 +25,76 @@ vi.mock('#imports', () => ({
 import authMiddleware from '../../../app/middleware/auth';
 
 describe('auth middleware', () => {
-  it('redirects to login when user is missing', () => {
+  it('does not redirect until auth bootstrap resolves', async () => {
+    authReadyRef.value = false;
     userRef.value = null;
     navigateToMock.mockClear();
 
-    const result = authMiddleware({ fullPath: '/library?x=1' } as any);
+    let resolveBootstrap: (() => void) | null = null;
+    ensureAuthReadyMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveBootstrap = () => {
+            authReadyRef.value = true;
+            resolve();
+          };
+        }),
+    );
+
+    const pending = authMiddleware({ fullPath: '/library' } as any);
+    expect(navigateToMock).not.toHaveBeenCalled();
+
+    resolveBootstrap?.();
+    await pending;
+
+    expect(navigateToMock).toHaveBeenCalledWith('/login?returnTo=%2Flibrary');
+  });
+
+  it('does not redirect when auth remains unknown after bootstrap attempt', async () => {
+    authReadyRef.value = false;
+    userRef.value = null;
+    navigateToMock.mockClear();
+    ensureAuthReadyMock.mockClear();
+    ensureAuthReadyMock.mockResolvedValueOnce(undefined);
+
+    const result = await authMiddleware({ fullPath: '/library' } as any);
+
+    expect(result).toBeUndefined();
+    expect(navigateToMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call bootstrap when auth is already ready', async () => {
+    authReadyRef.value = true;
+    userRef.value = { id: 'user-1' };
+    navigateToMock.mockClear();
+    ensureAuthReadyMock.mockClear();
+
+    const result = await authMiddleware({ fullPath: '/library' } as any);
+
+    expect(result).toBeUndefined();
+    expect(ensureAuthReadyMock).not.toHaveBeenCalled();
+    expect(navigateToMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login when user is missing', async () => {
+    authReadyRef.value = true;
+    userRef.value = null;
+    navigateToMock.mockClear();
+    ensureAuthReadyMock.mockClear();
+
+    const result = await authMiddleware({ fullPath: '/library?x=1' } as any);
 
     expect(navigateToMock).toHaveBeenCalledWith('/login?returnTo=%2Flibrary%3Fx%3D1');
     expect(result).toBe('/login?returnTo=%2Flibrary%3Fx%3D1');
   });
 
-  it('allows navigation when user is present', () => {
+  it('allows navigation when user is present', async () => {
+    authReadyRef.value = true;
     userRef.value = { id: 'user-1' };
     navigateToMock.mockClear();
+    ensureAuthReadyMock.mockClear();
 
-    const result = authMiddleware({ fullPath: '/library' } as any);
+    const result = await authMiddleware({ fullPath: '/library' } as any);
 
     expect(result).toBeUndefined();
     expect(navigateToMock).not.toHaveBeenCalled();

--- a/apps/web/tests/unit/middleware/guest-only.test.ts
+++ b/apps/web/tests/unit/middleware/guest-only.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const navigateToMock = vi.hoisted(() => vi.fn());
+const ensureAuthReadyMock = vi.hoisted(() => vi.fn(async () => {}));
 const userRef = vi.hoisted(() => {
   const { ref } = require('vue');
   return ref<any>(null);
 });
+
+vi.mock('~/composables/useAuthBootstrap', () => ({
+  ensureAuthReady: ensureAuthReadyMock,
+}));
 
 vi.mock('#imports', () => ({
   defineNuxtRouteMiddleware: (fn: any) => fn,
@@ -15,16 +20,39 @@ vi.mock('#imports', () => ({
 import guestOnly from '../../../app/middleware/guest-only.client';
 
 describe('guest-only middleware', () => {
-  it('redirects to /library when signed in', () => {
+  it('does not redirect until auth bootstrap resolves', async () => {
     userRef.value = { id: 'u1' };
-    guestOnly();
+    navigateToMock.mockClear();
+
+    let resolveBootstrap: (() => void) | null = null;
+    ensureAuthReadyMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveBootstrap = resolve;
+        }),
+    );
+
+    const pending = guestOnly();
+    expect(navigateToMock).not.toHaveBeenCalled();
+
+    resolveBootstrap?.();
+    await pending;
+
     expect(navigateToMock).toHaveBeenCalledWith('/library');
   });
 
-  it('does nothing when signed out', () => {
+  it('redirects to /library when signed in', async () => {
+    userRef.value = { id: 'u1' };
+    ensureAuthReadyMock.mockClear();
+    await guestOnly();
+    expect(navigateToMock).toHaveBeenCalledWith('/library');
+  });
+
+  it('does nothing when signed out', async () => {
     userRef.value = null;
     navigateToMock.mockClear();
-    const result = guestOnly();
+    ensureAuthReadyMock.mockClear();
+    const result = await guestOnly();
     expect(result).toBeUndefined();
     expect(navigateToMock).not.toHaveBeenCalled();
   });

--- a/apps/web/tests/unit/plugins/auth-bootstrap-client.test.ts
+++ b/apps/web/tests/unit/plugins/auth-bootstrap-client.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const ensureAuthReadyMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock('#imports', () => ({
+  defineNuxtPlugin: (fn: any) => fn,
+}));
+
+vi.mock('~/composables/useAuthBootstrap', () => ({
+  ensureAuthReady: ensureAuthReadyMock,
+}));
+
+import plugin from '../../../app/plugins/auth-bootstrap.client';
+
+describe('auth-bootstrap.client plugin', () => {
+  it('kicks off auth bootstrap on client', () => {
+    ensureAuthReadyMock.mockClear();
+    plugin({} as any);
+    expect(ensureAuthReadyMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #104.

## What
- Add client-side auth bootstrap gate so middleware does not treat the user as signed out before Supabase resolves the initial session.
- Show a deterministic loading state in the protected `app` layout while auth is unknown.

## How
- New `useAuthBootstrap` composable exposes `useAuthReady()` + `ensureAuthReady()` (deduped promise + timeout).
- `auth` and `guest-only` middleware await bootstrap before redirect decisions.
- Client plugin kicks off bootstrap early.

## Testing
- `make quality`