### PR TITLE
Issue #123: expand library UI with inline status/visibility edits

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "[pre-push] Running make quality..."
+make quality
+
+echo "[pre-push] quality checks passed."

--- a/apps/web/cypress/e2e/library.cy.ts
+++ b/apps/web/cypress/e2e/library.cy.ts
@@ -1,0 +1,167 @@
+type LibraryItem = {
+  id: string;
+  work_id: string;
+  work_title: string;
+  author_names: string[];
+  cover_url: string | null;
+  status: 'to_read' | 'reading' | 'completed' | 'abandoned';
+  visibility: 'private' | 'public';
+  tags: string[];
+  created_at: string;
+};
+
+const fakeJwt = [
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+  'eyJzdWIiOiIwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEiLCJleHAiOjQxMDI0NDQ4MDAsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwiYXVkIjoiYXV0aGVudGljYXRlZCJ9',
+  'test-signature',
+].join('.');
+
+const seedSession = (win: Window) => {
+  win.localStorage.setItem(
+    'sb-localhost-auth-token',
+    JSON.stringify({
+      access_token: fakeJwt,
+      refresh_token: 'refresh-token',
+      token_type: 'bearer',
+      expires_in: 60 * 60,
+      expires_at: Math.floor(Date.now() / 1000) + 60 * 60,
+      user: {
+        id: '00000000-0000-4000-8000-000000000001',
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'reader@theseedbed.app',
+      },
+    }),
+  );
+};
+
+const baseItems = (): LibraryItem[] => [
+  {
+    id: 'item-1',
+    work_id: 'work-1',
+    work_title: 'Book A',
+    author_names: ['Author A'],
+    cover_url: null,
+    status: 'to_read',
+    visibility: 'private',
+    tags: ['Favorites'],
+    created_at: '2026-02-08T00:00:00Z',
+  },
+  {
+    id: 'item-2',
+    work_id: 'work-2',
+    work_title: 'Book B',
+    author_names: ['Author B'],
+    cover_url: null,
+    status: 'reading',
+    visibility: 'public',
+    tags: ['History'],
+    created_at: '2026-02-09T00:00:00Z',
+  },
+];
+
+describe('library page (mocked api)', () => {
+  let items: LibraryItem[];
+
+  beforeEach(() => {
+    items = baseItems();
+
+    cy.intercept('GET', 'http://localhost:54321/auth/v1/user*', {
+      statusCode: 200,
+      body: {
+        id: '00000000-0000-4000-8000-000000000001',
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'reader@theseedbed.app',
+      },
+    });
+
+    cy.intercept('GET', 'http://localhost:8000/api/v1/library/items*', (req) => {
+      const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+      const visibility =
+        typeof req.query.visibility === 'string' ? req.query.visibility : undefined;
+      const filtered = items.filter(
+        (item) =>
+          (status ? item.status === status : true) &&
+          (visibility ? item.visibility === visibility : true),
+      );
+      req.reply({ statusCode: 200, body: { data: { items: filtered, next_cursor: null } } });
+    }).as('listItems');
+
+    cy.intercept('PATCH', 'http://localhost:8000/api/v1/library/items/*', (req) => {
+      const id = req.url.split('/').pop();
+      const index = items.findIndex((item) => item.id === id);
+      if (index < 0) {
+        req.reply({
+          statusCode: 404,
+          body: { data: null, error: { code: 'not_found', message: 'Not found' } },
+        });
+        return;
+      }
+
+      if (typeof req.body?.status === 'string') {
+        items[index] = { ...items[index], status: req.body.status };
+      }
+      if (typeof req.body?.visibility === 'string') {
+        items[index] = { ...items[index], visibility: req.body.visibility };
+      }
+      req.reply({ statusCode: 200, body: { data: items[index], error: null } });
+    }).as('patchItem');
+
+    cy.intercept('DELETE', 'http://localhost:8000/api/v1/library/items/*', (req) => {
+      const id = req.url.split('/').pop();
+      items = items.filter((item) => item.id !== id);
+      req.reply({ statusCode: 200, body: { data: { deleted: true }, error: null } });
+    }).as('deleteItem');
+  });
+
+  it('filters by visibility', () => {
+    cy.visit('/library', { onBeforeLoad: seedSession });
+    cy.wait('@listItems');
+    cy.contains('Book A').should('be.visible');
+    cy.contains('Book B').should('be.visible');
+
+    cy.get('[data-test="library-visibility-filter"]').click();
+    cy.contains('.p-select-option', 'Public').click();
+    cy.wait('@listItems').its('request.url').should('include', 'visibility=public');
+
+    cy.contains('Book B').should('be.visible');
+    cy.contains('Book A').should('not.exist');
+  });
+
+  it('updates status and visibility inline', () => {
+    cy.visit('/library', { onBeforeLoad: seedSession });
+    cy.wait('@listItems');
+
+    cy.get('[data-test="library-item-status-edit"]').first().click();
+    cy.contains('.p-select-option', 'Completed').click();
+    cy.wait('@patchItem').its('request.body').should('deep.equal', { status: 'completed' });
+
+    cy.get('[data-test="library-item-visibility-edit"]').last().click();
+    cy.contains('.p-select-option', 'Public').click();
+    cy.wait('@patchItem').its('request.body').should('deep.equal', { visibility: 'public' });
+
+    cy.contains('[data-test="library-item-status-chip"]', 'Completed').should('be.visible');
+    cy.contains('[data-test="library-item-visibility-chip"]', 'Public').should('be.visible');
+  });
+
+  it('deletes an item and shows update error feedback', () => {
+    cy.intercept('PATCH', 'http://localhost:8000/api/v1/library/items/*', {
+      statusCode: 500,
+      body: { data: null, error: { code: 'server_error', message: 'boom' } },
+    }).as('patchItemError');
+
+    cy.visit('/library', { onBeforeLoad: seedSession });
+    cy.wait('@listItems');
+
+    cy.get('[data-test="library-item-status-edit"]').last().click();
+    cy.contains('.p-select-option', 'Completed').click();
+    cy.wait('@patchItemError');
+    cy.contains('boom').should('be.visible');
+
+    cy.get('[data-test="library-item-remove"]').first().click();
+    cy.get('[data-test="library-remove-confirm"]').click();
+    cy.wait('@deleteItem');
+    cy.contains('Removed from your library.').should('be.visible');
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,8 +16,8 @@
     "format:check": "prettier --check .",
     "test:unit": "vitest run --coverage",
     "test:unit:watch": "vitest",
-    "test:e2e": "rm -rf .nuxt .output && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && start-server-and-test \"NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm preview --port 3000\" http://localhost:3000/login \"node scripts/warmup-e2e.mjs && pnpm exec cypress run\"",
-    "test:e2e:open": "rm -rf .nuxt .output && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && start-server-and-test \"NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm preview --port 3000\" http://localhost:3000/login \"node scripts/warmup-e2e.mjs && pnpm exec cypress open\""
+    "test:e2e": "rm -rf .nuxt .output && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && sh ./scripts/run-e2e.sh run",
+    "test:e2e:open": "rm -rf .nuxt .output && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && sh ./scripts/run-e2e.sh open"
   },
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.2.8",

--- a/apps/web/scripts/run-e2e.sh
+++ b/apps/web/scripts/run-e2e.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -eu
+
+MODE="${1:-run}"
+shift || true
+
+if [ "$MODE" != "run" ] && [ "$MODE" != "open" ]; then
+  echo "Unsupported Cypress mode: $MODE (expected run|open)" >&2
+  exit 2
+fi
+
+# pnpm forwards script args as: <script> -- <args>. Drop the sentinel if present.
+if [ "${1:-}" = "--" ]; then
+  shift
+fi
+
+PORT="$(node -e "const net=require('node:net'); const server=net.createServer(); server.listen(0,()=>{console.log(server.address().port); server.close();});")"
+BASE_URL="http://localhost:${PORT}"
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "${SERVER_PID}" ]; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+NUXT_PUBLIC_SUPABASE_URL="${NUXT_PUBLIC_SUPABASE_URL:-http://localhost:54321}" \
+NUXT_PUBLIC_SUPABASE_ANON_KEY="${NUXT_PUBLIC_SUPABASE_ANON_KEY:-test-anon-key}" \
+pnpm preview --port "${PORT}" >/tmp/chapterverse-preview-${PORT}.log 2>&1 &
+SERVER_PID="$!"
+
+ATTEMPTS=0
+until curl -sf "${BASE_URL}/login" >/dev/null; do
+  ATTEMPTS=$((ATTEMPTS + 1))
+  if [ "$ATTEMPTS" -gt 120 ]; then
+    echo "Preview server did not become ready at ${BASE_URL}" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+
+WARMUP_BASE_URL="${BASE_URL}" node scripts/warmup-e2e.mjs
+pnpm exec cypress "${MODE}" --config "baseUrl=${BASE_URL}" "$@"


### PR DESCRIPTION
## Summary
- implement Issue #123 library page expansion in `apps/web/app/pages/library/index.vue`
- add inline per-item status + visibility edit controls across current/list, grid, and table modes
- wire server-side visibility filter in list requests (preserving existing client-side tag filtering)
- add/extend unit tests and add mocked Cypress e2e coverage for update/delete/filter flows
- harden web e2e runner scripts with dynamic port selection and reliable `--spec` argument forwarding
- add repo `pre-push` hook to block push unless `make quality` passes

## Verification
- `make quality` (pass)
- `pnpm test:e2e -- --spec cypress/e2e/library.cy.ts` (pass)

Closes #123
