### PR TITLE
Expand OpenLibrary integration and polish discovery UX

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -12,6 +12,7 @@ from app.core.config import get_settings
 from app.core.errors import register_exception_handlers
 from app.core.schema_guard import run_schema_guard
 from app.routers import (
+    authors,
     books,
     editions,
     health,
@@ -74,6 +75,7 @@ def create_app() -> FastAPI:
     app.include_router(version.router)
     app.include_router(protected.router)
     app.include_router(books.router)
+    app.include_router(authors.router)
     app.include_router(editions.router)
     app.include_router(me.router)
     app.include_router(library.router)

--- a/apps/api/app/routers/__init__.py
+++ b/apps/api/app/routers/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    authors,
     books,
     editions,
     health,
@@ -15,6 +16,7 @@ from . import (
 )
 
 __all__ = [
+    "authors",
     "books",
     "editions",
     "health",

--- a/apps/api/app/routers/authors.py
+++ b/apps/api/app/routers/authors.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.responses import ok
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.routers.books import get_open_library_client
+from app.services.open_library import OpenLibraryClient
+from app.services.works import get_openlibrary_author_profile
+
+router = APIRouter(tags=["authors"])
+
+
+@router.get("/api/v1/authors/{author_id}")
+async def get_author(
+    author_id: uuid.UUID,
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+) -> dict[str, object]:
+    try:
+        profile = await get_openlibrary_author_profile(
+            session,
+            author_id=author_id,
+            open_library=open_library,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "open_library_unavailable",
+                "message": "Open Library is unavailable. Please try again shortly.",
+            },
+        ) from exc
+    return ok(profile)

--- a/apps/api/app/services/openlibrary_backfill.py
+++ b/apps/api/app/services/openlibrary_backfill.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import asyncio
+import random
+import uuid
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.bibliography import Edition, Work
+from app.db.models.external_provider import ExternalId
+from app.db.session import _session_factory
+from app.services.catalog import import_openlibrary_bundle
+from app.services.open_library import OpenLibraryClient
+
+
+@dataclass(frozen=True)
+class BackfillCandidate:
+    work_id: uuid.UUID
+    work_key: str
+
+
+@dataclass(frozen=True)
+class BackfillResult:
+    scanned: int
+    processed: int
+    refreshed: int
+    failed: int
+
+
+def _work_needs_backfill(
+    session: Session, *, work_id: uuid.UUID
+) -> bool:  # pragma: no cover
+    work = session.get(Work, work_id)
+    if work is None:
+        return False
+    if work.default_cover_url is None:
+        return True
+    rows = session.execute(
+        sa.select(
+            Edition.id,
+            Edition.isbn10,
+            Edition.isbn13,
+            Edition.publisher,
+            Edition.language,
+            Edition.format,
+            Edition.cover_url,
+        ).where(Edition.work_id == work_id)
+    ).all()
+    if not rows:
+        return True
+    for _, isbn10, isbn13, publisher, language, fmt, cover_url in rows:
+        if not (isbn10 or isbn13):
+            return True
+        if publisher is None or language is None or fmt is None or cover_url is None:
+            return True
+    return False
+
+
+def find_backfill_candidates(
+    *, limit: int = 500
+) -> list[BackfillCandidate]:  # pragma: no cover
+    session_factory = _session_factory()
+    session = session_factory()
+    try:
+        rows = session.execute(
+            sa.select(ExternalId.entity_id, ExternalId.provider_id)
+            .where(
+                ExternalId.entity_type == "work",
+                ExternalId.provider == "openlibrary",
+            )
+            .order_by(ExternalId.provider_id.asc())
+            .limit(limit * 5)
+        ).all()
+        candidates: list[BackfillCandidate] = []
+        for entity_id, provider_id in rows:
+            if not isinstance(entity_id, uuid.UUID) or not isinstance(provider_id, str):
+                continue
+            if not _work_needs_backfill(session, work_id=entity_id):
+                continue
+            candidates.append(
+                BackfillCandidate(work_id=entity_id, work_key=provider_id)
+            )
+            if len(candidates) >= limit:
+                break
+        return candidates
+    finally:
+        session.close()
+
+
+async def _refresh_candidate(
+    *,
+    candidate: BackfillCandidate,
+    open_library: OpenLibraryClient,
+    retries: int,
+) -> bool:  # pragma: no cover
+    for attempt in range(1, retries + 1):
+        session_factory = _session_factory()
+        session = session_factory()
+        try:
+            bundle = await open_library.fetch_work_bundle(work_key=candidate.work_key)
+            import_openlibrary_bundle(session, bundle=bundle)
+            return True
+        except Exception:
+            if attempt >= retries:
+                return False
+            await asyncio.sleep(random.uniform(0.1, 0.6 * attempt))
+        finally:
+            session.close()
+    return False
+
+
+async def run_openlibrary_backfill(
+    *,
+    limit: int = 500,
+    concurrency: int = 5,
+    retries: int = 3,
+) -> BackfillResult:  # pragma: no cover
+    candidates = find_backfill_candidates(limit=limit)
+    semaphore = asyncio.Semaphore(max(concurrency, 1))
+    refreshed = 0
+    failed = 0
+
+    async def _run(candidate: BackfillCandidate) -> None:
+        nonlocal refreshed, failed
+        async with semaphore:
+            ok = await _refresh_candidate(
+                candidate=candidate,
+                open_library=OpenLibraryClient(),
+                retries=max(retries, 1),
+            )
+            if ok:
+                refreshed += 1
+            else:
+                failed += 1
+
+    await asyncio.gather(*(_run(candidate) for candidate in candidates))
+    return BackfillResult(
+        scanned=len(candidates),
+        processed=len(candidates),
+        refreshed=refreshed,
+        failed=failed,
+    )

--- a/apps/api/scripts/openlibrary_backfill.py
+++ b/apps/api/scripts/openlibrary_backfill.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from app.services.openlibrary_backfill import run_openlibrary_backfill
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill OpenLibrary metadata for works missing key fields."
+    )
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--concurrency", type=int, default=5)
+    parser.add_argument("--retries", type=int, default=3)
+    return parser.parse_args()
+
+
+async def _main() -> None:
+    args = parse_args()
+    result = await run_openlibrary_backfill(
+        limit=max(args.limit, 1),
+        concurrency=max(args.concurrency, 1),
+        retries=max(args.retries, 1),
+    )
+    print(
+        json.dumps(
+            {
+                "scanned": result.scanned,
+                "processed": result.processed,
+                "refreshed": result.refreshed,
+                "failed": result.failed,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/apps/api/tests/test_authors_router.py
+++ b/apps/api/tests/test_authors_router.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.routers.authors import router as authors_router
+from app.routers.books import get_open_library_client
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
+    app = FastAPI()
+    app.include_router(authors_router)
+
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+    )
+    app.dependency_overrides[get_open_library_client] = lambda: object()
+
+    def _fake_session() -> Generator[object, None, None]:
+        yield object()
+
+    app.dependency_overrides[get_db_session] = _fake_session
+
+    async def _fake_profile(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "id": str(uuid.uuid4()),
+            "name": "Author A",
+            "bio": "Bio",
+            "photo_url": None,
+            "openlibrary_author_key": "/authors/OL1A",
+            "works": [],
+        }
+
+    monkeypatch.setattr(
+        "app.routers.authors.get_openlibrary_author_profile", _fake_profile
+    )
+    yield app
+
+
+def test_get_author(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get(f"/api/v1/authors/{uuid.uuid4()}")
+    assert response.status_code == 200
+    assert response.json()["data"]["name"] == "Author A"
+
+
+def test_get_author_404(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _missing(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise LookupError("missing")
+
+    monkeypatch.setattr("app.routers.authors.get_openlibrary_author_profile", _missing)
+    client = TestClient(app)
+    response = client.get(f"/api/v1/authors/{uuid.uuid4()}")
+    assert response.status_code == 404
+
+
+def test_get_author_502(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _down(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise httpx.ConnectError("down")
+
+    monkeypatch.setattr("app.routers.authors.get_openlibrary_author_profile", _down)
+    client = TestClient(app)
+    response = client.get(f"/api/v1/authors/{uuid.uuid4()}")
+    assert response.status_code == 502

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import uuid
 from typing import Any, cast
 
@@ -59,6 +60,9 @@ def _bundle() -> OpenLibraryWorkBundle:
             "isbn13": "456",
             "publisher": "Pub",
             "publish_date": None,
+            "publish_date_iso": dt.date(2020, 1, 1),
+            "language": "eng",
+            "format": "Paperback",
         },
         raw_work={"k": "v"},
         raw_edition={"ek": "ev"},
@@ -215,6 +219,8 @@ def test_import_openlibrary_bundle_uses_existing_records() -> None:
     assert result["edition"]["created"] is False
     assert work_model.default_cover_url == _bundle().cover_url
     assert edition_model.cover_url == _bundle().cover_url
+    assert edition_model.language == "eng"
+    assert edition_model.format == "Paperback"
 
 
 def test_import_openlibrary_bundle_does_not_overwrite_existing_covers() -> None:

--- a/apps/api/tests/test_openlibrary_backfill_service.py
+++ b/apps/api/tests/test_openlibrary_backfill_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any, cast
+
+from app.services.openlibrary_backfill import (
+    BackfillCandidate,
+    run_openlibrary_backfill,
+)
+
+
+def test_run_openlibrary_backfill_counts_success_and_failures(
+    monkeypatch: Any,
+) -> None:
+    candidates = [
+        BackfillCandidate(work_id=uuid.uuid4(), work_key="/works/OL1W"),
+        BackfillCandidate(work_id=uuid.uuid4(), work_key="/works/OL2W"),
+    ]
+    monkeypatch.setattr(
+        "app.services.openlibrary_backfill.find_backfill_candidates",
+        lambda **_kwargs: candidates,
+    )
+
+    async def _fake_refresh(*_args: object, **kwargs: object) -> bool:
+        candidate = cast(BackfillCandidate, kwargs["candidate"])
+        return bool(candidate.work_key.endswith("1W"))
+
+    monkeypatch.setattr(
+        "app.services.openlibrary_backfill._refresh_candidate", _fake_refresh
+    )
+    result = asyncio.run(run_openlibrary_backfill(limit=10, concurrency=2, retries=1))
+    assert result.scanned == 2
+    assert result.processed == 2
+    assert result.refreshed == 1
+    assert result.failed == 1

--- a/apps/api/tests/test_works_service.py
+++ b/apps/api/tests/test_works_service.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import uuid
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from app.db.models.bibliography import Author, Edition, Work
-from app.services.works import get_work_detail, list_work_editions
+from app.services.works import (
+    get_openlibrary_author_profile,
+    get_openlibrary_work_key,
+    get_work_detail,
+    list_related_works,
+    list_work_editions,
+    refresh_work_if_stale,
+)
 
 
 class FakeScalarResult:
@@ -96,6 +104,13 @@ def test_get_work_detail_falls_back_to_work_default_cover() -> None:
     assert detail["cover_url"] == "https://example.com/default.jpg"
 
 
+def test_get_work_detail_raises_when_work_missing() -> None:
+    session = FakeSession()
+    session.get_values = [None]
+    with pytest.raises(LookupError):
+        get_work_detail(session, work_id=uuid.uuid4())  # type: ignore[arg-type]
+
+
 def test_list_work_editions_returns_rows() -> None:
     work_id = uuid.uuid4()
     work = Work(
@@ -135,3 +150,181 @@ def test_list_work_editions_raises_when_work_missing() -> None:
     session.get_values = [None]
     with pytest.raises(LookupError):
         list_work_editions(session, work_id=uuid.uuid4(), limit=20)  # type: ignore[arg-type]
+
+
+def test_get_openlibrary_work_key_returns_provider_id() -> None:
+    session = FakeSession()
+    session.scalar_values = ["/works/OL1W"]
+    key = get_openlibrary_work_key(session, work_id=uuid.uuid4())  # type: ignore[arg-type]
+    assert key == "/works/OL1W"
+
+
+def test_list_related_works_returns_empty_without_mapping() -> None:
+    session = FakeSession()
+    session.scalar_values = [None]
+    open_library = object()
+    items = asyncio.run(
+        list_related_works(
+            session, work_id=uuid.uuid4(), open_library=open_library  # type: ignore[arg-type]
+        )
+    )
+    assert items == []
+
+
+def test_list_related_works_returns_empty_without_source_payload() -> None:
+    session = FakeSession()
+    session.scalar_values = ["/works/OL1W", "not-a-dict"]
+    items = asyncio.run(
+        list_related_works(
+            cast(Any, session),
+            work_id=uuid.uuid4(),
+            open_library=object(),  # type: ignore[arg-type]
+        )
+    )
+    assert items == []
+
+
+def test_list_related_works_builds_payload() -> None:
+    session = FakeSession()
+    session.scalar_values = ["/works/OL1W", {"subjects": ["Fantasy"]}]
+
+    class FakeOpenLibrary:
+        async def fetch_related_works(self, **_kwargs: Any) -> list[Any]:
+            return [
+                type(
+                    "R",
+                    (),
+                    {
+                        "work_key": "/works/OL2W",
+                        "title": "Related",
+                        "cover_url": None,
+                        "first_publish_year": 2001,
+                        "author_names": ["Author A"],
+                    },
+                )()
+            ]
+
+    items = asyncio.run(
+        list_related_works(
+            session, work_id=uuid.uuid4(), open_library=FakeOpenLibrary()  # type: ignore[arg-type]
+        )
+    )
+    assert items[0]["work_key"] == "/works/OL2W"
+    assert items[0]["author_names"] == ["Author A"]
+
+
+def test_get_openlibrary_author_profile_success() -> None:
+    author_id = uuid.uuid4()
+    session = FakeSession()
+    session.get_values = [Author(id=author_id, name="Author")]
+    session.scalar_values = ["/authors/OL1A"]
+
+    class FakeOpenLibrary:
+        async def fetch_author_profile(self, **_kwargs: Any) -> Any:
+            return type(
+                "P",
+                (),
+                {
+                    "name": "Author A",
+                    "bio": "Bio",
+                    "photo_url": None,
+                    "author_key": "/authors/OL1A",
+                    "top_works": [
+                        type(
+                            "W",
+                            (),
+                            {
+                                "work_key": "/works/OL2W",
+                                "title": "Book",
+                                "cover_url": None,
+                                "first_publish_year": 2001,
+                            },
+                        )()
+                    ],
+                },
+            )()
+
+    profile = asyncio.run(
+        get_openlibrary_author_profile(
+            session, author_id=author_id, open_library=FakeOpenLibrary()  # type: ignore[arg-type]
+        )
+    )
+    assert profile["name"] == "Author A"
+    assert profile["works"][0]["work_key"] == "/works/OL2W"
+
+
+def test_get_openlibrary_author_profile_raises_when_missing_mapping() -> None:
+    author_id = uuid.uuid4()
+    session = FakeSession()
+    session.get_values = [Author(id=author_id, name="Author")]
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        asyncio.run(
+            get_openlibrary_author_profile(
+                session, author_id=author_id, open_library=object()  # type: ignore[arg-type]
+            )
+        )
+
+
+def test_get_openlibrary_author_profile_raises_when_author_missing() -> None:
+    session = FakeSession()
+    session.get_values = [None]
+    with pytest.raises(LookupError):
+        asyncio.run(
+            get_openlibrary_author_profile(
+                cast(Any, session),
+                author_id=uuid.uuid4(),
+                open_library=object(),  # type: ignore[arg-type]
+            )
+        )
+
+
+def test_refresh_work_if_stale_refreshes(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = FakeSession()
+    stale = dt.datetime.now(dt.UTC) - dt.timedelta(days=31)
+    session.scalar_values = ["/works/OL1W", stale]
+    called = {"imported": False}
+
+    class FakeOpenLibrary:
+        async def fetch_work_bundle(self, **_kwargs: Any) -> Any:
+            return object()
+
+    monkeypatch.setattr(
+        "app.services.works.import_openlibrary_bundle",
+        lambda *_args, **_kwargs: called.__setitem__("imported", True),
+    )
+    result = asyncio.run(
+        refresh_work_if_stale(
+            session,  # type: ignore[arg-type]
+            work_id=uuid.uuid4(),
+            open_library=FakeOpenLibrary(),  # type: ignore[arg-type]
+        )
+    )
+
+    assert result is True
+    assert called["imported"] is True
+
+
+def test_refresh_work_if_stale_skips_when_fresh() -> None:
+    session = FakeSession()
+    fresh = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+    session.scalar_values = ["/works/OL1W", fresh]
+    result = asyncio.run(
+        refresh_work_if_stale(
+            session, work_id=uuid.uuid4(), open_library=object()  # type: ignore[arg-type]
+        )
+    )
+    assert result is False
+
+
+def test_refresh_work_if_stale_returns_false_without_openlibrary_mapping() -> None:
+    session = FakeSession()
+    session.scalar_values = [None]
+    result = asyncio.run(
+        refresh_work_if_stale(
+            cast(Any, session),
+            work_id=uuid.uuid4(),
+            open_library=object(),  # type: ignore[arg-type]
+        )
+    )
+    assert result is False

--- a/apps/web/app/components/books/BookDiscoverySection.vue
+++ b/apps/web/app/components/books/BookDiscoverySection.vue
@@ -1,0 +1,250 @@
+<template>
+  <Card class="overflow-hidden">
+    <template #title>
+      <div class="flex items-center gap-3">
+        <Avatar
+          icon="pi pi-compass"
+          shape="circle"
+          aria-hidden="true"
+          class="ring-1 ring-amber-400/40"
+        />
+        <div class="flex flex-col">
+          <span class="font-serif text-lg font-semibold tracking-tight">Discovery</span>
+          <span class="text-xs font-normal text-[var(--p-text-muted-color)]"
+            >Recommended from related titles and your authors</span
+          >
+        </div>
+      </div>
+    </template>
+    <template #content>
+      <div class="space-y-6">
+        <section class="space-y-2">
+          <p class="text-sm font-medium">Related books</p>
+          <p v-if="relatedLoading" class="text-sm text-[var(--p-text-muted-color)]">Loading…</p>
+          <div
+            v-else-if="visibleRelatedBooks.length"
+            class="grid grid-cols-[repeat(auto-fill,minmax(8.25rem,1fr))] gap-2"
+          >
+            <button
+              v-for="item in visibleRelatedBooks"
+              :key="item.work_key"
+              type="button"
+              class="group overflow-hidden rounded-xl border border-[var(--p-content-border-color)] bg-[var(--p-content-background)] text-left shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--p-primary-color)]/30 hover:shadow-md"
+              :data-test="`related-book-${item.work_key}`"
+              @click="importAndOpenRelated(item.work_key)"
+            >
+              <div class="p-1 pb-0">
+                <div
+                  class="aspect-[3/4] w-full overflow-hidden rounded-md bg-black/5 dark:bg-white/10"
+                >
+                  <img
+                    :src="item.cover_url as string"
+                    alt=""
+                    class="block h-full w-full object-cover object-center transition duration-300 group-hover:scale-[1.02]"
+                  />
+                </div>
+              </div>
+              <div class="flex min-h-[6.75rem] flex-col gap-0.5 p-2">
+                <p class="min-h-[2.5rem] text-xs font-semibold leading-snug">
+                  {{ item.title }}
+                </p>
+                <p class="text-[11px] leading-snug text-[var(--p-text-muted-color)]">
+                  {{ relatedAuthorLabel(item) }}
+                </p>
+                <p class="mt-auto text-xs text-[var(--p-text-muted-color)]">
+                  {{ item.first_publish_year ?? 'Year unknown' }}
+                </p>
+              </div>
+            </button>
+          </div>
+          <p v-else class="text-sm text-[var(--p-text-muted-color)]">
+            No related books with covers yet.
+          </p>
+        </section>
+
+        <section class="space-y-2">
+          <p class="text-sm font-medium">More from the author(s)</p>
+          <p v-if="authorLoading" class="text-sm text-[var(--p-text-muted-color)]">Loading…</p>
+          <div v-else-if="authorProfilesWithCoverWorks.length" class="grid gap-3">
+            <Card
+              v-for="author in authorProfilesWithCoverWorks"
+              :key="author.id"
+              class="overflow-hidden"
+            >
+              <template #content>
+                <div class="flex items-center gap-3">
+                  <div
+                    class="h-12 w-12 shrink-0 overflow-hidden rounded-full border border-[var(--p-content-border-color)] bg-black/5 dark:bg-white/5"
+                  >
+                    <img
+                      v-if="author.photo_url"
+                      :src="author.photo_url"
+                      alt=""
+                      class="h-full w-full object-cover"
+                    />
+                    <div v-else class="flex h-full w-full items-center justify-center">
+                      <span class="pi pi-user text-sm text-[var(--p-text-muted-color)]" />
+                    </div>
+                  </div>
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium">{{ author.name }}</p>
+                    <p
+                      v-if="author.bio"
+                      class="line-clamp-1 text-xs text-[var(--p-text-muted-color)]"
+                    >
+                      {{ author.bio }}
+                    </p>
+                  </div>
+                </div>
+                <div class="mt-3 grid grid-cols-[repeat(auto-fill,minmax(7.7rem,1fr))] gap-2">
+                  <button
+                    v-for="book in author.works.slice(0, 6)"
+                    :key="`${author.id}-${book.work_key}`"
+                    type="button"
+                    class="group overflow-hidden rounded-lg border border-[var(--p-content-border-color)] bg-[var(--p-content-background)] text-left transition hover:border-[var(--p-primary-color)]/30"
+                    :data-test="`author-work-${book.work_key}`"
+                    @click="importAndOpenRelated(book.work_key)"
+                  >
+                    <div class="p-1 pb-0">
+                      <div
+                        class="aspect-[3/4] w-full overflow-hidden rounded-md bg-black/5 dark:bg-white/10"
+                      >
+                        <img
+                          :src="book.cover_url as string"
+                          alt=""
+                          class="block h-full w-full object-cover object-center transition duration-300 group-hover:scale-[1.02]"
+                        />
+                      </div>
+                    </div>
+                    <div class="p-2">
+                      <p class="text-[11px] font-medium leading-snug">{{ book.title }}</p>
+                    </div>
+                  </button>
+                </div>
+              </template>
+            </Card>
+          </div>
+          <p v-else class="text-sm text-[var(--p-text-muted-color)]">
+            No author books with covers yet.
+          </p>
+        </section>
+      </div>
+    </template>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { navigateTo } from '#imports';
+import { computed, onMounted, ref, watch } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import { ApiClientError, apiRequest } from '~/utils/api';
+
+const props = defineProps<{
+  workId: string;
+  authors: { id: string; name: string }[];
+}>();
+
+type RelatedWork = {
+  work_key: string;
+  title: string;
+  cover_url: string | null;
+  first_publish_year?: number | null;
+  author_names?: string[];
+};
+
+type AuthorProfile = {
+  id: string;
+  name: string;
+  bio: string | null;
+  photo_url: string | null;
+  openlibrary_author_key: string;
+  works: {
+    work_key: string;
+    title: string;
+    cover_url: string | null;
+    first_publish_year?: number | null;
+  }[];
+};
+
+const toast = useToast();
+const relatedBooks = ref<RelatedWork[]>([]);
+const relatedLoading = ref(false);
+const authorProfiles = ref<AuthorProfile[]>([]);
+const authorLoading = ref(false);
+const visibleRelatedBooks = computed(() => relatedBooks.value.filter((item) => !!item.cover_url));
+const authorProfilesWithCoverWorks = computed(() =>
+  authorProfiles.value
+    .map((author) => ({
+      ...author,
+      works: author.works.filter((work) => !!work.cover_url),
+    }))
+    .filter((author) => author.works.length),
+);
+
+const load = async () => {
+  relatedLoading.value = true;
+  try {
+    const payload = await apiRequest<{ items: RelatedWork[] }>(
+      `/api/v1/works/${props.workId}/related`,
+    );
+    relatedBooks.value = payload.items || [];
+  } catch {
+    relatedBooks.value = [];
+  } finally {
+    relatedLoading.value = false;
+  }
+
+  if (!props.authors.length) {
+    authorProfiles.value = [];
+    return;
+  }
+
+  authorLoading.value = true;
+  try {
+    authorProfiles.value = await Promise.all(
+      props.authors
+        .slice(0, 3)
+        .map((author) => apiRequest<AuthorProfile>(`/api/v1/authors/${author.id}`)),
+    );
+  } catch {
+    authorProfiles.value = [];
+  } finally {
+    authorLoading.value = false;
+  }
+};
+
+const importAndOpenRelated = async (relatedWorkKey: string) => {
+  try {
+    const imported = await apiRequest<{ work: { id: string } }>('/api/v1/books/import', {
+      method: 'POST',
+      body: { work_key: relatedWorkKey },
+    });
+    await navigateTo(`/books/${imported.work.id}`);
+  } catch (err) {
+    const msg = err instanceof ApiClientError ? err.message : 'Unable to open related book.';
+    toast.add({ severity: 'error', summary: msg, life: 3000 });
+  }
+};
+
+const relatedAuthorLabel = (item: RelatedWork): string => {
+  if (!item.author_names?.length) {
+    return 'Unknown author';
+  }
+  const firstEntry = item.author_names[0]?.trim();
+  if (!firstEntry) {
+    return 'Unknown author';
+  }
+  return firstEntry.split(',')[0]?.split(';')[0]?.trim() || 'Unknown author';
+};
+
+onMounted(() => {
+  void load();
+});
+
+watch(
+  () => [props.workId, props.authors.map((author) => author.id).join(',')],
+  () => {
+    void load();
+  },
+);
+</script>

--- a/apps/web/app/pages/books/[workId].vue
+++ b/apps/web/app/pages/books/[workId].vue
@@ -616,6 +616,13 @@
         </div>
       </template>
     </Card>
+
+    <BookDiscoverySection
+      v-if="work"
+      :work-id="workId"
+      :authors="work.authors || []"
+      data-test="book-discovery"
+    />
   </div>
 </template>
 
@@ -627,6 +634,7 @@ import { navigateTo, useRoute } from '#imports';
 import { useToast } from 'primevue/usetoast';
 import { ApiClientError, apiRequest } from '~/utils/api';
 import { libraryStatusLabel } from '~/utils/libraryStatus';
+import BookDiscoverySection from '~/components/books/BookDiscoverySection.vue';
 import CoverPlaceholder from '~/components/CoverPlaceholder.vue';
 import type { FileUploadSelectEvent } from 'primevue/fileupload';
 

--- a/apps/web/tests/unit/components/book-discovery-section.test.ts
+++ b/apps/web/tests/unit/components/book-discovery-section.test.ts
@@ -1,0 +1,374 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiRequest = vi.hoisted(() => vi.fn());
+const navigateToMock = vi.hoisted(() => vi.fn());
+const toastAdd = vi.hoisted(() => vi.fn());
+const ApiClientErrorMock = vi.hoisted(
+  () =>
+    class ApiClientError extends Error {
+      code: string;
+      status?: number;
+      constructor(message: string, code: string, status?: number) {
+        super(message);
+        this.code = code;
+        this.status = status;
+      }
+    },
+);
+
+vi.mock('~/utils/api', () => ({
+  apiRequest,
+  ApiClientError: ApiClientErrorMock,
+}));
+
+vi.mock('#imports', () => ({
+  navigateTo: navigateToMock,
+}));
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAdd }),
+}));
+
+import BookDiscoverySection from '../../../app/components/books/BookDiscoverySection.vue';
+
+const mountSection = (
+  authors: Array<{ id: string; name: string }> = [{ id: 'author-1', name: 'A' }],
+) =>
+  mount(BookDiscoverySection, {
+    props: { workId: 'work-1', authors },
+    global: {
+      plugins: [[PrimeVue, { ripple: false }]],
+      stubs: {
+        Card: {
+          template:
+            '<section><header><slot name="title" /></header><div><slot name="content" /></div></section>',
+        },
+        Avatar: { template: '<div />' },
+      },
+    },
+  });
+
+describe('book discovery section', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    navigateToMock.mockReset();
+    toastAdd.mockReset();
+  });
+
+  it('shows empty states when no authors are provided', async () => {
+    const wrapper = mountSection([]);
+    await flushPromises();
+    expect(wrapper.text()).toContain('No related books with covers yet.');
+    expect(wrapper.text()).toContain('No author books with covers yet.');
+  });
+
+  it('loads related books and author works', async () => {
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      const method = (opts?.method || 'GET').toUpperCase();
+      if (url === '/api/v1/works/work-1/related') {
+        return {
+          items: [
+            {
+              work_key: '/works/OL2W',
+              title: 'Related One',
+              cover_url: 'https://example.com/related.jpg',
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: 'Bio',
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [
+            {
+              work_key: '/works/OL9W',
+              title: 'Other Book',
+              cover_url: 'https://example.com/other.jpg',
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/books/import' && method === 'POST') {
+        return { work: { id: 'work-2' } };
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain('Related One');
+    expect(wrapper.text()).toContain('Unknown author');
+    expect(wrapper.text()).toContain('Other Book');
+    await wrapper.get('[data-test="related-book-/works/OL2W"]').trigger('click');
+    await flushPromises();
+    expect(navigateToMock).toHaveBeenCalledWith('/books/work-2');
+  });
+
+  it('renders cover-forward discovery cards and imports from author works', async () => {
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      const method = (opts?.method || 'GET').toUpperCase();
+      if (url === '/api/v1/works/work-1/related') {
+        return {
+          items: [
+            {
+              work_key: '/works/OL2W',
+              title: 'Related One',
+              cover_url: 'https://example.com/related.jpg',
+              first_publish_year: 2001,
+              author_names: ['Author One, Author Two; Author Three'],
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: 'Bio',
+          photo_url: 'https://example.com/author.jpg',
+          openlibrary_author_key: '/authors/OL1A',
+          works: [
+            {
+              work_key: '/works/OL9W',
+              title: 'Other Book',
+              cover_url: 'https://example.com/other.jpg',
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/books/import' && method === 'POST') {
+        const workKey = opts?.body?.work_key;
+        return { work: { id: workKey === '/works/OL9W' ? 'work-9' : 'work-2' } };
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+
+    const wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="related-book-/works/OL2W"] img').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Author One');
+    expect(wrapper.text()).not.toContain('Author Two');
+    expect(wrapper.find('[data-test="author-work-/works/OL9W"] img').exists()).toBe(true);
+
+    await wrapper.get('[data-test="author-work-/works/OL9W"]').trigger('click');
+    await flushPromises();
+    expect(navigateToMock).toHaveBeenCalledWith('/books/work-9');
+  });
+
+  it('reloads when work or author props change', async () => {
+    apiRequest.mockImplementation(async (url: string) => {
+      if (url === '/api/v1/works/work-1/related') return { items: [] };
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [],
+        };
+      }
+      if (url === '/api/v1/works/work-2/related') return { items: [] };
+      if (url === '/api/v1/authors/author-2') {
+        return {
+          id: 'author-2',
+          name: 'Author B',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL2A',
+          works: [],
+        };
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const wrapper = mountSection();
+    await flushPromises();
+
+    await wrapper.setProps({ workId: 'work-2', authors: [{ id: 'author-2', name: 'B' }] });
+    await flushPromises();
+
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/works/work-2/related');
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/authors/author-2');
+  });
+
+  it('handles related payload without items array', async () => {
+    apiRequest.mockImplementation(async (url: string) => {
+      if (url === '/api/v1/works/work-1/related') return {} as any;
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [],
+        };
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const wrapper = mountSection();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('No related books with covers yet.');
+  });
+
+  it('falls back to Unknown author when related author entry is blank', async () => {
+    apiRequest.mockImplementation(async (url: string) => {
+      if (url === '/api/v1/works/work-1/related') {
+        return {
+          items: [
+            {
+              work_key: '/works/OL2W',
+              title: 'Related One',
+              cover_url: 'https://example.com/related.jpg',
+              author_names: ['   '],
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [],
+        };
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain('Unknown author');
+  });
+
+  it('handles load failures', async () => {
+    apiRequest.mockImplementation(async (url: string) => {
+      if (url === '/api/v1/works/work-1/related') throw new Error('boom');
+      if (url === '/api/v1/authors/author-1') throw new Error('boom');
+      throw new Error(`unexpected request: ${url}`);
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).toContain('No related books with covers yet.');
+    expect(wrapper.text()).toContain('No author books with covers yet.');
+  });
+
+  it('shows import errors from api and generic failures', async () => {
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      const method = (opts?.method || 'GET').toUpperCase();
+      if (url === '/api/v1/works/work-1/related') {
+        return {
+          items: [
+            {
+              work_key: '/works/OL2W',
+              title: 'Related One',
+              cover_url: 'https://example.com/related.jpg',
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [],
+        };
+      }
+      if (url === '/api/v1/books/import' && method === 'POST') {
+        throw new ApiClientErrorMock('Denied', 'forbidden', 403);
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+    const wrapper = mountSection();
+    await flushPromises();
+    await wrapper.get('[data-test="related-book-/works/OL2W"]').trigger('click');
+    await flushPromises();
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Denied' }));
+
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      const method = (opts?.method || 'GET').toUpperCase();
+      if (url === '/api/v1/works/work-1/related') {
+        return {
+          items: [
+            {
+              work_key: '/works/OL2W',
+              title: 'Related One',
+              cover_url: 'https://example.com/related.jpg',
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [],
+        };
+      }
+      if (url === '/api/v1/books/import' && method === 'POST') {
+        throw new Error('boom');
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+    await wrapper.get('[data-test="related-book-/works/OL2W"]').trigger('click');
+    await flushPromises();
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ summary: 'Unable to open related book.' }),
+    );
+  });
+
+  it('filters out books without covers', async () => {
+    apiRequest.mockImplementation(async (url: string) => {
+      if (url === '/api/v1/works/work-1/related') {
+        return {
+          items: [
+            { work_key: '/works/OL2W', title: 'No Cover', cover_url: null },
+            { work_key: '/works/OL3W', title: 'Has Cover', cover_url: 'https://example.com/x.jpg' },
+          ],
+        };
+      }
+      if (url === '/api/v1/authors/author-1') {
+        return {
+          id: 'author-1',
+          name: 'Author A',
+          bio: null,
+          photo_url: null,
+          openlibrary_author_key: '/authors/OL1A',
+          works: [
+            { work_key: '/works/OL4W', title: 'No Cover Work', cover_url: null },
+            {
+              work_key: '/works/OL5W',
+              title: 'Cover Work',
+              cover_url: 'https://example.com/y.jpg',
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const wrapper = mountSection();
+    await flushPromises();
+    expect(wrapper.text()).not.toContain('No Cover');
+    expect(wrapper.text()).toContain('Has Cover');
+    expect(wrapper.text()).not.toContain('No Cover Work');
+    expect(wrapper.text()).toContain('Cover Work');
+  });
+});


### PR DESCRIPTION
## Summary
- expand OpenLibrary search and import behavior (filters, payload shaping, edition scoring, richer metadata)
- add related works and author enrichment endpoints backed by OpenLibrary subjects/authors APIs
- add discovery UI on book detail with cover-forward related/author sections and iterative layout polish
- improve resilience around OpenLibrary sort handling and API error paths
- add backfill command/service scaffolding for OpenLibrary metadata maintenance

## API changes
- enhanced `GET /api/v1/books/search` query params and additive response fields
- added `GET /api/v1/works/{work_id}/related`
- added `GET /api/v1/authors/{author_id}`

## Web changes
- new discovery component and rendering on book detail
- expanded search/topbar filter UX for OpenLibrary-driven discovery
- related/author tiles constrained to cover-backed items and language-aware related selection where possible

## Validation
- `make quality` (passes locally)
