### PR TITLE
test(api): harden RLS seeding fixture against rerun flakiness

### DIFF
--- a/apps/api/tests/test_rls_policies.py
+++ b/apps/api/tests/test_rls_policies.py
@@ -204,10 +204,6 @@ def _build_seed_data() -> dict[str, uuid.UUID]:
     api_client_2 = uuid.uuid4()
     api_audit_log_1 = uuid.uuid4()
     api_audit_log_2 = uuid.uuid4()
-    user_1_email = f"user1-{user_1.hex}@example.com"
-    user_2_email = f"user2-{user_2.hex}@example.com"
-    external_provider_id = f"OL-{work_1.hex[:12]}"
-    source_provider_id = f"OL-SRC-{source_record_1.hex[:12]}"
 
     return {
         "user_1": user_1,

--- a/apps/api/tests/test_rls_policies.py
+++ b/apps/api/tests/test_rls_policies.py
@@ -168,11 +168,9 @@ def db_url() -> str:
     return _get_db_url()
 
 
-@pytest.fixture(scope="session")
-def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
+def _build_seed_data() -> dict[str, uuid.UUID]:
     user_1 = uuid.uuid4()
     user_2 = uuid.uuid4()
-    now = dt.datetime.now(tz=dt.UTC)
 
     author_1 = uuid.uuid4()
     author_2 = uuid.uuid4()
@@ -199,223 +197,7 @@ def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
     api_audit_log_1 = uuid.uuid4()
     api_audit_log_2 = uuid.uuid4()
 
-    with psycopg.connect(db_url, autocommit=True) as conn:
-        conn.execute("set role postgres;")
-        _insert_auth_user(conn, user_1, "user1@example.com")
-        _insert_auth_user(conn, user_2, "user2@example.com")
-
-        conn.execute(
-            """
-            insert into public.users (id, handle, display_name)
-            values (%s, %s, %s), (%s, %s, %s);
-            """,
-            (
-                user_1,
-                f"user_{user_1.hex[:8]}",
-                "User One",
-                user_2,
-                f"user_{user_2.hex[:8]}",
-                "User Two",
-            ),
-        )
-
-        conn.execute(
-            "insert into public.authors (id, name) values (%s, %s), (%s, %s);",
-            (author_1, "Author One", author_2, "Author Two"),
-        )
-        conn.execute(
-            "insert into public.works (id, title) values (%s, %s), (%s, %s);",
-            (work_1, "Work One", work_2, "Work Two"),
-        )
-        conn.execute(
-            "insert into public.editions (id, work_id, isbn10) values (%s, %s, %s);",
-            (edition_1, work_1, "1234567890"),
-        )
-        conn.execute(
-            "insert into public.work_authors (work_id, author_id) values (%s, %s);",
-            (work_1, author_1),
-        )
-        conn.execute(
-            """
-            insert into public.external_ids
-                (id, entity_type, entity_id, provider, provider_id)
-            values (%s, %s, %s, %s, %s);
-            """,
-            (external_id_1, "work", work_1, "openlibrary", "OL123"),
-        )
-        conn.execute(
-            """
-            insert into public.source_records
-                (id, provider, entity_type, provider_id, raw, fetched_at)
-            values (%s, %s, %s, %s, %s, %s);
-            """,
-            (
-                source_record_1,
-                "openlibrary",
-                "work",
-                "OL123",
-                Json({"title": "Work One"}),
-                now,
-            ),
-        )
-
-        conn.execute(
-            """
-            insert into public.library_items
-                (id, user_id, work_id, status, visibility)
-            values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
-            """,
-            (
-                library_item_1,
-                user_1,
-                work_1,
-                "to_read",
-                "private",
-                library_item_2,
-                user_2,
-                work_2,
-                "reading",
-                "private",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.reading_sessions
-                (id, user_id, library_item_id, started_at)
-            values (%s, %s, %s, %s), (%s, %s, %s, %s);
-            """,
-            (
-                reading_session_1,
-                user_1,
-                library_item_1,
-                now,
-                reading_session_2,
-                user_2,
-                library_item_2,
-                now,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.reading_state_events
-                (id, user_id, library_item_id, event_type, occurred_at)
-            values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
-            """,
-            (
-                reading_state_event_1,
-                user_1,
-                library_item_1,
-                "started",
-                now,
-                reading_state_event_2,
-                user_2,
-                library_item_2,
-                "started",
-                now,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.notes
-                (id, user_id, library_item_id, title, body)
-            values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
-            """,
-            (
-                note_1,
-                user_1,
-                library_item_1,
-                "Note One",
-                "Note body one",
-                note_2,
-                user_2,
-                library_item_2,
-                "Note Two",
-                "Note body two",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.highlights
-                (id, user_id, library_item_id, quote)
-            values (%s, %s, %s, %s), (%s, %s, %s, %s);
-            """,
-            (
-                highlight_1,
-                user_1,
-                library_item_1,
-                "Highlight one",
-                highlight_2,
-                user_2,
-                library_item_2,
-                "Highlight two",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.reviews
-                (id, user_id, library_item_id, title, body, rating)
-            values (%s, %s, %s, %s, %s, %s), (%s, %s, %s, %s, %s, %s);
-            """,
-            (
-                review_1,
-                user_1,
-                library_item_1,
-                "Review One",
-                "Review body one",
-                7,
-                review_2,
-                user_2,
-                library_item_2,
-                "Review Two",
-                "Review body two",
-                8,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.api_clients
-                (client_id, name, owner_user_id)
-            values (%s, %s, %s), (%s, %s, %s);
-            """,
-            (
-                api_client_1,
-                "Client One",
-                user_1,
-                api_client_2,
-                "Client Two",
-                user_2,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.api_audit_logs
-                (id, client_id, user_id, method, path, status, latency_ms, ip, occurred_at)
-            values (%s, %s, %s, %s, %s, %s, %s, %s, %s),
-                   (%s, %s, %s, %s, %s, %s, %s, %s, %s);
-            """,
-            (
-                api_audit_log_1,
-                api_client_1,
-                user_1,
-                "GET",
-                "/v1/books",
-                200,
-                12,
-                "127.0.0.1",
-                now,
-                api_audit_log_2,
-                api_client_2,
-                user_2,
-                "POST",
-                "/v1/books",
-                201,
-                18,
-                "127.0.0.1",
-                now,
-            ),
-        )
-
-    data: dict[str, uuid.UUID] = {
+    return {
         "user_1": user_1,
         "user_2": user_2,
         "author_1": author_1,
@@ -443,73 +225,327 @@ def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
         "api_audit_log_2": api_audit_log_2,
     }
 
+
+def _seed_rls_data(
+    conn: psycopg.Connection, data: dict[str, uuid.UUID], now: dt.datetime
+) -> None:
+    user_1 = data["user_1"]
+    user_2 = data["user_2"]
+    provider_id = f"OL{data['work_1'].hex[:12]}"
+
+    _insert_auth_user(conn, user_1, f"rls-user-{user_1}@example.test")
+    _insert_auth_user(conn, user_2, f"rls-user-{user_2}@example.test")
+
+    conn.execute(
+        """
+        insert into public.users (id, handle, display_name)
+        values (%s, %s, %s), (%s, %s, %s);
+        """,
+        (
+            user_1,
+            f"user_{user_1.hex[:8]}",
+            "User One",
+            user_2,
+            f"user_{user_2.hex[:8]}",
+            "User Two",
+        ),
+    )
+
+    conn.execute(
+        "insert into public.authors (id, name) values (%s, %s), (%s, %s);",
+        (data["author_1"], "Author One", data["author_2"], "Author Two"),
+    )
+    conn.execute(
+        "insert into public.works (id, title) values (%s, %s), (%s, %s);",
+        (data["work_1"], "Work One", data["work_2"], "Work Two"),
+    )
+    conn.execute(
+        "insert into public.editions (id, work_id, isbn10) values (%s, %s, %s);",
+        (data["edition_1"], data["work_1"], "1234567890"),
+    )
+    conn.execute(
+        "insert into public.work_authors (work_id, author_id) values (%s, %s);",
+        (data["work_1"], data["author_1"]),
+    )
+    conn.execute(
+        """
+        insert into public.external_ids
+            (id, entity_type, entity_id, provider, provider_id)
+        values (%s, %s, %s, %s, %s);
+        """,
+        (data["external_id_1"], "work", data["work_1"], "openlibrary", provider_id),
+    )
+    conn.execute(
+        """
+        insert into public.source_records
+            (id, provider, entity_type, provider_id, raw, fetched_at)
+        values (%s, %s, %s, %s, %s, %s);
+        """,
+        (
+            data["source_record_1"],
+            "openlibrary",
+            "work",
+            provider_id,
+            Json({"title": "Work One"}),
+            now,
+        ),
+    )
+
+    conn.execute(
+        """
+        insert into public.library_items
+            (id, user_id, work_id, status, visibility)
+        values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["library_item_1"],
+            user_1,
+            data["work_1"],
+            "to_read",
+            "private",
+            data["library_item_2"],
+            user_2,
+            data["work_2"],
+            "reading",
+            "private",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.reading_sessions
+            (id, user_id, library_item_id, started_at)
+        values (%s, %s, %s, %s), (%s, %s, %s, %s);
+        """,
+        (
+            data["reading_session_1"],
+            user_1,
+            data["library_item_1"],
+            now,
+            data["reading_session_2"],
+            user_2,
+            data["library_item_2"],
+            now,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.reading_state_events
+            (id, user_id, library_item_id, event_type, occurred_at)
+        values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["reading_state_event_1"],
+            user_1,
+            data["library_item_1"],
+            "started",
+            now,
+            data["reading_state_event_2"],
+            user_2,
+            data["library_item_2"],
+            "started",
+            now,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.notes
+            (id, user_id, library_item_id, title, body)
+        values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["note_1"],
+            user_1,
+            data["library_item_1"],
+            "Note One",
+            "Note body one",
+            data["note_2"],
+            user_2,
+            data["library_item_2"],
+            "Note Two",
+            "Note body two",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.highlights
+            (id, user_id, library_item_id, quote)
+        values (%s, %s, %s, %s), (%s, %s, %s, %s);
+        """,
+        (
+            data["highlight_1"],
+            user_1,
+            data["library_item_1"],
+            "Highlight one",
+            data["highlight_2"],
+            user_2,
+            data["library_item_2"],
+            "Highlight two",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.reviews
+            (id, user_id, library_item_id, title, body, rating)
+        values (%s, %s, %s, %s, %s, %s), (%s, %s, %s, %s, %s, %s);
+        """,
+        (
+            data["review_1"],
+            user_1,
+            data["library_item_1"],
+            "Review One",
+            "Review body one",
+            7,
+            data["review_2"],
+            user_2,
+            data["library_item_2"],
+            "Review Two",
+            "Review body two",
+            8,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.api_clients
+            (client_id, name, owner_user_id)
+        values (%s, %s, %s), (%s, %s, %s);
+        """,
+        (
+            data["api_client_1"],
+            "Client One",
+            user_1,
+            data["api_client_2"],
+            "Client Two",
+            user_2,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.api_audit_logs
+            (id, client_id, user_id, method, path, status, latency_ms, ip, occurred_at)
+        values (%s, %s, %s, %s, %s, %s, %s, %s, %s),
+               (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+        """,
+        (
+            data["api_audit_log_1"],
+            data["api_client_1"],
+            user_1,
+            "GET",
+            "/v1/books",
+            200,
+            12,
+            "127.0.0.1",
+            now,
+            data["api_audit_log_2"],
+            data["api_client_2"],
+            user_2,
+            "POST",
+            "/v1/books",
+            201,
+            18,
+            "127.0.0.1",
+            now,
+        ),
+    )
+
+
+def _cleanup_rls_data(conn: psycopg.Connection, data: dict[str, uuid.UUID]) -> None:
+    conn.execute(
+        "delete from public.api_audit_logs where id in (%s, %s);",
+        (data["api_audit_log_1"], data["api_audit_log_2"]),
+    )
+    conn.execute(
+        "delete from public.api_clients where client_id in (%s, %s);",
+        (data["api_client_1"], data["api_client_2"]),
+    )
+    conn.execute(
+        "delete from public.reviews where id in (%s, %s);",
+        (data["review_1"], data["review_2"]),
+    )
+    conn.execute(
+        "delete from public.highlights where id in (%s, %s);",
+        (data["highlight_1"], data["highlight_2"]),
+    )
+    conn.execute(
+        "delete from public.notes where id in (%s, %s);",
+        (data["note_1"], data["note_2"]),
+    )
+    conn.execute(
+        "delete from public.reading_state_events where id in (%s, %s);",
+        (data["reading_state_event_1"], data["reading_state_event_2"]),
+    )
+    conn.execute(
+        "delete from public.reading_sessions where id in (%s, %s);",
+        (data["reading_session_1"], data["reading_session_2"]),
+    )
+    conn.execute(
+        "delete from public.library_items where id in (%s, %s);",
+        (data["library_item_1"], data["library_item_2"]),
+    )
+    conn.execute(
+        "delete from public.work_authors where work_id = %s and author_id = %s;",
+        (data["work_1"], data["author_1"]),
+    )
+    conn.execute(
+        "delete from public.editions where id = %s;",
+        (data["edition_1"],),
+    )
+    conn.execute(
+        "delete from public.works where id in (%s, %s);",
+        (data["work_1"], data["work_2"]),
+    )
+    conn.execute(
+        "delete from public.authors where id in (%s, %s);",
+        (data["author_1"], data["author_2"]),
+    )
+    conn.execute(
+        "delete from public.external_ids where id = %s;",
+        (data["external_id_1"],),
+    )
+    conn.execute(
+        "delete from public.source_records where id = %s;",
+        (data["source_record_1"],),
+    )
+    conn.execute(
+        "delete from public.users where id in (%s, %s);",
+        (data["user_1"], data["user_2"]),
+    )
+    conn.execute(
+        "delete from auth.users where id in (%s, %s);",
+        (data["user_1"], data["user_2"]),
+    )
+
+
+@pytest.fixture(scope="session")
+def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
+    data = _build_seed_data()
+    now = dt.datetime.now(tz=dt.UTC)
+
+    with psycopg.connect(db_url, autocommit=True) as conn:
+        conn.execute("set role postgres;")
+        try:
+            _seed_rls_data(conn, data, now)
+        except Exception:
+            _cleanup_rls_data(conn, data)
+            raise
+
     try:
         yield data
     finally:
         with psycopg.connect(db_url, autocommit=True) as conn:
             conn.execute("set role postgres;")
-            conn.execute(
-                "delete from public.api_audit_logs where id in (%s, %s);",
-                (api_audit_log_1, api_audit_log_2),
-            )
-            conn.execute(
-                "delete from public.api_clients where client_id in (%s, %s);",
-                (api_client_1, api_client_2),
-            )
-            conn.execute(
-                "delete from public.reviews where id in (%s, %s);",
-                (review_1, review_2),
-            )
-            conn.execute(
-                "delete from public.highlights where id in (%s, %s);",
-                (highlight_1, highlight_2),
-            )
-            conn.execute(
-                "delete from public.notes where id in (%s, %s);",
-                (note_1, note_2),
-            )
-            conn.execute(
-                "delete from public.reading_state_events where id in (%s, %s);",
-                (reading_state_event_1, reading_state_event_2),
-            )
-            conn.execute(
-                "delete from public.reading_sessions where id in (%s, %s);",
-                (reading_session_1, reading_session_2),
-            )
-            conn.execute(
-                "delete from public.library_items where id in (%s, %s);",
-                (library_item_1, library_item_2),
-            )
-            conn.execute(
-                "delete from public.work_authors where work_id = %s and author_id = %s;",
-                (work_1, author_1),
-            )
-            conn.execute(
-                "delete from public.editions where id = %s;",
-                (edition_1,),
-            )
-            conn.execute(
-                "delete from public.works where id in (%s, %s);",
-                (work_1, work_2),
-            )
-            conn.execute(
-                "delete from public.authors where id in (%s, %s);",
-                (author_1, author_2),
-            )
-            conn.execute(
-                "delete from public.external_ids where id = %s;",
-                (external_id_1,),
-            )
-            conn.execute(
-                "delete from public.source_records where id = %s;",
-                (source_record_1,),
-            )
-            conn.execute(
-                "delete from public.users where id in (%s, %s);", (user_1, user_2)
-            )
-            conn.execute(
-                "delete from auth.users where id in (%s, %s);", (user_1, user_2)
-            )
+            _cleanup_rls_data(conn, data)
+
+
+def test_seed_data_can_be_reapplied(db_url: str) -> None:
+    for _ in range(2):
+        data = _build_seed_data()
+        now = dt.datetime.now(tz=dt.UTC)
+        with psycopg.connect(db_url, autocommit=True) as conn:
+            conn.execute("set role postgres;")
+            try:
+                _seed_rls_data(conn, data, now)
+            finally:
+                _cleanup_rls_data(conn, data)
 
 
 def test_policies_present(db_url: str) -> None:
@@ -964,7 +1000,7 @@ def test_users_insert_enforces_owner(db_url: str) -> None:
     user_id = uuid.uuid4()
     with psycopg.connect(db_url, autocommit=True) as conn:
         conn.execute("set role postgres;")
-        _insert_auth_user(conn, user_id, "user3@example.com")
+        _insert_auth_user(conn, user_id, f"rls-user-{user_id}@example.test")
 
     with _authenticated_conn(db_url, user_id) as conn:
         handle = f"user_{user_id.hex[:8]}"

--- a/apps/api/tests/test_rls_policies.py
+++ b/apps/api/tests/test_rls_policies.py
@@ -174,11 +174,9 @@ def db_url() -> str:
     return url
 
 
-@pytest.fixture(scope="session")
-def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
+def _build_seed_data() -> dict[str, uuid.UUID]:
     user_1 = uuid.uuid4()
     user_2 = uuid.uuid4()
-    now = dt.datetime.now(tz=dt.UTC)
 
     author_1 = uuid.uuid4()
     author_2 = uuid.uuid4()
@@ -211,243 +209,7 @@ def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
     external_provider_id = f"OL-{work_1.hex[:12]}"
     source_provider_id = f"OL-SRC-{source_record_1.hex[:12]}"
 
-    with psycopg.connect(db_url, autocommit=True) as conn:
-        conn.execute("set role postgres;")
-        _insert_auth_user(conn, user_1, user_1_email)
-        _insert_auth_user(conn, user_2, user_2_email)
-
-        conn.execute(
-            """
-            insert into public.users (id, handle, display_name)
-            values (%s, %s, %s), (%s, %s, %s);
-            """,
-            (
-                user_1,
-                f"user_{user_1.hex[:8]}",
-                "User One",
-                user_2,
-                f"user_{user_2.hex[:8]}",
-                "User Two",
-            ),
-        )
-
-        conn.execute(
-            "insert into public.authors (id, name) values (%s, %s), (%s, %s);",
-            (author_1, "Author One", author_2, "Author Two"),
-        )
-        conn.execute(
-            "insert into public.works (id, title) values (%s, %s), (%s, %s);",
-            (work_1, "Work One", work_2, "Work Two"),
-        )
-        conn.execute(
-            "insert into public.editions (id, work_id, isbn10) values (%s, %s, %s);",
-            (edition_1, work_1, "1234567890"),
-        )
-        conn.execute(
-            "insert into public.work_authors (work_id, author_id) values (%s, %s);",
-            (work_1, author_1),
-        )
-        conn.execute(
-            """
-            insert into public.external_ids
-                (id, entity_type, entity_id, provider, provider_id)
-            values (%s, %s, %s, %s, %s);
-            """,
-            (external_id_1, "work", work_1, "openlibrary", external_provider_id),
-        )
-        conn.execute(
-            """
-            insert into public.source_records
-                (id, provider, entity_type, provider_id, raw, fetched_at)
-            values (%s, %s, %s, %s, %s, %s);
-            """,
-            (
-                source_record_1,
-                "openlibrary",
-                "work",
-                source_provider_id,
-                Json({"title": "Work One"}),
-                now,
-            ),
-        )
-
-        conn.execute(
-            """
-            insert into public.library_items
-                (id, user_id, work_id, status, visibility)
-            values
-                (%s, %s, %s, %s, %s),
-                (%s, %s, %s, %s, %s),
-                (%s, %s, %s, %s, %s);
-            """,
-            (
-                library_item_1,
-                user_1,
-                work_1,
-                "to_read",
-                "private",
-                library_item_2,
-                user_2,
-                work_2,
-                "reading",
-                "private",
-                library_item_3,
-                user_2,
-                work_1,
-                "to_read",
-                "private",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.reading_sessions
-                (id, user_id, library_item_id, started_at)
-            values (%s, %s, %s, %s), (%s, %s, %s, %s);
-            """,
-            (
-                reading_session_1,
-                user_1,
-                library_item_1,
-                now,
-                reading_session_2,
-                user_2,
-                library_item_2,
-                now,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.reading_state_events
-                (id, user_id, library_item_id, event_type, occurred_at)
-            values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
-            """,
-            (
-                reading_state_event_1,
-                user_1,
-                library_item_1,
-                "started",
-                now,
-                reading_state_event_2,
-                user_2,
-                library_item_2,
-                "started",
-                now,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.notes
-                (id, user_id, library_item_id, title, body)
-            values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
-            """,
-            (
-                note_1,
-                user_1,
-                library_item_1,
-                "Note One",
-                "Note body one",
-                note_2,
-                user_2,
-                library_item_2,
-                "Note Two",
-                "Note body two",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.highlights
-                (id, user_id, library_item_id, quote)
-            values (%s, %s, %s, %s), (%s, %s, %s, %s);
-            """,
-            (
-                highlight_1,
-                user_1,
-                library_item_1,
-                "Highlight one",
-                highlight_2,
-                user_2,
-                library_item_2,
-                "Highlight two",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.reviews
-                (id, user_id, library_item_id, title, body, rating, visibility)
-            values
-                (%s, %s, %s, %s, %s, %s, %s),
-                (%s, %s, %s, %s, %s, %s, %s),
-                (%s, %s, %s, %s, %s, %s, %s);
-            """,
-            (
-                review_1,
-                user_1,
-                library_item_1,
-                "Review One",
-                "Review body one",
-                7,
-                "private",
-                review_2,
-                user_2,
-                library_item_2,
-                "Review Two",
-                "Review body two",
-                8,
-                "public",
-                review_3,
-                user_2,
-                library_item_3,
-                "Review Three",
-                "Review body three",
-                6,
-                "unlisted",
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.api_clients
-                (client_id, name, owner_user_id)
-            values (%s, %s, %s), (%s, %s, %s);
-            """,
-            (
-                api_client_1,
-                "Client One",
-                user_1,
-                api_client_2,
-                "Client Two",
-                user_2,
-            ),
-        )
-        conn.execute(
-            """
-            insert into public.api_audit_logs
-                (id, client_id, user_id, method, path, status, latency_ms, ip, occurred_at)
-            values (%s, %s, %s, %s, %s, %s, %s, %s, %s),
-                   (%s, %s, %s, %s, %s, %s, %s, %s, %s);
-            """,
-            (
-                api_audit_log_1,
-                api_client_1,
-                user_1,
-                "GET",
-                "/v1/books",
-                200,
-                12,
-                "127.0.0.1",
-                now,
-                api_audit_log_2,
-                api_client_2,
-                user_2,
-                "POST",
-                "/v1/books",
-                201,
-                18,
-                "127.0.0.1",
-                now,
-            ),
-        )
-
-    data: dict[str, uuid.UUID] = {
+    return {
         "user_1": user_1,
         "user_2": user_2,
         "author_1": author_1,
@@ -477,73 +239,354 @@ def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
         "api_audit_log_2": api_audit_log_2,
     }
 
+
+def _seed_rls_data(
+    conn: psycopg.Connection, data: dict[str, uuid.UUID], now: dt.datetime
+) -> None:
+    user_1 = data["user_1"]
+    user_2 = data["user_2"]
+    external_provider_id = f"OL-{data['work_1'].hex[:12]}"
+    source_provider_id = f"OL-SRC-{data['source_record_1'].hex[:12]}"
+
+    _insert_auth_user(conn, user_1, f"user1-{user_1.hex}@example.com")
+    _insert_auth_user(conn, user_2, f"user2-{user_2.hex}@example.com")
+
+    conn.execute(
+        """
+        insert into public.users (id, handle, display_name)
+        values (%s, %s, %s), (%s, %s, %s);
+        """,
+        (
+            user_1,
+            f"user_{user_1.hex[:8]}",
+            "User One",
+            user_2,
+            f"user_{user_2.hex[:8]}",
+            "User Two",
+        ),
+    )
+
+    conn.execute(
+        "insert into public.authors (id, name) values (%s, %s), (%s, %s);",
+        (data["author_1"], "Author One", data["author_2"], "Author Two"),
+    )
+    conn.execute(
+        "insert into public.works (id, title) values (%s, %s), (%s, %s);",
+        (data["work_1"], "Work One", data["work_2"], "Work Two"),
+    )
+    conn.execute(
+        "insert into public.editions (id, work_id, isbn10) values (%s, %s, %s);",
+        (data["edition_1"], data["work_1"], "1234567890"),
+    )
+    conn.execute(
+        "insert into public.work_authors (work_id, author_id) values (%s, %s);",
+        (data["work_1"], data["author_1"]),
+    )
+    conn.execute(
+        """
+        insert into public.external_ids
+            (id, entity_type, entity_id, provider, provider_id)
+        values (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["external_id_1"],
+            "work",
+            data["work_1"],
+            "openlibrary",
+            external_provider_id,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.source_records
+            (id, provider, entity_type, provider_id, raw, fetched_at)
+        values (%s, %s, %s, %s, %s, %s);
+        """,
+        (
+            data["source_record_1"],
+            "openlibrary",
+            "work",
+            source_provider_id,
+            Json({"title": "Work One"}),
+            now,
+        ),
+    )
+
+    conn.execute(
+        """
+        insert into public.library_items
+            (id, user_id, work_id, status, visibility)
+        values
+            (%s, %s, %s, %s, %s),
+            (%s, %s, %s, %s, %s),
+            (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["library_item_1"],
+            user_1,
+            data["work_1"],
+            "to_read",
+            "private",
+            data["library_item_2"],
+            user_2,
+            data["work_2"],
+            "reading",
+            "private",
+            data["library_item_3"],
+            user_2,
+            data["work_1"],
+            "to_read",
+            "private",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.reading_sessions
+            (id, user_id, library_item_id, started_at)
+        values (%s, %s, %s, %s), (%s, %s, %s, %s);
+        """,
+        (
+            data["reading_session_1"],
+            user_1,
+            data["library_item_1"],
+            now,
+            data["reading_session_2"],
+            user_2,
+            data["library_item_2"],
+            now,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.reading_state_events
+            (id, user_id, library_item_id, event_type, occurred_at)
+        values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["reading_state_event_1"],
+            user_1,
+            data["library_item_1"],
+            "started",
+            now,
+            data["reading_state_event_2"],
+            user_2,
+            data["library_item_2"],
+            "started",
+            now,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.notes
+            (id, user_id, library_item_id, title, body)
+        values (%s, %s, %s, %s, %s), (%s, %s, %s, %s, %s);
+        """,
+        (
+            data["note_1"],
+            user_1,
+            data["library_item_1"],
+            "Note One",
+            "Note body one",
+            data["note_2"],
+            user_2,
+            data["library_item_2"],
+            "Note Two",
+            "Note body two",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.highlights
+            (id, user_id, library_item_id, quote)
+        values (%s, %s, %s, %s), (%s, %s, %s, %s);
+        """,
+        (
+            data["highlight_1"],
+            user_1,
+            data["library_item_1"],
+            "Highlight one",
+            data["highlight_2"],
+            user_2,
+            data["library_item_2"],
+            "Highlight two",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.reviews
+            (id, user_id, library_item_id, title, body, rating, visibility)
+        values
+            (%s, %s, %s, %s, %s, %s, %s),
+            (%s, %s, %s, %s, %s, %s, %s),
+            (%s, %s, %s, %s, %s, %s, %s);
+        """,
+        (
+            data["review_1"],
+            user_1,
+            data["library_item_1"],
+            "Review One",
+            "Review body one",
+            7,
+            "private",
+            data["review_2"],
+            user_2,
+            data["library_item_2"],
+            "Review Two",
+            "Review body two",
+            8,
+            "public",
+            data["review_3"],
+            user_2,
+            data["library_item_3"],
+            "Review Three",
+            "Review body three",
+            6,
+            "unlisted",
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.api_clients
+            (client_id, name, owner_user_id)
+        values (%s, %s, %s), (%s, %s, %s);
+        """,
+        (
+            data["api_client_1"],
+            "Client One",
+            user_1,
+            data["api_client_2"],
+            "Client Two",
+            user_2,
+        ),
+    )
+    conn.execute(
+        """
+        insert into public.api_audit_logs
+            (id, client_id, user_id, method, path, status, latency_ms, ip, occurred_at)
+        values (%s, %s, %s, %s, %s, %s, %s, %s, %s),
+               (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+        """,
+        (
+            data["api_audit_log_1"],
+            data["api_client_1"],
+            user_1,
+            "GET",
+            "/v1/books",
+            200,
+            12,
+            "127.0.0.1",
+            now,
+            data["api_audit_log_2"],
+            data["api_client_2"],
+            user_2,
+            "POST",
+            "/v1/books",
+            201,
+            18,
+            "127.0.0.1",
+            now,
+        ),
+    )
+
+
+def _cleanup_rls_data(conn: psycopg.Connection, data: dict[str, uuid.UUID]) -> None:
+    conn.execute(
+        "delete from public.api_audit_logs where id in (%s, %s);",
+        (data["api_audit_log_1"], data["api_audit_log_2"]),
+    )
+    conn.execute(
+        "delete from public.api_clients where client_id in (%s, %s);",
+        (data["api_client_1"], data["api_client_2"]),
+    )
+    conn.execute(
+        "delete from public.reviews where id in (%s, %s, %s);",
+        (data["review_1"], data["review_2"], data["review_3"]),
+    )
+    conn.execute(
+        "delete from public.highlights where id in (%s, %s);",
+        (data["highlight_1"], data["highlight_2"]),
+    )
+    conn.execute(
+        "delete from public.notes where id in (%s, %s);",
+        (data["note_1"], data["note_2"]),
+    )
+    conn.execute(
+        "delete from public.reading_state_events where id in (%s, %s);",
+        (data["reading_state_event_1"], data["reading_state_event_2"]),
+    )
+    conn.execute(
+        "delete from public.reading_sessions where id in (%s, %s);",
+        (data["reading_session_1"], data["reading_session_2"]),
+    )
+    conn.execute(
+        "delete from public.library_items where id in (%s, %s, %s);",
+        (data["library_item_1"], data["library_item_2"], data["library_item_3"]),
+    )
+    conn.execute(
+        "delete from public.work_authors where work_id = %s and author_id = %s;",
+        (data["work_1"], data["author_1"]),
+    )
+    conn.execute(
+        "delete from public.editions where id = %s;",
+        (data["edition_1"],),
+    )
+    conn.execute(
+        "delete from public.works where id in (%s, %s);",
+        (data["work_1"], data["work_2"]),
+    )
+    conn.execute(
+        "delete from public.authors where id in (%s, %s);",
+        (data["author_1"], data["author_2"]),
+    )
+    conn.execute(
+        "delete from public.external_ids where id = %s;",
+        (data["external_id_1"],),
+    )
+    conn.execute(
+        "delete from public.source_records where id = %s;",
+        (data["source_record_1"],),
+    )
+    conn.execute(
+        "delete from public.users where id in (%s, %s);",
+        (data["user_1"], data["user_2"]),
+    )
+    conn.execute(
+        "delete from auth.users where id in (%s, %s);",
+        (data["user_1"], data["user_2"]),
+    )
+
+
+@pytest.fixture(scope="session")
+def seed_data(db_url: str) -> Iterator[dict[str, uuid.UUID]]:
+    data = _build_seed_data()
+    now = dt.datetime.now(tz=dt.UTC)
+
+    with psycopg.connect(db_url, autocommit=True) as conn:
+        conn.execute("set role postgres;")
+        try:
+            _seed_rls_data(conn, data, now)
+        except Exception:
+            _cleanup_rls_data(conn, data)
+            raise
+
     try:
         yield data
     finally:
         with psycopg.connect(db_url, autocommit=True) as conn:
             conn.execute("set role postgres;")
-            conn.execute(
-                "delete from public.api_audit_logs where id in (%s, %s);",
-                (api_audit_log_1, api_audit_log_2),
-            )
-            conn.execute(
-                "delete from public.api_clients where client_id in (%s, %s);",
-                (api_client_1, api_client_2),
-            )
-            conn.execute(
-                "delete from public.reviews where id in (%s, %s, %s);",
-                (review_1, review_2, review_3),
-            )
-            conn.execute(
-                "delete from public.highlights where id in (%s, %s);",
-                (highlight_1, highlight_2),
-            )
-            conn.execute(
-                "delete from public.notes where id in (%s, %s);",
-                (note_1, note_2),
-            )
-            conn.execute(
-                "delete from public.reading_state_events where id in (%s, %s);",
-                (reading_state_event_1, reading_state_event_2),
-            )
-            conn.execute(
-                "delete from public.reading_sessions where id in (%s, %s);",
-                (reading_session_1, reading_session_2),
-            )
-            conn.execute(
-                "delete from public.library_items where id in (%s, %s, %s);",
-                (library_item_1, library_item_2, library_item_3),
-            )
-            conn.execute(
-                "delete from public.work_authors where work_id = %s and author_id = %s;",
-                (work_1, author_1),
-            )
-            conn.execute(
-                "delete from public.editions where id = %s;",
-                (edition_1,),
-            )
-            conn.execute(
-                "delete from public.works where id in (%s, %s);",
-                (work_1, work_2),
-            )
-            conn.execute(
-                "delete from public.authors where id in (%s, %s);",
-                (author_1, author_2),
-            )
-            conn.execute(
-                "delete from public.external_ids where id = %s;",
-                (external_id_1,),
-            )
-            conn.execute(
-                "delete from public.source_records where id = %s;",
-                (source_record_1,),
-            )
-            conn.execute(
-                "delete from public.users where id in (%s, %s);", (user_1, user_2)
-            )
-            conn.execute(
-                "delete from auth.users where id in (%s, %s);", (user_1, user_2)
-            )
+            _cleanup_rls_data(conn, data)
+
+
+def test_seed_data_can_be_reapplied(db_url: str) -> None:
+    for _ in range(2):
+        data = _build_seed_data()
+        now = dt.datetime.now(tz=dt.UTC)
+        with psycopg.connect(db_url, autocommit=True) as conn:
+            conn.execute("set role postgres;")
+            try:
+                _seed_rls_data(conn, data, now)
+            finally:
+                _cleanup_rls_data(conn, data)
 
 
 def test_policies_present(db_url: str) -> None:


### PR DESCRIPTION
## Summary
Fixes flaky RLS integration test seeding so reruns are safe against stale local DB state.

Closes #120.

## What changed
- Refactored `apps/api/tests/test_rls_policies.py` seeding into explicit helpers:
  - `_build_seed_data()`
  - `_seed_rls_data(...)`
  - `_cleanup_rls_data(...)`
- Replaced fixed auth emails with UUID-derived unique emails:
  - `rls-user-<uuid>@example.test`
- Replaced fixed Open Library provider id (`OL123`) with UUID-derived value to avoid unique index collisions in `external_ids` / `source_records`.
- Hardened fixture flow to clean up on setup failure before `yield`.
- Added rerun regression test: `test_seed_data_can_be_reapplied`.
- Updated `test_users_insert_enforces_owner` to use a unique test email.

## Validation
- `cd apps/api && .venv/bin/python -m pytest --no-cov tests/test_rls_policies.py` (run 3 times back-to-back): passed each run.
- `make quality`:
  - API checks/tests pass (including full RLS suite).
  - Existing unrelated web e2e failure remains: missing `@primevue/themes/aura` in `apps/web/nuxt.config.ts` (tracked separately in #121).
