### PR TITLE
Implement PrimeVue library view overhaul (issues #113 and #114)

### DIFF
--- a/apps/api/tests/test_me_library_router.py
+++ b/apps/api/tests/test_me_library_router.py
@@ -65,6 +65,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
                     "visibility": "private",
                     "rating": None,
                     "tags": [],
+                    "last_read_at": None,
                     "created_at": dt.datetime.now(tz=dt.UTC).isoformat(),
                 }
             ],
@@ -141,6 +142,7 @@ def test_list_library_items(app: FastAPI) -> None:
     )
     assert response.status_code == 200
     assert response.json()["data"]["items"][0]["status"] == "reading"
+    assert "last_read_at" in response.json()["data"]["items"][0]
 
 
 def test_create_library_item(app: FastAPI) -> None:

--- a/apps/api/tests/test_user_library_service.py
+++ b/apps/api/tests/test_user_library_service.py
@@ -39,7 +39,7 @@ class FakeSession:
         self.get_map: dict[tuple[type[Any], Any], Any] = {}
         self.scalar_values: list[Any] = []
         self.added: list[Any] = []
-        self.execute_rows: list[tuple[Any, str, Any]] = []
+        self.execute_rows: list[tuple[Any, ...]] = []
         self.execute_results: list[list[tuple[Any, ...]]] = []
         self.deleted: list[Any] = []
         self.committed = False
@@ -314,7 +314,16 @@ def test_list_library_items_returns_cursor() -> None:
         },
     )()
     session.execute_results = [
-        [(item1, "One", None), (item2, "Two", "https://example.com/cover.jpg")],
+        [
+            (
+                item1,
+                "One",
+                "First description",
+                None,
+                dt.datetime(2026, 2, 10, 12, 0, tzinfo=dt.UTC),
+            ),
+            (item2, "Two", None, "https://example.com/cover.jpg", None),
+        ],
         # Author lookup for the page.
         [(item1.work_id, "Author A"), (item1.work_id, "Author A")],
     ]
@@ -330,7 +339,9 @@ def test_list_library_items_returns_cursor() -> None:
     )
     assert len(result["items"]) == 1
     assert result["items"][0]["cover_url"] in (None, "https://example.com/cover.jpg")
+    assert result["items"][0]["work_description"] == "First description"
     assert result["items"][0]["author_names"] == ["Author A"]
+    assert result["items"][0]["last_read_at"] == "2026-02-10T12:00:00+00:00"
     assert result["next_cursor"] is not None
 
 

--- a/apps/web/app/components/shell/AppBreadcrumbs.vue
+++ b/apps/web/app/components/shell/AppBreadcrumbs.vue
@@ -24,7 +24,7 @@ const home = computed<BreadcrumbItem | undefined>(() => undefined);
 const items = computed<BreadcrumbItem[]>(() => {
   const path = route.path || '/';
   if (path === '/library') {
-    return [{ label: 'Library' }];
+    return [];
   }
   if (path === '/books/search') {
     return [{ label: 'Library', to: '/library' }, { label: 'Add books' }];

--- a/apps/web/app/layouts/app.vue
+++ b/apps/web/app/layouts/app.vue
@@ -1,50 +1,40 @@
 <template>
   <div>
-    <AppTopBar :show-sidebar-toggle="true" @toggleSidebar="sidebarVisible = true" />
+    <AppTopBar />
 
-    <div
-      class="mx-auto grid w-full max-w-6xl min-w-0 grid-cols-1 gap-6 px-4 py-6 md:grid-cols-[16rem_1fr] md:px-8 md:py-8"
+    <main
+      :class="[
+        'mx-auto w-full min-w-0 px-4 py-6 md:px-8 md:py-8',
+        isLibraryRoute ? 'max-w-none' : 'max-w-6xl',
+      ]"
     >
-      <aside class="hidden md:block">
-        <Card>
-          <template #content>
-            <AppNavMenu />
-          </template>
-        </Card>
-      </aside>
-
-      <main class="min-w-0">
-        <div class="mb-5 flex items-center justify-between gap-4">
-          <AppBreadcrumbs />
-        </div>
+      <div class="mb-5 flex items-center justify-between gap-4">
+        <AppBreadcrumbs />
+      </div>
+      <div
+        v-if="isClient && !authReady"
+        class="flex min-h-[30vh] flex-col items-center justify-center gap-3"
+        data-test="auth-bootstrap-loading"
+      >
         <div
-          v-if="isClient && !authReady"
-          class="flex min-h-[30vh] flex-col items-center justify-center gap-3"
-          data-test="auth-bootstrap-loading"
-        >
-          <div
-            class="h-10 w-10 animate-spin rounded-full border-4 border-[var(--p-surface-300)] border-t-[var(--p-primary-color)]"
-            aria-hidden="true"
-          />
-          <p class="text-sm text-[var(--p-text-muted-color)]">Loading your session...</p>
-        </div>
-        <slot v-else />
-      </main>
-    </div>
-
-    <AppSidebar v-model:visible="sidebarVisible" />
+          class="h-10 w-10 animate-spin rounded-full border-4 border-[var(--p-surface-300)] border-t-[var(--p-primary-color)]"
+          aria-hidden="true"
+        />
+        <p class="text-sm text-[var(--p-text-muted-color)]">Loading your session...</p>
+      </div>
+      <slot v-else />
+    </main>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import Card from 'primevue/card';
+import { computed } from 'vue';
+import { useRoute } from '#imports';
 import AppBreadcrumbs from '~/components/shell/AppBreadcrumbs.vue';
-import AppNavMenu from '~/components/shell/AppNavMenu.vue';
-import AppSidebar from '~/components/shell/AppSidebar.vue';
 import AppTopBar from '~/components/shell/AppTopBar.vue';
 import { useAuthReady } from '~/composables/useAuthBootstrap';
-const sidebarVisible = ref(false);
+const route = useRoute();
 const authReady = useAuthReady();
 const isClient = typeof window !== 'undefined';
+const isLibraryRoute = computed(() => route.path === '/library');
 </script>

--- a/apps/web/app/pages/library/index.vue
+++ b/apps/web/app/pages/library/index.vue
@@ -19,7 +19,18 @@
         <div class="flex flex-col gap-4">
           <Card>
             <template #content>
-              <div class="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <div
+                class="grid w-full grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5"
+              >
+                <SelectButton
+                  v-model="viewMode"
+                  :options="viewModeOptions"
+                  option-label="label"
+                  option-value="value"
+                  aria-label="Library view mode"
+                  data-test="library-view-select"
+                  class="min-w-0 w-full"
+                />
                 <Select
                   v-model="statusFilter"
                   :options="statusFilters"
@@ -40,6 +51,19 @@
                   option-label="label"
                   option-value="value"
                   data-test="library-sort-select"
+                  class="min-w-0 w-full"
+                />
+                <MultiSelect
+                  v-if="viewMode === 'table'"
+                  v-model="tableColumns"
+                  :options="tableColumnOptions"
+                  option-label="label"
+                  option-value="value"
+                  display="chip"
+                  :max-selected-labels="1"
+                  selected-items-label="{0} columns"
+                  placeholder="Columns"
+                  data-test="library-columns-select"
                   class="min-w-0 w-full"
                 />
               </div>
@@ -69,67 +93,484 @@
             </Card>
           </div>
 
-          <div v-else-if="displayItems.length" class="grid gap-3" data-test="library-items">
-            <div v-for="item in displayItems" :key="item.id" class="block">
-              <Card>
-                <template #content>
-                  <div class="flex items-start gap-4">
-                    <NuxtLink
-                      :to="`/books/${item.work_id}`"
-                      class="flex min-w-0 flex-1 items-start gap-4"
+          <template v-else-if="displayItems.length">
+            <DataTable
+              v-if="viewMode === 'table'"
+              :value="displayItems"
+              data-key="id"
+              size="small"
+              striped-rows
+              row-hover
+              class="w-full library-table"
+              data-test="library-items-table"
+            >
+              <Column v-if="isColumnVisible('cover')" class="w-[72px] min-w-[72px]">
+                <template #header>
+                  <span class="library-header-label">Cover</span>
+                </template>
+                <template #body="slotProps">
+                  <div class="flex justify-center">
+                    <div
+                      class="h-14 w-10 overflow-hidden rounded-md border border-[var(--p-content-border-color)] bg-black/5 dark:bg-white/5"
                     >
-                      <div
-                        class="h-[120px] w-[80px] shrink-0 overflow-hidden rounded-lg border border-[var(--p-content-border-color)] bg-black/5 dark:bg-white/5"
-                      >
-                        <Image
-                          v-if="item.cover_url"
-                          :src="item.cover_url"
-                          alt=""
-                          :preview="false"
-                          class="h-full w-full"
-                          image-class="h-full w-full object-cover"
-                          data-test="library-item-cover"
-                        />
-                        <CoverPlaceholder v-else data-test="library-item-cover-placeholder" />
-                      </div>
-
-                      <div class="min-w-0 pt-1">
-                        <p class="truncate font-serif text-base font-semibold tracking-tight">
-                          {{ item.work_title }}
-                        </p>
-                        <p
-                          v-if="item.author_names?.length"
-                          class="truncate text-sm text-[var(--p-text-muted-color)]"
-                        >
-                          {{ item.author_names.join(', ') }}
-                        </p>
-                        <div class="mt-3 flex flex-wrap items-center gap-2">
-                          <Tag :value="libraryStatusLabel(item.status)" severity="secondary" />
-                          <Tag
-                            v-for="tag in (item.tags || []).slice(0, 3)"
-                            :key="tag"
-                            :value="tag"
-                            severity="info"
-                          />
-                        </div>
-                      </div>
-                    </NuxtLink>
-
-                    <div class="shrink-0">
-                      <Button
-                        label="Remove"
-                        size="small"
-                        text
-                        severity="danger"
-                        data-test="library-item-remove"
-                        @click.stop="openRemoveConfirm(item)"
+                      <Image
+                        v-if="slotProps.data.cover_url"
+                        :src="slotProps.data.cover_url"
+                        alt=""
+                        :preview="false"
+                        class="h-full w-full"
+                        image-class="h-full w-full object-cover"
+                        data-test="library-item-cover"
                       />
+                      <CoverPlaceholder v-else data-test="library-item-cover-placeholder" />
                     </div>
                   </div>
                 </template>
-              </Card>
-            </div>
-          </div>
+              </Column>
+
+              <Column v-if="isColumnVisible('title')" class="min-w-[14rem]">
+                <template #header>
+                  <button
+                    type="button"
+                    class="library-sort-trigger"
+                    data-test="library-table-sort-title"
+                    @click="toggleTitleSort"
+                  >
+                    Title
+                    <i :class="titleSortIcon" aria-hidden="true"></i>
+                  </button>
+                </template>
+                <template #body="slotProps">
+                  <div class="min-w-0">
+                    <NuxtLink
+                      :to="`/books/${slotProps.data.work_id}`"
+                      class="line-clamp-1 block font-semibold text-primary no-underline hover:underline focus-visible:underline"
+                      data-test="library-item-title-link"
+                    >
+                      {{ slotProps.data.work_title }}
+                    </NuxtLink>
+                  </div>
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('author')" class="min-w-[10rem]">
+                <template #header>
+                  <button
+                    type="button"
+                    class="library-sort-trigger"
+                    data-test="library-table-sort-author"
+                    @click="toggleAuthorSort"
+                  >
+                    Author
+                    <i :class="authorSortIcon" aria-hidden="true"></i>
+                  </button>
+                </template>
+                <template #body="slotProps">
+                  <p class="line-clamp-1 text-sm text-[var(--p-text-muted-color)]">
+                    {{ slotProps.data.author_names?.join(', ') || 'Unknown author' }}
+                  </p>
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('status')" class="min-w-[8rem]">
+                <template #header>
+                  <button
+                    type="button"
+                    class="library-sort-trigger"
+                    data-test="library-table-sort-status"
+                    @click="toggleStatusSort"
+                  >
+                    Status
+                    <i :class="statusSortIcon" aria-hidden="true"></i>
+                  </button>
+                </template>
+                <template #body="slotProps">
+                  <div class="flex justify-center">
+                    <div class="library-meta-chip" data-test="library-item-status-chip">
+                      <i class="pi pi-bookmark text-xs" aria-hidden="true"></i>
+                      <span>{{ libraryStatusLabel(slotProps.data.status) }}</span>
+                    </div>
+                  </div>
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('description')" class="min-w-[18rem]">
+                <template #header>
+                  <span class="library-header-label">Description</span>
+                </template>
+                <template #body="slotProps">
+                  <p
+                    class="library-description line-clamp-2 text-sm text-[var(--p-text-muted-color)]"
+                    data-test="library-item-description"
+                    v-html="renderDescriptionSnippet(slotProps.data.work_description)"
+                  />
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('rating')" class="min-w-[12rem]">
+                <template #header>
+                  <button
+                    type="button"
+                    class="library-sort-trigger"
+                    data-test="library-table-sort-rating"
+                    @click="toggleRatingSort"
+                  >
+                    Rating
+                    <i :class="ratingSortIcon" aria-hidden="true"></i>
+                  </button>
+                </template>
+                <template #body="slotProps">
+                  <div class="flex justify-center">
+                    <Rating
+                      :model-value="ratingValue(slotProps.data.rating)"
+                      :stars="5"
+                      readonly
+                      :cancel="false"
+                      class="text-xs"
+                      data-test="library-item-rating"
+                    />
+                  </div>
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('tags')" class="min-w-[10rem]">
+                <template #header>
+                  <span class="library-header-label">Tags</span>
+                </template>
+                <template #body="slotProps">
+                  <div class="flex flex-wrap items-center gap-1">
+                    <div
+                      v-for="tag in visibleTags(slotProps.data.tags, 2)"
+                      :key="`${slotProps.data.id}-${tag}`"
+                      class="library-meta-chip"
+                    >
+                      {{ tag }}
+                    </div>
+                    <span
+                      v-if="remainingTagCount(slotProps.data.tags, 2)"
+                      class="text-xs text-[var(--p-text-muted-color)]"
+                    >
+                      +{{ remainingTagCount(slotProps.data.tags, 2) }}
+                    </span>
+                    <span
+                      v-if="!visibleTags(slotProps.data.tags, 2).length"
+                      class="text-xs text-[var(--p-text-muted-color)]"
+                    >
+                      —
+                    </span>
+                  </div>
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('recommendations')" class="min-w-[10rem]">
+                <template #header>
+                  <span class="library-header-label">Friends recs</span>
+                </template>
+                <template #body="slotProps">
+                  <div class="library-meta-chip" data-test="library-item-recs">
+                    <i class="pi pi-users text-xs" aria-hidden="true"></i>
+                    <span>{{
+                      recommendationLabel(slotProps.data.friend_recommendations_count)
+                    }}</span>
+                  </div>
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('last_read')" class="min-w-[8rem]">
+                <template #header>
+                  <span class="library-header-label">Last read</span>
+                </template>
+                <template #body="slotProps">
+                  {{ formatLastReadAt(slotProps.data.last_read_at) }}
+                </template>
+              </Column>
+
+              <Column v-if="isColumnVisible('added')" class="min-w-[8rem]">
+                <template #header>
+                  <button
+                    type="button"
+                    class="library-sort-trigger"
+                    data-test="library-table-sort-added"
+                    @click="toggleAddedSort"
+                  >
+                    Added
+                    <i :class="addedSortIcon" aria-hidden="true"></i>
+                  </button>
+                </template>
+                <template #body="slotProps">
+                  <span class="block text-center">
+                    {{ formatCreatedAt(slotProps.data.created_at) }}
+                  </span>
+                </template>
+              </Column>
+
+              <Column class="w-[7rem] min-w-[7rem]">
+                <template #header>
+                  <span class="library-header-label">Actions</span>
+                </template>
+                <template #body="slotProps">
+                  <div class="flex justify-center">
+                    <Button
+                      icon="pi pi-trash"
+                      size="small"
+                      text
+                      severity="secondary"
+                      aria-label="Remove from library"
+                      class="opacity-70 transition-opacity hover:opacity-100"
+                      data-test="library-item-remove"
+                      @click="openRemoveConfirm(slotProps.data)"
+                    />
+                  </div>
+                </template>
+              </Column>
+            </DataTable>
+
+            <DataView
+              v-else
+              :value="displayItems"
+              :layout="viewMode === 'grid' ? 'grid' : 'list'"
+              data-test="library-data-view"
+            >
+              <template #list="slotProps">
+                <div class="grid gap-3" data-test="library-items">
+                  <div v-for="item in slotProps.items" :key="item.id" class="block">
+                    <Card class="transition-shadow duration-200 hover:shadow-md">
+                      <template #content>
+                        <div
+                          class="grid grid-cols-1 gap-3 md:h-[16rem] md:grid-cols-[10.75rem_minmax(0,1fr)_auto] md:items-stretch md:gap-4"
+                        >
+                          <div
+                            class="mx-auto h-[168px] w-[112px] shrink-0 overflow-hidden rounded-lg border border-[var(--p-content-border-color)] md:mx-0 md:h-full md:w-full"
+                          >
+                            <Image
+                              v-if="item.cover_url"
+                              :src="item.cover_url"
+                              alt=""
+                              :preview="false"
+                              class="h-full w-full"
+                              image-class="h-full w-full object-contain"
+                              data-test="library-item-cover"
+                            />
+                            <CoverPlaceholder v-else data-test="library-item-cover-placeholder" />
+                          </div>
+
+                          <div class="min-w-0 flex min-h-[168px] flex-col">
+                            <NuxtLink
+                              :to="`/books/${item.work_id}`"
+                              class="line-clamp-2 font-serif text-lg font-semibold tracking-tight text-primary no-underline hover:underline focus-visible:underline"
+                              data-test="library-item-title-link"
+                            >
+                              {{ item.work_title }}
+                            </NuxtLink>
+                            <p
+                              v-if="item.author_names?.length"
+                              class="mt-0.5 truncate text-sm text-[var(--p-text-muted-color)]"
+                            >
+                              {{ item.author_names.join(', ') }}
+                            </p>
+                            <p
+                              class="library-description mt-1 line-clamp-6 overflow-hidden text-sm text-[var(--p-text-muted-color)]"
+                              data-test="library-item-description"
+                              v-html="renderDescriptionSnippet(item.work_description)"
+                            />
+                            <div
+                              class="mt-auto flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-[var(--p-content-border-color)]/60 pt-2"
+                            >
+                              <div class="library-meta-chip" data-test="library-item-status-chip">
+                                <i class="pi pi-bookmark text-xs" aria-hidden="true"></i>
+                                <span>{{ libraryStatusLabel(item.status) }}</span>
+                              </div>
+                              <div
+                                class="flex min-w-[7rem] flex-col items-center justify-center gap-0.5 text-center text-xs"
+                                data-test="library-item-rating"
+                              >
+                                <Rating
+                                  :model-value="ratingValue(item.rating)"
+                                  :stars="5"
+                                  readonly
+                                  :cancel="false"
+                                  class="text-xs"
+                                />
+                                <span
+                                  class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--p-text-muted-color)]"
+                                >
+                                  Rating
+                                </span>
+                              </div>
+                              <div class="library-meta-chip" data-test="library-item-recs">
+                                <i class="pi pi-users text-xs" aria-hidden="true"></i>
+                                <span>{{
+                                  recommendationLabel(item.friend_recommendations_count)
+                                }}</span>
+                              </div>
+                              <div
+                                v-for="tag in visibleTags(item.tags, 2)"
+                                :key="`${item.id}-${tag}`"
+                                class="library-meta-chip"
+                              >
+                                {{ tag }}
+                              </div>
+                              <div v-if="remainingTagCount(item.tags, 2)" class="library-meta-chip">
+                                +{{ remainingTagCount(item.tags, 2) }}
+                              </div>
+                            </div>
+                          </div>
+
+                          <div class="shrink-0 md:self-start">
+                            <Button
+                              icon="pi pi-trash"
+                              size="small"
+                              variant="text"
+                              severity="secondary"
+                              class="self-start opacity-70 transition-opacity hover:opacity-100"
+                              aria-label="Remove from library"
+                              data-test="library-item-remove"
+                              @click.stop="openRemoveConfirm(item)"
+                            />
+                          </div>
+                        </div>
+                      </template>
+                    </Card>
+                  </div>
+                </div>
+              </template>
+
+              <template #grid="slotProps">
+                <div
+                  class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                  data-test="library-items-grid"
+                >
+                  <Card
+                    v-for="item in slotProps.items"
+                    :key="item.id"
+                    class="group h-full transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
+                  >
+                    <template #content>
+                      <div class="flex h-full flex-col gap-1 pt-1">
+                        <div
+                          class="grid min-h-[10.5rem] grid-cols-2 rounded-xl bg-gradient-to-r from-black/10 via-transparent to-transparent py-2 dark:from-white/5"
+                        >
+                          <div class="flex items-start justify-center">
+                            <div
+                              class="h-[176px] w-[118px] shrink-0 overflow-hidden rounded-lg border border-[var(--p-content-border-color)] bg-black/5 dark:bg-white/5 transition-transform duration-200 group-hover:scale-[1.02]"
+                            >
+                              <Image
+                                v-if="item.cover_url"
+                                :src="item.cover_url"
+                                alt=""
+                                :preview="false"
+                                class="h-full w-full"
+                                image-class="h-full w-full object-cover"
+                                data-test="library-item-cover"
+                              />
+                              <CoverPlaceholder v-else data-test="library-item-cover-placeholder" />
+                            </div>
+                          </div>
+                          <div class="flex min-w-0 items-start justify-center">
+                            <div
+                              class="flex h-full min-h-[8.75rem] w-full flex-col justify-between pb-1"
+                            >
+                              <div class="-mt-1 flex justify-end">
+                                <Button
+                                  icon="pi pi-trash"
+                                  size="small"
+                                  variant="text"
+                                  severity="secondary"
+                                  class="opacity-70 transition-opacity hover:opacity-100"
+                                  aria-label="Remove from library"
+                                  data-test="library-item-remove"
+                                  @click.stop="openRemoveConfirm(item)"
+                                />
+                              </div>
+                              <div
+                                class="library-meta-chip mx-auto justify-center whitespace-nowrap"
+                                data-test="library-item-status-chip"
+                              >
+                                <i class="pi pi-bookmark text-xs" aria-hidden="true"></i>
+                                <span>{{ libraryStatusLabel(item.status) }}</span>
+                              </div>
+                              <div
+                                class="mx-auto flex min-w-[7rem] flex-col items-center gap-0.5 text-center text-xs"
+                                data-test="library-item-rating"
+                              >
+                                <Rating
+                                  :model-value="ratingValue(item.rating)"
+                                  :stars="5"
+                                  readonly
+                                  :cancel="false"
+                                  class="text-xs"
+                                />
+                                <span
+                                  class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--p-text-muted-color)]"
+                                >
+                                  Rating
+                                </span>
+                                <span
+                                  v-if="item.rating !== null && item.rating !== undefined"
+                                  class="text-xs text-[var(--p-text-muted-color)]"
+                                >
+                                  {{ ratingLabel(item.rating) }}
+                                </span>
+                              </div>
+                              <div
+                                class="library-meta-chip mx-auto justify-center whitespace-nowrap"
+                                data-test="library-item-recs"
+                              >
+                                <i class="pi pi-users text-xs" aria-hidden="true"></i>
+                                <span>{{
+                                  recommendationLabel(item.friend_recommendations_count)
+                                }}</span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div class="min-w-0">
+                          <NuxtLink
+                            :to="`/books/${item.work_id}`"
+                            class="line-clamp-2 block text-center font-serif text-lg font-semibold tracking-tight text-primary no-underline hover:underline focus-visible:underline"
+                            data-test="library-item-title-link"
+                          >
+                            {{ item.work_title }}
+                          </NuxtLink>
+                          <p
+                            v-if="item.author_names?.length"
+                            class="mt-0.5 truncate text-center text-sm text-[var(--p-text-muted-color)]"
+                          >
+                            {{ item.author_names.join(', ') }}
+                          </p>
+                          <div
+                            v-if="
+                              visibleTags(item.tags, 2).length > 0 ||
+                              remainingTagCount(item.tags, 2) > 0
+                            "
+                            class="mt-1 flex flex-wrap justify-center gap-1"
+                          >
+                            <div
+                              v-for="tag in visibleTags(item.tags, 2)"
+                              :key="`${item.id}-${tag}`"
+                              class="library-meta-chip"
+                            >
+                              {{ tag }}
+                            </div>
+                            <div v-if="remainingTagCount(item.tags, 2)" class="library-meta-chip">
+                              +{{ remainingTagCount(item.tags, 2) }}
+                            </div>
+                          </div>
+                        </div>
+
+                        <p
+                          class="library-description mt-0.5 line-clamp-4 text-left text-sm text-[var(--p-text-muted-color)]"
+                          data-test="library-item-description"
+                          v-html="renderDescriptionSnippet(item.work_description)"
+                        />
+                      </div>
+                    </template>
+                  </Card>
+                </div>
+              </template>
+            </DataView>
+          </template>
 
           <EmptyState
             v-else
@@ -192,6 +633,7 @@
 definePageMeta({ layout: 'app', middleware: 'auth' });
 
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import MarkdownIt from 'markdown-it';
 import { useToast } from 'primevue/usetoast';
 import { ApiClientError, apiRequest } from '~/utils/api';
 import { libraryStatusLabel } from '~/utils/libraryStatus';
@@ -199,24 +641,86 @@ import CoverPlaceholder from '~/components/CoverPlaceholder.vue';
 import EmptyState from '~/components/EmptyState.vue';
 
 const toast = useToast();
+const markdownRenderer = new MarkdownIt({
+  html: false,
+  linkify: true,
+  typographer: true,
+  breaks: true,
+});
+const EMPTY_DESCRIPTION_LABEL = 'No description available.';
+
+type LibraryViewMode = 'current' | 'grid' | 'table';
+type SortMode =
+  | 'newest'
+  | 'oldest'
+  | 'title_asc'
+  | 'title_desc'
+  | 'author_asc'
+  | 'author_desc'
+  | 'status_asc'
+  | 'status_desc'
+  | 'rating_asc'
+  | 'rating_desc';
+type TableColumnKey =
+  | 'cover'
+  | 'title'
+  | 'author'
+  | 'status'
+  | 'description'
+  | 'rating'
+  | 'tags'
+  | 'recommendations'
+  | 'last_read'
+  | 'added';
 
 type LibraryItem = {
   id: string;
   work_id: string;
   work_title: string;
+  work_description?: string | null;
+  friend_recommendations_count?: number | null;
   author_names?: string[];
   cover_url?: string | null;
   status: string;
   visibility: string;
+  rating?: number | null;
   tags?: string[];
+  last_read_at?: string | null;
   created_at?: string;
 };
+
 const LIBRARY_UPDATED_EVENT = 'chapterverse:library-updated';
+const VIEW_MODE_STORAGE_KEY = 'seedbed.library.viewMode';
+const TABLE_COLUMNS_STORAGE_KEY = 'seedbed.library.tableColumns';
+const ALL_TABLE_COLUMNS = [
+  'cover',
+  'title',
+  'author',
+  'status',
+  'description',
+  'rating',
+  'tags',
+  'recommendations',
+  'last_read',
+  'added',
+] as const satisfies readonly TableColumnKey[];
+const DEFAULT_TABLE_COLUMNS = [
+  'cover',
+  'title',
+  'author',
+  'status',
+  'description',
+  'rating',
+  'tags',
+  'added',
+] as const satisfies readonly TableColumnKey[];
 
 const items = ref<LibraryItem[]>([]);
+const viewMode = ref<LibraryViewMode>('current');
 const statusFilter = ref<string>('');
 const tagFilter = ref('');
-const sortMode = ref<'newest' | 'oldest' | 'title_asc'>('newest');
+const sortMode = ref<SortMode>('newest');
+const tableColumns = ref<TableColumnKey[]>([...DEFAULT_TABLE_COLUMNS]);
 const nextCursor = ref<string | null>(null);
 const loading = ref(false);
 const loadingMore = ref(false);
@@ -225,6 +729,12 @@ const error = ref('');
 const pendingRemoveItem = ref<LibraryItem | null>(null);
 const removeConfirmOpen = ref(false);
 const removeConfirmLoading = ref(false);
+
+const viewModeOptions = [
+  { label: 'List', value: 'current' },
+  { label: 'Grid', value: 'grid' },
+  { label: 'Table', value: 'table' },
+] satisfies Array<{ label: string; value: LibraryViewMode }>;
 
 const statusFilters = [
   { label: 'All statuses', value: '' },
@@ -237,7 +747,209 @@ const sortOptions = [
   { label: 'Newest first', value: 'newest' },
   { label: 'Oldest first', value: 'oldest' },
   { label: 'Title A-Z', value: 'title_asc' },
-];
+  { label: 'Title Z-A', value: 'title_desc' },
+  { label: 'Author A-Z', value: 'author_asc' },
+  { label: 'Author Z-A', value: 'author_desc' },
+  { label: 'Status A-Z', value: 'status_asc' },
+  { label: 'Status Z-A', value: 'status_desc' },
+  { label: 'Rating low-high', value: 'rating_asc' },
+  { label: 'Rating high-low', value: 'rating_desc' },
+] satisfies Array<{ label: string; value: SortMode }>;
+
+const tableColumnOptions = [
+  { label: 'Cover', value: 'cover' },
+  { label: 'Title', value: 'title' },
+  { label: 'Author', value: 'author' },
+  { label: 'Status', value: 'status' },
+  { label: 'Description', value: 'description' },
+  { label: 'Rating', value: 'rating' },
+  { label: 'Tags', value: 'tags' },
+  { label: 'Recommendations', value: 'recommendations' },
+  { label: 'Last read', value: 'last_read' },
+  { label: 'Added', value: 'added' },
+] satisfies Array<{ label: string; value: TableColumnKey }>;
+
+const isLibraryViewMode = (value: string): value is LibraryViewMode =>
+  value === 'current' || value === 'grid' || value === 'table';
+
+const isTableColumnKey = (value: string): value is TableColumnKey =>
+  (ALL_TABLE_COLUMNS as readonly string[]).includes(value);
+
+const readStoredViewMode = (): LibraryViewMode => {
+  const storage = globalThis.localStorage;
+  if (!storage || typeof storage.getItem !== 'function') {
+    return 'current';
+  }
+
+  try {
+    const raw = storage.getItem(VIEW_MODE_STORAGE_KEY);
+    return raw && isLibraryViewMode(raw) ? raw : 'current';
+  } catch {
+    return 'current';
+  }
+};
+
+const writeStoredViewMode = (next: LibraryViewMode) => {
+  const storage = globalThis.localStorage;
+  if (!storage || typeof storage.setItem !== 'function') {
+    return;
+  }
+
+  try {
+    storage.setItem(VIEW_MODE_STORAGE_KEY, next);
+  } catch {
+    // Best-effort only.
+  }
+};
+
+const normalizeStoredColumns = (value: unknown): TableColumnKey[] => {
+  if (!Array.isArray(value)) return [...DEFAULT_TABLE_COLUMNS];
+  const valid = value.filter((entry): entry is TableColumnKey =>
+    typeof entry === 'string' ? isTableColumnKey(entry) : false,
+  );
+  return valid.length ? valid : [...DEFAULT_TABLE_COLUMNS];
+};
+
+const readStoredTableColumns = (): TableColumnKey[] => {
+  const storage = globalThis.localStorage;
+  if (!storage || typeof storage.getItem !== 'function') {
+    return [...DEFAULT_TABLE_COLUMNS];
+  }
+
+  try {
+    const raw = storage.getItem(TABLE_COLUMNS_STORAGE_KEY);
+    if (!raw) return [...DEFAULT_TABLE_COLUMNS];
+    return normalizeStoredColumns(JSON.parse(raw));
+  } catch {
+    return [...DEFAULT_TABLE_COLUMNS];
+  }
+};
+
+const writeStoredTableColumns = (next: TableColumnKey[]) => {
+  const storage = globalThis.localStorage;
+  if (!storage || typeof storage.setItem !== 'function') {
+    return;
+  }
+
+  try {
+    storage.setItem(TABLE_COLUMNS_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Best-effort only.
+  }
+};
+
+const isColumnVisible = (key: TableColumnKey) => tableColumns.value.includes(key);
+
+const titleSortIcon = computed(() => {
+  if (sortMode.value === 'title_asc') return 'pi pi-sort-alpha-down';
+  if (sortMode.value === 'title_desc') return 'pi pi-sort-alpha-up-alt';
+  return 'pi pi-sort-alt';
+});
+
+const authorSortIcon = computed(() => {
+  if (sortMode.value === 'author_asc') return 'pi pi-sort-alpha-down';
+  if (sortMode.value === 'author_desc') return 'pi pi-sort-alpha-up-alt';
+  return 'pi pi-sort-alt';
+});
+
+const statusSortIcon = computed(() => {
+  if (sortMode.value === 'status_asc') return 'pi pi-sort-alpha-down';
+  if (sortMode.value === 'status_desc') return 'pi pi-sort-alpha-up-alt';
+  return 'pi pi-sort-alt';
+});
+
+const ratingSortIcon = computed(() => {
+  if (sortMode.value === 'rating_asc') return 'pi pi-sort-amount-up';
+  if (sortMode.value === 'rating_desc') return 'pi pi-sort-amount-down';
+  return 'pi pi-sort-alt';
+});
+
+const addedSortIcon = computed(() => {
+  if (sortMode.value === 'newest') return 'pi pi-sort-amount-down';
+  if (sortMode.value === 'oldest') return 'pi pi-sort-amount-up';
+  return 'pi pi-sort-alt';
+});
+
+const formatCreatedAt = (value?: string) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString();
+};
+
+const formatLastReadAt = (value?: string | null) => formatCreatedAt(value ?? undefined);
+
+const descriptionSnippet = (value?: string | null) => {
+  if (!value) return EMPTY_DESCRIPTION_LABEL;
+  const normalized = value.trim();
+  return normalized || EMPTY_DESCRIPTION_LABEL;
+};
+
+const renderDescriptionSnippet = (value?: string | null) => {
+  const snippet = descriptionSnippet(value);
+  if (snippet === EMPTY_DESCRIPTION_LABEL) return snippet;
+  return markdownRenderer.renderInline(snippet);
+};
+
+const ratingValue = (value?: number | null) => {
+  if (typeof value !== 'number') return 0;
+  return Math.max(0, Math.min(5, Math.round(value / 2)));
+};
+
+const ratingLabel = (value?: number | null) => {
+  if (typeof value !== 'number') return 'No rating';
+  return `${value}/10`;
+};
+
+const visibleTags = (tags?: string[], max = 2) => (tags || []).slice(0, max);
+
+const remainingTagCount = (tags?: string[], max = 2) => Math.max(0, (tags || []).length - max);
+
+const recommendationLabel = (value?: number | null) => {
+  if (typeof value !== 'number') return 'No recs';
+  if (value <= 0) return '0 recs';
+  if (value === 1) return '1 rec';
+  return `${value} recs`;
+};
+
+const toggleTitleSort = () => {
+  sortMode.value = sortMode.value === 'title_asc' ? 'title_desc' : 'title_asc';
+};
+
+const toggleAddedSort = () => {
+  sortMode.value = sortMode.value === 'newest' ? 'oldest' : 'newest';
+};
+
+const toggleAuthorSort = () => {
+  sortMode.value = sortMode.value === 'author_asc' ? 'author_desc' : 'author_asc';
+};
+
+const toggleStatusSort = () => {
+  sortMode.value = sortMode.value === 'status_asc' ? 'status_desc' : 'status_asc';
+};
+
+const toggleRatingSort = () => {
+  sortMode.value = sortMode.value === 'rating_asc' ? 'rating_desc' : 'rating_asc';
+};
+
+const firstAuthor = (item: LibraryItem) => item.author_names?.[0] ?? 'Unknown author';
+
+const sortComparators = {
+  newest: (a, b) => (b.created_at || '').localeCompare(a.created_at || ''),
+  oldest: (a, b) => (a.created_at || '').localeCompare(b.created_at || ''),
+  title_asc: (a, b) => a.work_title.localeCompare(b.work_title),
+  title_desc: (a, b) => b.work_title.localeCompare(a.work_title),
+  author_asc: (a, b) => firstAuthor(a).localeCompare(firstAuthor(b)),
+  author_desc: (a, b) => firstAuthor(b).localeCompare(firstAuthor(a)),
+  status_asc: (a, b) => libraryStatusLabel(a.status).localeCompare(libraryStatusLabel(b.status)),
+  status_desc: (a, b) => libraryStatusLabel(b.status).localeCompare(libraryStatusLabel(a.status)),
+  rating_asc: (a, b) =>
+    Number((a.rating ?? Number.POSITIVE_INFINITY) > (b.rating ?? Number.POSITIVE_INFINITY)) -
+    Number((a.rating ?? Number.POSITIVE_INFINITY) < (b.rating ?? Number.POSITIVE_INFINITY)),
+  rating_desc: (a, b) =>
+    Number((b.rating ?? Number.NEGATIVE_INFINITY) > (a.rating ?? Number.NEGATIVE_INFINITY)) -
+    Number((b.rating ?? Number.NEGATIVE_INFINITY) < (a.rating ?? Number.NEGATIVE_INFINITY)),
+} as const;
 
 const displayItems = computed(() => {
   const tag = tagFilter.value.trim().toLowerCase();
@@ -249,13 +961,7 @@ const displayItems = computed(() => {
   }
 
   const sorted = [...filtered];
-  if (sortMode.value === 'title_asc') {
-    sorted.sort((a, b) => a.work_title.localeCompare(b.work_title));
-  } else if (sortMode.value === 'oldest') {
-    sorted.sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
-  } else {
-    sorted.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
-  }
+  sorted.sort(sortComparators[sortMode.value]);
   return sorted;
 });
 
@@ -343,11 +1049,21 @@ watch(statusFilter, () => {
   void fetchPage(false);
 });
 
+watch(viewMode, (next) => {
+  writeStoredViewMode(next);
+});
+
+watch(tableColumns, (next) => {
+  writeStoredTableColumns(next);
+});
+
 const onLibraryUpdated = () => {
   void fetchPage(false);
 };
 
 onMounted(() => {
+  viewMode.value = readStoredViewMode();
+  tableColumns.value = readStoredTableColumns();
   window.addEventListener(LIBRARY_UPDATED_EVENT, onLibraryUpdated);
   void fetchPage(false);
 });
@@ -356,3 +1072,92 @@ onBeforeUnmount(() => {
   window.removeEventListener(LIBRARY_UPDATED_EVENT, onLibraryUpdated);
 });
 </script>
+
+<style scoped>
+.library-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in oklab, var(--p-content-border-color) 70%, transparent);
+  background: color-mix(in oklab, var(--p-content-border-color) 20%, transparent);
+  padding: 0.12rem 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--p-text-muted-color);
+}
+
+.library-table :deep(.p-datatable-thead > tr > th) {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.library-table :deep(.p-datatable-thead > tr > th .p-column-header-content) {
+  align-items: center;
+  justify-content: center;
+}
+
+.library-table :deep(.p-datatable-thead > tr > th .p-datatable-column-header-content) {
+  align-items: center;
+  justify-content: center;
+}
+
+.library-table :deep(tbody > tr > td) {
+  vertical-align: middle;
+}
+
+.library-sort-trigger {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font-family: 'Avenir Next', Avenir, 'Atkinson Hyperlegible', ui-sans-serif, system-ui, sans-serif;
+  font-size: inherit;
+  font-style: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.library-header-label {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Avenir Next', Avenir, 'Atkinson Hyperlegible', ui-sans-serif, system-ui, sans-serif;
+  font-size: inherit;
+  font-style: inherit;
+  letter-spacing: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.library-description :deep(strong) {
+  color: var(--p-text-color);
+  font-weight: 600;
+}
+
+.library-description :deep(a) {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted currentColor;
+}
+
+.library-description :deep(a:hover),
+.library-description :deep(a:focus-visible) {
+  border-bottom-style: solid;
+}
+
+.library-description :deep(code) {
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.3rem;
+  background: color-mix(in oklab, var(--p-content-border-color) 35%, transparent);
+  font-size: 0.92em;
+}
+</style>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@primeuix/themes": "^2.0.3",
     "@primevue/nuxt-module": "^4.3.3",
     "@supabase/supabase-js": "^2.56.1",
+    "markdown-it": "^14.1.1",
     "nuxt": "^4.2.2",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.3",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.56.1
         version: 2.89.0
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
       nuxt:
         specifier: ^4.2.2
         version: 4.2.2(@parcel/watcher@2.5.1)(@types/node@25.0.3)(@vue/compiler-sfc@3.5.26)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.8.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.54.0)(terser@5.44.1)(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
@@ -3351,6 +3354,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   listhen@1.9.0:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
@@ -3431,6 +3437,10 @@ packages:
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3440,6 +3450,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -4121,6 +4134,10 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4685,6 +4702,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -8625,6 +8645,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   listhen@1.9.0:
     dependencies:
       '@parcel/watcher': 2.5.1
@@ -8733,11 +8757,22 @@ snapshots:
 
   map-stream@0.1.0: {}
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -9580,6 +9615,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   qs@6.14.0:
@@ -10195,6 +10232,8 @@ snapshots:
   type-level-regexp@0.1.17: {}
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.1: {}
 

--- a/apps/web/tests/unit/components/app-breadcrumbs.test.ts
+++ b/apps/web/tests/unit/components/app-breadcrumbs.test.ts
@@ -78,7 +78,7 @@ describe('AppBreadcrumbs', () => {
 
     routeState.path = '/library';
     await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="item-Library"]').text()).toContain('Library');
+    expect(wrapper.find('[data-test="item-Library"]').exists()).toBe(false);
     expect(wrapper.get('[data-test="home"]').findAll('a').length).toBe(0);
 
     routeState.path = '/books/search';

--- a/apps/web/tests/unit/layouts/layouts.test.ts
+++ b/apps/web/tests/unit/layouts/layouts.test.ts
@@ -44,47 +44,29 @@ describe('layouts', () => {
     }
   });
 
-  it('renders app layout and includes the sidebar shell components', async () => {
+  it('renders app layout shell without the left nav section', async () => {
     authReadyRef.value = true;
-    const AppSidebarStub = defineComponent({
-      name: 'AppSidebar',
-      props: ['visible'],
-      emits: ['update:visible'],
-      template: '<div data-test="sidebar">visible={{ visible }}</div>',
-    });
+    routeState.path = '/library';
 
     const wrapper = mount(AppLayout as any, {
       slots: { default: SlotContent },
       global: {
         stubs: {
-          AppTopBar: {
-            template: '<button data-test="topbar" @click="$emit(\'toggleSidebar\')"></button>',
-          },
-          AppSidebar: AppSidebarStub,
+          AppTopBar: { template: '<div data-test="topbar" />' },
           AppBreadcrumbs: { template: '<div data-test="crumbs" />' },
-          AppNavMenu: { template: '<div data-test="navmenu" />' },
           NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
-          Button: { template: '<div><slot :class="`p-button`" /></div>' },
-          Card: { template: '<div data-test="card"><slot name="content" /></div>' },
         },
       },
     });
 
     expect(wrapper.get('[data-test="topbar"]').exists()).toBe(true);
-    expect(wrapper.get('[data-test="sidebar"]').exists()).toBe(true);
     expect(wrapper.get('[data-test="crumbs"]').exists()).toBe(true);
-    expect(wrapper.get('[data-test="navmenu"]').exists()).toBe(true);
     expect(wrapper.get('[data-test="slot"]').exists()).toBe(true);
+    expect(wrapper.get('main').classes()).toContain('max-w-none');
 
-    expect(wrapper.get('[data-test="sidebar"]').text()).toContain('visible=false');
-    await wrapper.get('[data-test="topbar"]').trigger('click');
+    routeState.path = '/books/search';
     await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="sidebar"]').text()).toContain('visible=true');
-
-    // Exercise the v-model update handler in the layout.
-    wrapper.findComponent(AppSidebarStub).vm.$emit('update:visible', false);
-    await wrapper.vm.$nextTick();
-    expect(wrapper.get('[data-test="sidebar"]').text()).toContain('visible=false');
+    expect(wrapper.get('main').classes()).toContain('max-w-6xl');
   });
 
   it('shows an auth bootstrap loading state while auth is unknown', () => {
@@ -95,10 +77,7 @@ describe('layouts', () => {
       global: {
         stubs: {
           AppTopBar: { template: '<div data-test="topbar" />' },
-          AppSidebar: { template: '<div data-test="sidebar" />' },
           AppBreadcrumbs: { template: '<div data-test="crumbs" />' },
-          AppNavMenu: { template: '<div data-test="navmenu" />' },
-          Card: { template: '<div data-test="card"><slot name="content" /></div>' },
         },
       },
     });

--- a/apps/web/tests/unit/pages/library.test.ts
+++ b/apps/web/tests/unit/pages/library.test.ts
@@ -1,5 +1,13 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import PrimeVue from 'primevue/config';
+import Badge from 'primevue/badge';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+import DataView from 'primevue/dataview';
+import Image from 'primevue/image';
+import MultiSelect from 'primevue/multiselect';
+import Rating from 'primevue/rating';
+import SelectButton from 'primevue/selectbutton';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({
@@ -37,10 +45,39 @@ vi.mock('#imports', () => ({
 
 import LibraryPage from '../../../app/pages/library/index.vue';
 
+const installLocalStorageMock = () => {
+  const storage: Record<string, string> = {};
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (key in storage ? storage[key] : null),
+      setItem: (key: string, value: string) => {
+        storage[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete storage[key];
+      },
+      clear: () => {
+        Object.keys(storage).forEach((key) => delete storage[key]);
+      },
+    },
+  });
+};
+
 const mountPage = () =>
   mount(LibraryPage, {
     global: {
       plugins: [[PrimeVue, { ripple: false }]],
+      components: {
+        Badge,
+        Column,
+        DataTable,
+        DataView,
+        Image,
+        MultiSelect,
+        Rating,
+        SelectButton,
+      },
       stubs: {
         NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
         Dialog: {
@@ -79,9 +116,11 @@ const mountPage = () =>
 
 describe('library page', () => {
   beforeEach(() => {
+    installLocalStorageMock();
     apiRequest.mockReset();
     toastAdd.mockReset();
     state.route = { fullPath: '/library' };
+    globalThis.localStorage?.clear();
   });
 
   it('loads library items on mount', async () => {
@@ -109,7 +148,7 @@ describe('library page', () => {
       query: { limit: 10, cursor: undefined, status: undefined },
     });
     expect(wrapper.text()).toContain('Book A');
-    expect(wrapper.findAll('[data-test="library-item-cover"]').length).toBe(1);
+    expect(wrapper.findAll('[data-test="library-item-cover"]').length).toBeGreaterThan(0);
   });
 
   it('loads next page when load more is clicked', async () => {
@@ -234,6 +273,207 @@ describe('library page', () => {
     expect(removeSpy).toHaveBeenCalledWith('chapterverse:library-updated', expect.any(Function));
   });
 
+  it('renders view mode selector with all three options', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const viewSelect = wrapper.get('[data-test="library-view-select"]');
+    expect(viewSelect.text()).toContain('List');
+    expect(viewSelect.text()).toContain('Grid');
+    expect(viewSelect.text()).toContain('Table');
+    expect((wrapper.vm as any).viewMode).toBe('current');
+  });
+
+  it('updates view mode via SelectButton v-model event', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const selectButton = wrapper.findComponent(SelectButton);
+    selectButton.vm.$emit('update:modelValue', 'grid');
+    await flushPromises();
+
+    expect((wrapper.vm as any).viewMode).toBe('grid');
+  });
+
+  it('restores persisted view mode from localStorage', async () => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.setItem === 'function') {
+      globalThis.localStorage.setItem('seedbed.library.viewMode', 'table');
+    }
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).viewMode).toBe('table');
+  });
+
+  it('falls back to current view when persisted view mode is invalid', async () => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.setItem === 'function') {
+      globalThis.localStorage.setItem('seedbed.library.viewMode', 'bad-value');
+    }
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).viewMode).toBe('current');
+  });
+
+  it('persists view mode changes', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'grid';
+    await flushPromises();
+
+    if (globalThis.localStorage && typeof globalThis.localStorage.getItem === 'function') {
+      expect(globalThis.localStorage.getItem('seedbed.library.viewMode')).toBe('grid');
+    }
+  });
+
+  it('uses curated default table columns when storage is empty', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).tableColumns).toEqual([
+      'cover',
+      'title',
+      'author',
+      'status',
+      'description',
+      'rating',
+      'tags',
+      'added',
+    ]);
+  });
+
+  it('restores persisted table columns from localStorage', async () => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.setItem === 'function') {
+      globalThis.localStorage.setItem(
+        'seedbed.library.tableColumns',
+        JSON.stringify(['title', 'author', 'last_read', 'added']),
+      );
+    }
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).tableColumns).toEqual(['title', 'author', 'last_read', 'added']);
+  });
+
+  it('falls back to default table columns when persisted columns are invalid', async () => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.setItem === 'function') {
+      globalThis.localStorage.setItem('seedbed.library.tableColumns', JSON.stringify(['invalid']));
+    }
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).tableColumns).toEqual([
+      'cover',
+      'title',
+      'author',
+      'status',
+      'description',
+      'rating',
+      'tags',
+      'added',
+    ]);
+  });
+
+  it('persists table columns when changed', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).tableColumns = ['title', 'added'];
+    await flushPromises();
+
+    if (globalThis.localStorage && typeof globalThis.localStorage.getItem === 'function') {
+      expect(globalThis.localStorage.getItem('seedbed.library.tableColumns')).toBe(
+        JSON.stringify(['title', 'added']),
+      );
+    }
+  });
+
+  it('defaults to current when localStorage.getItem is unavailable', async () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {},
+    });
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).viewMode).toBe('current');
+  });
+
+  it('defaults to current when reading persisted view mode throws', async () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => {
+          throw new Error('storage read error');
+        },
+      },
+    });
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).viewMode).toBe('current');
+  });
+
+  it('ignores storage write when setItem is unavailable', async () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => 'current',
+      },
+    });
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(() => {
+      (wrapper.vm as any).viewMode = 'grid';
+    }).not.toThrow();
+  });
+
+  it('ignores storage write errors when persisting view mode', async () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => 'current',
+        setItem: () => {
+          throw new Error('storage write error');
+        },
+      },
+    });
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(() => {
+      (wrapper.vm as any).viewMode = 'grid';
+    }).not.toThrow();
+  });
+
   it('filters by tag substring (case-insensitive)', async () => {
     apiRequest.mockResolvedValueOnce({
       items: [
@@ -324,6 +564,586 @@ describe('library page', () => {
     expect(titles[1]).toContain('Zoo Book');
   });
 
+  it('renders table columns and supports table header sorting', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Zoo Book',
+          work_description: 'Zoo description',
+          author_names: ['Zed Author'],
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          rating: 4,
+          friend_recommendations_count: 2,
+          tags: ['Favorites'],
+          created_at: '2026-02-08T00:00:00Z',
+        },
+        {
+          id: 'item-2',
+          work_id: 'work-2',
+          work_title: 'Alpha Book',
+          work_description: 'Alpha description',
+          author_names: ['Alice Author'],
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          rating: 3,
+          friend_recommendations_count: null,
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'table';
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Status');
+    expect(wrapper.text()).toContain('Rating');
+    expect(wrapper.text()).toContain('Tags');
+    expect(wrapper.text()).not.toContain('Friends recs');
+    expect(wrapper.text()).toContain('Added');
+    expect(wrapper.text()).toContain('Actions');
+    expect(wrapper.text()).toContain('Zoo description');
+
+    (wrapper.vm as any).tableColumns = [
+      'title',
+      'author',
+      'status',
+      'rating',
+      'recommendations',
+      'added',
+    ];
+    await flushPromises();
+    expect(wrapper.text()).toContain('Friends recs');
+    expect(wrapper.text()).toContain('2 recs');
+
+    await wrapper.get('[data-test="library-table-sort-title"]').trigger('click');
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('title_asc');
+    let items = wrapper.findAll('[data-test="library-item-title-link"]');
+    expect(items[0]?.text()).toContain('Alpha Book');
+
+    await wrapper.get('[data-test="library-table-sort-title"]').trigger('click');
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('title_desc');
+    items = wrapper.findAll('[data-test="library-item-title-link"]');
+    expect(items[0]?.text()).toContain('Zoo Book');
+
+    await wrapper.get('[data-test="library-table-sort-author"]').trigger('click');
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('author_asc');
+    items = wrapper.findAll('[data-test="library-item-title-link"]');
+    expect(items[0]?.text()).toContain('Alpha Book');
+
+    await wrapper.get('[data-test="library-table-sort-status"]').trigger('click');
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('status_asc');
+    items = wrapper.findAll('[data-test="library-item-title-link"]');
+    expect(items[0]?.text()).toContain('Alpha Book');
+
+    await wrapper.get('[data-test="library-table-sort-rating"]').trigger('click');
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('rating_asc');
+    items = wrapper.findAll('[data-test="library-item-title-link"]');
+    expect(items[0]?.text()).toContain('Alpha Book');
+
+    (wrapper.vm as any).sortMode = 'newest';
+    (wrapper.vm as any).toggleAddedSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('oldest');
+
+    (wrapper.vm as any).tableColumns = ['title', 'author', 'added'];
+    await flushPromises();
+    expect(wrapper.text()).not.toContain('Status');
+  });
+
+  it('shows columns picker in table mode only', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="library-columns-select"]').exists()).toBe(false);
+    (wrapper.vm as any).viewMode = 'table';
+    await flushPromises();
+    expect(wrapper.find('[data-test="library-columns-select"]').exists()).toBe(true);
+  });
+
+  it('renders columns picker on initial mount when persisted view mode is table', async () => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.setItem === 'function') {
+      globalThis.localStorage.setItem('seedbed.library.viewMode', 'table');
+    }
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="library-columns-select"]').exists()).toBe(true);
+  });
+
+  it('updates table columns via MultiSelect v-model event', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'table';
+    await flushPromises();
+
+    const multiSelect = wrapper.findComponent(MultiSelect);
+    multiSelect.vm.$emit('update:modelValue', ['title', 'added']);
+    await flushPromises();
+
+    expect((wrapper.vm as any).tableColumns).toEqual(['title', 'added']);
+  });
+
+  it('renders last read column when enabled', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Last Read Book',
+          work_description: 'Description',
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          rating: 7,
+          tags: [],
+          last_read_at: '2026-02-11T00:00:00Z',
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'table';
+    (wrapper.vm as any).tableColumns = ['title', 'last_read', 'added'];
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Last read');
+    expect(wrapper.text()).toContain((wrapper.vm as any).formatLastReadAt('2026-02-11T00:00:00Z'));
+  });
+
+  it('returns fallback date glyph and icon defaults for non-matching sort modes', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).formatCreatedAt()).toBe('—');
+    expect((wrapper.vm as any).formatCreatedAt('not-a-date')).toBe('—');
+    expect((wrapper.vm as any).descriptionSnippet('   ')).toBe('No description available.');
+    expect((wrapper.vm as any).recommendationLabel(0)).toBe('0 recs');
+    expect((wrapper.vm as any).recommendationLabel(1)).toBe('1 rec');
+    expect((wrapper.vm as any).recommendationLabel(3)).toBe('3 recs');
+    expect((wrapper.vm as any).ratingValue(11)).toBe(5);
+    expect((wrapper.vm as any).ratingValue(-1)).toBe(0);
+
+    (wrapper.vm as any).sortMode = 'newest';
+    await flushPromises();
+    expect((wrapper.vm as any).titleSortIcon).toBe('pi pi-sort-alt');
+
+    (wrapper.vm as any).sortMode = 'title_asc';
+    await flushPromises();
+    expect((wrapper.vm as any).addedSortIcon).toBe('pi pi-sort-alt');
+
+    (wrapper.vm as any).sortMode = 'newest';
+    await flushPromises();
+    expect((wrapper.vm as any).authorSortIcon).toBe('pi pi-sort-alt');
+    expect((wrapper.vm as any).statusSortIcon).toBe('pi pi-sort-alt');
+    expect((wrapper.vm as any).ratingSortIcon).toBe('pi pi-sort-alt');
+  });
+
+  it('covers extended table sort modes and toggle helpers', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Gamma',
+          author_names: ['Zed'],
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          rating: null,
+          tags: [],
+          created_at: '2026-02-08T00:00:00Z',
+        },
+        {
+          id: 'item-2',
+          work_id: 'work-2',
+          work_title: 'Beta',
+          author_names: ['Alice'],
+          cover_url: null,
+          status: 'completed',
+          visibility: 'private',
+          rating: 9,
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+        {
+          id: 'item-3',
+          work_id: 'work-3',
+          work_title: 'Alpha',
+          author_names: undefined,
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          rating: 3,
+          tags: [],
+          created_at: '2026-02-10T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).sortMode = 'author_desc';
+    await flushPromises();
+    expect((wrapper.vm as any).displayItems[0].work_title).toBe('Gamma');
+
+    (wrapper.vm as any).sortMode = 'status_desc';
+    await flushPromises();
+    expect((wrapper.vm as any).displayItems[0].status).toBe('to_read');
+
+    (wrapper.vm as any).sortMode = 'rating_desc';
+    await flushPromises();
+    expect((wrapper.vm as any).displayItems[0].work_title).toBe('Beta');
+
+    (wrapper.vm as any).sortMode = 'rating_asc';
+    await flushPromises();
+    expect((wrapper.vm as any).displayItems[0].work_title).toBe('Alpha');
+
+    (wrapper.vm as any).toggleAuthorSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('author_asc');
+    (wrapper.vm as any).toggleAuthorSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('author_desc');
+
+    (wrapper.vm as any).toggleStatusSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('status_asc');
+    (wrapper.vm as any).toggleStatusSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('status_desc');
+
+    (wrapper.vm as any).toggleRatingSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('rating_asc');
+    (wrapper.vm as any).toggleRatingSort();
+    await flushPromises();
+    expect((wrapper.vm as any).sortMode).toBe('rating_desc');
+  });
+
+  it('covers comparator map and helper branches used by table sorting', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const vm = wrapper.vm as any;
+    expect(vm.formatLastReadAt(null)).toBe('—');
+    expect(vm.formatLastReadAt('2026-02-11T00:00:00Z')).toBe(
+      vm.formatCreatedAt('2026-02-11T00:00:00Z'),
+    );
+    expect(vm.ratingLabel(undefined)).toBe('No rating');
+    expect(vm.ratingLabel(8)).toBe('8/10');
+
+    const a = {
+      created_at: '2026-02-09T00:00:00Z',
+      work_title: 'A',
+      author_names: ['Author A'],
+      status: 'reading',
+      rating: 4,
+    };
+    const b = {
+      created_at: '2026-02-08T00:00:00Z',
+      work_title: 'B',
+      author_names: ['Author B'],
+      status: 'to_read',
+      rating: null,
+    };
+    const c = {
+      created_at: undefined,
+      work_title: 'C',
+      author_names: undefined,
+      status: 'completed',
+      rating: undefined,
+    };
+
+    expect(vm.sortComparators.newest(a, b)).toBeLessThan(0);
+    expect(vm.sortComparators.oldest(a, b)).toBeGreaterThan(0);
+    expect(vm.sortComparators.title_asc(a, b)).toBeLessThan(0);
+    expect(vm.sortComparators.title_desc(a, b)).toBeGreaterThan(0);
+    expect(vm.sortComparators.author_asc(a, b)).toBeLessThan(0);
+    expect(vm.sortComparators.author_desc(a, b)).toBeGreaterThan(0);
+    expect(vm.sortComparators.status_asc(a, b)).toBeLessThan(0);
+    expect(vm.sortComparators.status_desc(a, b)).toBeGreaterThan(0);
+    expect(vm.sortComparators.rating_asc(a, b)).toBeLessThan(0);
+    expect(vm.sortComparators.rating_desc(a, b)).toBeLessThan(0);
+
+    expect(vm.sortComparators.newest(c, b)).toBeGreaterThan(0);
+    expect(vm.sortComparators.oldest(c, b)).toBeLessThan(0);
+    expect(vm.sortComparators.author_asc(c, b)).toBeGreaterThan(0);
+    expect(vm.sortComparators.author_desc(c, b)).toBeLessThan(0);
+    expect(vm.sortComparators.rating_asc(c, b)).toBe(0);
+    expect(vm.sortComparators.rating_desc(c, b)).toBe(0);
+
+    vm.sortMode = 'rating_desc';
+    await flushPromises();
+    expect(vm.ratingSortIcon).toBe('pi pi-sort-amount-down');
+  });
+
+  it('renders description snippets in list, grid, and table modes', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Book With Description',
+          work_description: 'A **concise** description for testing.',
+          author_names: ['Author A'],
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          rating: 8,
+          friend_recommendations_count: null,
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('A concise description for testing.');
+    expect(wrapper.find('[data-test="library-item-description"] strong').exists()).toBe(true);
+    expect(wrapper.text()).toContain('No recs');
+    expect(wrapper.find('[data-test="library-item-rating"]').text()).toContain('Rating');
+
+    (wrapper.vm as any).viewMode = 'grid';
+    await flushPromises();
+    expect(wrapper.find('[data-test="library-items-grid"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('A concise description for testing.');
+    expect(wrapper.text()).toContain('No recs');
+
+    (wrapper.vm as any).viewMode = 'table';
+    (wrapper.vm as any).tableColumns = [
+      'title',
+      'author',
+      'description',
+      'rating',
+      'recommendations',
+    ];
+    await flushPromises();
+    expect(wrapper.find('[data-test="library-items-table"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('A concise description for testing.');
+    expect(wrapper.text()).toContain('No recs');
+  });
+
+  it('escapes unsafe html in markdown descriptions', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Unsafe Description Book',
+          work_description: '<script>alert(1)</script> **bold**',
+          author_names: ['Author A'],
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="library-item-description"] script').exists()).toBe(false);
+    expect(wrapper.find('[data-test="library-item-description"] strong').exists()).toBe(true);
+    expect(wrapper.text()).toContain('<script>alert(1)</script> bold');
+  });
+
+  it('uses title-only link styling and keeps author/description as plain text', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Link Styled Title',
+          work_description: 'Description text',
+          author_names: ['Author Link'],
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          rating: null,
+          tags: ['Tag1', 'Tag2', 'Tag3'],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const titleLink = wrapper.get('[data-test="library-item-title-link"]');
+    expect(titleLink.classes()).toContain('no-underline');
+    expect(wrapper.find('[data-test="library-item-description"] a').exists()).toBe(false);
+    expect(wrapper.text()).toContain('+1');
+  });
+
+  it('renders grid mode and opens remove dialog from a grid card', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Grid Book',
+          author_names: ['Author A'],
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          tags: ['Tag1', 'Tag2'],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'grid';
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="library-items-grid"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Grid Book');
+
+    await wrapper.get('[data-test="library-item-remove"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="library-remove-dialog"]').exists()).toBe(true);
+  });
+
+  it('covers grid conditional branches for cover, author, and tags', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Grid With Cover',
+          author_names: [],
+          cover_url: 'https://example.com/cover.jpg',
+          status: 'reading',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+        {
+          id: 'item-2',
+          work_id: 'work-2',
+          work_title: 'Grid Without Cover',
+          author_names: ['Author B'],
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          tags: ['Tag1', 'Tag2'],
+          created_at: '2026-02-08T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'grid';
+    await flushPromises();
+
+    expect(wrapper.findAll('[data-test="library-item-cover"]').length).toBeGreaterThan(0);
+    expect(wrapper.findAll('[data-test="library-item-cover-placeholder"]').length).toBeGreaterThan(
+      0,
+    );
+    expect(wrapper.text()).toContain('Author B');
+  });
+
+  it('opens remove dialog from table mode actions', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Table Book',
+          author_names: [],
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'table';
+    await flushPromises();
+
+    await wrapper.get('[data-test="library-item-remove"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="library-remove-dialog"]').exists()).toBe(true);
+  });
+
+  it('renders table tag fallback dash when tags are empty', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'No Tags',
+          author_names: [],
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).viewMode = 'table';
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('—');
+  });
+
   it('sorts by oldest first when selected programmatically', async () => {
     apiRequest.mockResolvedValueOnce({
       items: [
@@ -361,6 +1181,83 @@ describe('library page', () => {
     const titles = items.map((a) => a.text());
     expect(titles[0]).toContain('Book B');
     expect(titles[1]).toContain('Book A');
+  });
+
+  it('sorts oldest first when created_at is missing', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Book Missing Date',
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          tags: [],
+        },
+        {
+          id: 'item-2',
+          work_id: 'work-2',
+          work_title: 'Book With Date',
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-08T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).sortMode = 'oldest';
+    await flushPromises();
+
+    const items = wrapper.get('[data-test="library-items"]').findAll('a');
+    const titles = items.map((a) => a.text());
+    expect(titles[0]).toContain('Book Missing Date');
+    expect(titles[1]).toContain('Book With Date');
+  });
+
+  it('sorts by title Z-A when selected programmatically', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'Alpha Book',
+          cover_url: null,
+          status: 'to_read',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+        {
+          id: 'item-2',
+          work_id: 'work-2',
+          work_title: 'Zoo Book',
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-08T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).sortMode = 'title_desc';
+    await flushPromises();
+
+    const items = wrapper.get('[data-test="library-items"]').findAll('a');
+    const titles = items.map((a) => a.text());
+    expect(titles[0]).toContain('Zoo Book');
+    expect(titles[1]).toContain('Alpha Book');
   });
 
   it('sorts even when created_at is missing (covers created_at fallback branches)', async () => {
@@ -627,6 +1524,41 @@ describe('library page', () => {
     );
   });
 
+  it('shows ApiClientError message for non-404 delete failures', async () => {
+    apiRequest
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'item-1',
+            work_id: 'work-1',
+            work_title: 'Book A',
+            author_names: [],
+            cover_url: null,
+            status: 'to_read',
+            visibility: 'private',
+            tags: [],
+            created_at: '2026-02-08T00:00:00Z',
+          },
+        ],
+        next_cursor: null,
+      })
+      .mockRejectedValueOnce(new ApiClientErrorMock('Permission denied', 'forbidden', 403));
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-test="library-item-remove"]').trigger('click');
+    await wrapper.get('[data-test="library-remove-confirm"]').trigger('click');
+    await flushPromises();
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        summary: 'Permission denied',
+      }),
+    );
+  });
+
   it('renders the remove dialog message when the pending item is null (covers nullish branches)', async () => {
     apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
 
@@ -679,5 +1611,34 @@ describe('library page', () => {
     await flushPromises();
 
     expect(wrapper.get('[data-test="library-remove-dialog"]').text()).toContain('Remove ""');
+  });
+
+  it('updates dialog visibility via v-model event', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).removeConfirmOpen = true;
+    await flushPromises();
+
+    const dialog = wrapper.findComponent({ name: 'Dialog' });
+    dialog.vm.$emit('update:visible', false);
+    await flushPromises();
+
+    expect((wrapper.vm as any).removeConfirmOpen).toBe(false);
+  });
+
+  it('toggles added sort back to newest when currently oldest', async () => {
+    apiRequest.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    (wrapper.vm as any).sortMode = 'oldest';
+    (wrapper.vm as any).toggleAddedSort();
+    await flushPromises();
+
+    expect((wrapper.vm as any).sortMode).toBe('newest');
   });
 });


### PR DESCRIPTION
## Summary
- implements the PrimeVue-based library view-mode overhaul for list/grid/table
- resolves layout-space issues by removing side push and improving responsive usage
- adds table-only column controls, richer table/list/grid metadata presentation, and sortable table headers
- persists library view mode and table column visibility selections
- adds last_read_at to library API payloads and wires UI display
- updates API + web unit tests for new behaviors and coverage

## Validation
- make quality

Closes #113
Closes #114
