### PR TITLE
Add optional Google Books integration and provider-aware cover selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ SUPABASE_ANON_KEY=
 # Server-only (never commit or share broadly)
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_DB_URL=
+BOOK_PROVIDER_GOOGLE_ENABLED=false
+GOOGLE_BOOKS_API_KEY=
+
+# Optional local launcher (make dev-api-bitwarden)
+BITWARDEN_ACCESS_TOKEN=
+GOOGLE_BOOKS_API_KEY_SECRET_ID=
+BITWARDEN_API_URL=https://api.bitwarden.com
+BITWARDEN_IDENTITY_URL=https://identity.bitwarden.com
 
 # Optional: select staging/prod DB targets for migrations
 # SUPABASE_ENV=staging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Project instructions for Codex. These rules override any defaults.
 ## Working agreements (highest priority)
 - Always create and work on a new branch for any change.
 - NEVER commit or open a PR without explicit permission from the user.
+- When writing PR titles/bodies with `gh`, pass real multiline Markdown (or `--body-file`) and never include escaped newline literals like `\n`.
 - Always use the GitHub CLI to read issue descriptions before planning work on an issue.
 - Always read current official documentation (Context7 when available) for any library, framework, or service you touch.
 - Always run `make quality` and fix all failures before reporting a task as complete.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-api dev-web dev-up install install-api install-web \
+.PHONY: dev dev-api dev-api-bitwarden dev-web dev-up install install-api install-web \
 	supabase-start supabase-env supabase-health ensure-web-env \
 	lint lint-api lint-web format format-api format-web \
 	format-check format-check-api format-check-web \
@@ -23,6 +23,10 @@ dev-up:
 # Run API server
 dev-api:
 	cd apps/api && $(API_RUN) uvicorn main:app --reload --port 8000
+
+# Run API server with GOOGLE_BOOKS_API_KEY loaded from Bitwarden Secrets Manager
+dev-api-bitwarden:
+	cd apps/api && $(if $(wildcard $(API_VENV_PY)),$(API_VENV_PY),uv run python) scripts/dev_api_with_bitwarden.py
 
 # Run web server
 dev-web:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,37 @@ Health check:
 make supabase-health
 ```
 
+### Local API with Bitwarden Secrets Manager
+
+To avoid storing `GOOGLE_BOOKS_API_KEY` in `.env`, you can fetch it at runtime from Bitwarden:
+
+1. Install SDK in API env:
+
+```bash
+cd apps/api
+uv add --dev bitwarden-sdk
+```
+
+2. Export required vars:
+
+```bash
+export BITWARDEN_ACCESS_TOKEN=...
+export GOOGLE_BOOKS_API_KEY_SECRET_ID=...
+```
+
+Optional for self-hosted Bitwarden:
+
+```bash
+export BITWARDEN_API_URL=https://api.bitwarden.com
+export BITWARDEN_IDENTITY_URL=https://identity.bitwarden.com
+```
+
+3. Start API:
+
+```bash
+make dev-api-bitwarden
+```
+
 ## Environments
 
 Local development uses a local Supabase instance (`supabase start`). Staging and production use hosted Supabase projects with environment variables set in those environments. See `docs/supabase.md` for how local vs hosted are handled and when to use `supabase link`.

--- a/apps/api/alembic/versions/0012_user_google_books_pref.py
+++ b/apps/api/alembic/versions/0012_user_google_books_pref.py
@@ -16,7 +16,17 @@ branch_labels = None
 depends_on = None
 
 
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = inspector.get_columns(table_name)
+    return any(column["name"] == column_name for column in columns)
+
+
 def upgrade() -> None:
+    if _column_exists("users", "enable_google_books"):
+        return
+
     op.add_column(
         "users",
         sa.Column(
@@ -29,4 +39,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    if not _column_exists("users", "enable_google_books"):
+        return
+
     op.drop_column("users", "enable_google_books")

--- a/apps/api/alembic/versions/0012_user_google_books_pref.py
+++ b/apps/api/alembic/versions/0012_user_google_books_pref.py
@@ -1,0 +1,32 @@
+"""Add per-user Google Books opt-in preference.
+
+Revision ID: 0012_user_google_books_pref
+Revises: 0011_revoke_alembic_privs
+Create Date: 2026-02-13
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0012_user_google_books_pref"
+down_revision = "0011_revoke_alembic_privs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "enable_google_books",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "enable_google_books")

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -19,6 +19,8 @@ class Settings:
     supabase_storage_covers_bucket: str
     public_highlight_max_chars: int
     api_version: str
+    book_provider_google_enabled: bool = False
+    google_books_api_key: str | None = None
     cors_allowed_origins: tuple[str, ...] = (
         "http://localhost:3000",
         "http://127.0.0.1:3000",
@@ -150,6 +152,18 @@ def _parse_public_highlight_max_chars() -> int:
     return max(value, 1)
 
 
+def _parse_bool_env(name: str, *, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
 @lru_cache
 def get_settings() -> Settings:
     """Settings are cached; call reset_settings_cache when env values change."""
@@ -179,6 +193,10 @@ def get_settings() -> Settings:
     if not covers_bucket:
         covers_bucket = "covers"
     public_highlight_max_chars = _parse_public_highlight_max_chars()
+    book_provider_google_enabled = _parse_bool_env(
+        "BOOK_PROVIDER_GOOGLE_ENABLED", default=False
+    )
+    google_books_api_key = os.getenv("GOOGLE_BOOKS_API_KEY", "").strip() or None
     cors_allowed_origins = _parse_cors_origins()
     api_version = os.getenv("API_VERSION", "0.1.0").strip()
     return Settings(
@@ -189,6 +207,8 @@ def get_settings() -> Settings:
         supabase_service_role_key=service_role_key,
         supabase_storage_covers_bucket=covers_bucket,
         public_highlight_max_chars=public_highlight_max_chars,
+        book_provider_google_enabled=book_provider_google_enabled,
+        google_books_api_key=google_books_api_key,
         cors_allowed_origins=cors_allowed_origins,
         api_version=api_version,
     )

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -46,6 +46,11 @@ class User(Base):
     handle: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     display_name: Mapped[str | None] = mapped_column(sa.String(255))
     avatar_url: Mapped[str | None] = mapped_column(sa.Text)
+    enable_google_books: Mapped[bool] = mapped_column(
+        sa.Boolean,
+        nullable=False,
+        server_default=sa.text("false"),
+    )
     actor_uri: Mapped[str | None] = mapped_column(sa.Text)
     created_at: Mapped[dt.datetime] = mapped_column(
         sa.DateTime(timezone=True),

--- a/apps/api/app/routers/me.py
+++ b/apps/api/app/routers/me.py
@@ -17,6 +17,7 @@ class UpdateProfileRequest(BaseModel):
     handle: str | None = Field(default=None, max_length=64)
     display_name: str | None = Field(default=None, max_length=255)
     avatar_url: str | None = Field(default=None, max_length=2048)
+    enable_google_books: bool | None = None
 
 
 router = APIRouter(
@@ -38,6 +39,7 @@ def get_me(
             "handle": profile.handle,
             "display_name": profile.display_name,
             "avatar_url": profile.avatar_url,
+            "enable_google_books": profile.enable_google_books,
         }
     )
 
@@ -55,6 +57,7 @@ def patch_me(
             handle=payload.handle,
             display_name=payload.display_name,
             avatar_url=payload.avatar_url,
+            enable_google_books=payload.enable_google_books,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -65,5 +68,6 @@ def patch_me(
             "handle": profile.handle,
             "display_name": profile.display_name,
             "avatar_url": profile.avatar_url,
+            "enable_google_books": profile.enable_google_books,
         }
     )

--- a/apps/api/app/services/book_providers.py
+++ b/apps/api/app/services/book_providers.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from app.services.google_books import GoogleBooksClient
+from app.services.open_library import OpenLibraryClient
+
+
+@dataclass(frozen=True)
+class BookAttribution:
+    text: str
+    url: str | None
+
+
+@dataclass(frozen=True)
+class BookSearchItem:
+    source: str
+    source_id: str
+    work_key: str
+    title: str
+    author_names: list[str]
+    first_publish_year: int | None
+    cover_url: str | None
+    edition_count: int | None
+    languages: list[str]
+    readable: bool
+    attribution: BookAttribution | None
+
+
+@dataclass(frozen=True)
+class BookSearchResponse:
+    items: list[BookSearchItem]
+    next_page: int | None
+    has_more: bool
+    num_found: int | None
+    cache_hit: bool
+
+
+class BookSearchProvider(Protocol):
+    provider: str
+
+    async def search_books(
+        self,
+        *,
+        query: str,
+        limit: int,
+        page: int,
+        author: str | None = None,
+        subject: str | None = None,
+        language: str | None = None,
+        first_publish_year_from: int | None = None,
+        first_publish_year_to: int | None = None,
+        sort: Literal["relevance", "new", "old"] = "relevance",
+    ) -> BookSearchResponse: ...
+
+
+class OpenLibrarySearchProvider:
+    provider = "openlibrary"
+
+    def __init__(self, client: OpenLibraryClient) -> None:
+        self._client = client
+
+    async def search_books(
+        self,
+        *,
+        query: str,
+        limit: int,
+        page: int,
+        author: str | None = None,
+        subject: str | None = None,
+        language: str | None = None,
+        first_publish_year_from: int | None = None,
+        first_publish_year_to: int | None = None,
+        sort: Literal["relevance", "new", "old"] = "relevance",
+    ) -> BookSearchResponse:
+        response = await self._client.search_books(
+            query=query,
+            limit=limit,
+            page=page,
+            author=author,
+            subject=subject,
+            language=language,
+            first_publish_year_from=first_publish_year_from,
+            first_publish_year_to=first_publish_year_to,
+            sort=sort,
+        )
+        return BookSearchResponse(
+            items=[
+                BookSearchItem(
+                    source=self.provider,
+                    source_id=item.work_key,
+                    work_key=item.work_key,
+                    title=item.title,
+                    author_names=item.author_names,
+                    first_publish_year=item.first_publish_year,
+                    cover_url=item.cover_url,
+                    edition_count=item.edition_count,
+                    languages=item.languages,
+                    readable=item.readable,
+                    attribution=None,
+                )
+                for item in response.items
+            ],
+            next_page=response.next_page,
+            has_more=response.has_more,
+            num_found=response.num_found,
+            cache_hit=response.cache_hit,
+        )
+
+
+class GoogleBooksSearchProvider:
+    provider = "googlebooks"
+
+    def __init__(self, client: GoogleBooksClient) -> None:
+        self._client = client
+
+    async def search_books(
+        self,
+        *,
+        query: str,
+        limit: int,
+        page: int,
+        author: str | None = None,
+        subject: str | None = None,
+        language: str | None = None,
+        first_publish_year_from: int | None = None,
+        first_publish_year_to: int | None = None,
+        sort: Literal["relevance", "new", "old"] = "relevance",
+    ) -> BookSearchResponse:
+        response = await self._client.search_books(
+            query=query,
+            limit=limit,
+            page=page,
+            author=author,
+            subject=subject,
+            language=language,
+            first_publish_year_from=first_publish_year_from,
+            first_publish_year_to=first_publish_year_to,
+            sort=sort,
+        )
+        return BookSearchResponse(
+            items=[
+                BookSearchItem(
+                    source=self.provider,
+                    source_id=item.volume_id,
+                    work_key=f"googlebooks:{item.volume_id}",
+                    title=item.title,
+                    author_names=item.author_names,
+                    first_publish_year=item.first_publish_year,
+                    cover_url=item.cover_url,
+                    edition_count=None,
+                    languages=[item.language] if item.language else [],
+                    readable=item.readable,
+                    attribution=BookAttribution(
+                        text="Data provided by Google Books",
+                        url=item.attribution_url,
+                    ),
+                )
+                for item in response.items
+            ],
+            next_page=response.next_page,
+            has_more=response.has_more,
+            num_found=response.num_found,
+            cache_hit=response.cache_hit,
+        )

--- a/apps/api/app/services/catalog.py
+++ b/apps/api/app/services/catalog.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
 from app.db.models.external_provider import ExternalId, SourceRecord
+from app.services.google_books import GoogleBooksWorkBundle
 from app.services.open_library import OpenLibraryWorkBundle
 
 
@@ -232,6 +233,257 @@ def import_openlibrary_bundle(
                 "created": created_edition,
             }
             if edition_id and edition_key
+            else None
+        ),
+        "authors_processed": len(bundle.authors),
+        "authors_created": created_authors,
+    }
+
+
+def _find_work_by_isbn(
+    session: Session,
+    *,
+    isbn10: str | None,
+    isbn13: str | None,
+) -> Work | None:
+    predicates: list[Any] = []
+    if isbn13:
+        predicates.append(Edition.isbn13 == isbn13)
+    if isbn10:
+        predicates.append(Edition.isbn10 == isbn10)
+    if not predicates:
+        return None
+    work_id = session.scalar(
+        sa.select(Edition.work_id).where(sa.or_(*predicates)).limit(1)
+    )
+    if work_id is None:
+        return None
+    return session.get(Work, work_id)
+
+
+def _find_existing_author_by_name(session: Session, *, name: str) -> Author | None:
+    normalized = name.strip()
+    if not normalized:
+        return None
+    return session.scalar(sa.select(Author).where(Author.name == normalized))
+
+
+def import_googlebooks_bundle(
+    session: Session,
+    *,
+    bundle: GoogleBooksWorkBundle,
+) -> dict[str, Any]:
+    provider = "googlebooks"
+    work_external = _get_external_id(
+        session,
+        entity_type="work",
+        provider=provider,
+        provider_id=bundle.volume_id,
+    )
+
+    edition_data = bundle.edition if isinstance(bundle.edition, dict) else {}
+    isbn10 = edition_data.get("isbn10")
+    isbn13 = edition_data.get("isbn13")
+    matched_work = _find_work_by_isbn(
+        session,
+        isbn10=isbn10 if isinstance(isbn10, str) else None,
+        isbn13=isbn13 if isinstance(isbn13, str) else None,
+    )
+
+    if work_external is not None:
+        work = session.get(Work, work_external.entity_id)
+        if work is None:
+            raise RuntimeError("work external ID points to missing work")
+        created_work = False
+    elif matched_work is not None:
+        work = matched_work
+        created_work = False
+        existing_work_link = session.scalar(
+            sa.select(ExternalId).where(
+                ExternalId.entity_type == "work",
+                ExternalId.entity_id == work.id,
+                ExternalId.provider == provider,
+            )
+        )
+        if existing_work_link is None:
+            session.add(
+                ExternalId(
+                    entity_type="work",
+                    entity_id=work.id,
+                    provider=provider,
+                    provider_id=bundle.volume_id,
+                )
+            )
+    else:
+        work = Work(
+            title=bundle.title,
+            description=bundle.description,
+            first_publish_year=bundle.first_publish_year,
+            default_cover_url=bundle.cover_url,
+        )
+        session.add(work)
+        session.flush()
+        session.add(
+            ExternalId(
+                entity_type="work",
+                entity_id=work.id,
+                provider=provider,
+                provider_id=bundle.volume_id,
+            )
+        )
+        created_work = True
+
+    if not work.description and bundle.description:
+        work.description = bundle.description
+    if work.first_publish_year is None and bundle.first_publish_year is not None:
+        work.first_publish_year = bundle.first_publish_year
+    if work.default_cover_url is None and bundle.cover_url is not None:
+        work.default_cover_url = bundle.cover_url
+
+    _upsert_source_record(
+        session,
+        provider=provider,
+        entity_type="work",
+        provider_id=bundle.volume_id,
+        raw=bundle.raw_volume,
+    )
+
+    created_authors = 0
+    for author_name in bundle.authors:
+        normalized_name = author_name.strip()
+        if not normalized_name:
+            continue
+        author_model = _find_existing_author_by_name(session, name=normalized_name)
+        if author_model is None:
+            author_model = Author(name=normalized_name)
+            session.add(author_model)
+            session.flush()
+            created_authors += 1
+        work_author_link = session.scalar(
+            sa.select(WorkAuthor).where(
+                WorkAuthor.work_id == work.id,
+                WorkAuthor.author_id == author_model.id,
+            )
+        )
+        if work_author_link is None:
+            session.add(WorkAuthor(work_id=work.id, author_id=author_model.id))
+
+    created_edition = False
+    edition_id: str | None = None
+    if edition_data:
+        edition_external = _get_external_id(
+            session,
+            entity_type="edition",
+            provider=provider,
+            provider_id=bundle.volume_id,
+        )
+        if edition_external is not None:
+            edition = session.get(Edition, edition_external.entity_id)
+            if edition is None:
+                raise RuntimeError("edition external ID points to missing edition")
+        else:
+            existing_by_isbn: Edition | None = None
+            predicates: list[Any] = []
+            if isinstance(isbn13, str) and isbn13:
+                predicates.append(Edition.isbn13 == isbn13)
+            if isinstance(isbn10, str) and isbn10:
+                predicates.append(Edition.isbn10 == isbn10)
+            if predicates:
+                existing_by_isbn = session.scalar(
+                    sa.select(Edition)
+                    .where(Edition.work_id == work.id)
+                    .where(sa.or_(*predicates))
+                    .limit(1)
+                )
+            if existing_by_isbn is not None:
+                edition = existing_by_isbn
+            else:
+                edition = Edition(
+                    work_id=work.id,
+                    isbn10=isbn10 if isinstance(isbn10, str) else None,
+                    isbn13=isbn13 if isinstance(isbn13, str) else None,
+                    publisher=(
+                        edition_data.get("publisher")
+                        if isinstance(edition_data.get("publisher"), str)
+                        else None
+                    ),
+                    publish_date=(
+                        edition_data.get("publish_date_iso")
+                        if isinstance(edition_data.get("publish_date_iso"), dt.date)
+                        else None
+                    ),
+                    language=(
+                        edition_data.get("language")
+                        if isinstance(edition_data.get("language"), str)
+                        else None
+                    ),
+                    format=(
+                        edition_data.get("format")
+                        if isinstance(edition_data.get("format"), str)
+                        else None
+                    ),
+                    cover_url=bundle.cover_url,
+                )
+                session.add(edition)
+                session.flush()
+                created_edition = True
+            existing_edition_link = session.scalar(
+                sa.select(ExternalId).where(
+                    ExternalId.entity_type == "edition",
+                    ExternalId.entity_id == edition.id,
+                    ExternalId.provider == provider,
+                )
+            )
+            if existing_edition_link is None:
+                session.add(
+                    ExternalId(
+                        entity_type="edition",
+                        entity_id=edition.id,
+                        provider=provider,
+                        provider_id=bundle.volume_id,
+                    )
+                )
+
+        if edition.isbn10 is None and isinstance(isbn10, str):
+            edition.isbn10 = isbn10
+        if edition.isbn13 is None and isinstance(isbn13, str):
+            edition.isbn13 = isbn13
+        if edition.publisher is None and isinstance(edition_data.get("publisher"), str):
+            edition.publisher = edition_data.get("publisher")
+        if edition.publish_date is None and isinstance(
+            edition_data.get("publish_date_iso"), dt.date
+        ):
+            edition.publish_date = edition_data.get("publish_date_iso")
+        if edition.language is None and isinstance(edition_data.get("language"), str):
+            edition.language = edition_data.get("language")
+        if edition.format is None and isinstance(edition_data.get("format"), str):
+            edition.format = edition_data.get("format")
+        if edition.cover_url is None and bundle.cover_url is not None:
+            edition.cover_url = bundle.cover_url
+        edition_id = str(edition.id)
+
+        _upsert_source_record(
+            session,
+            provider=provider,
+            entity_type="edition",
+            provider_id=bundle.volume_id,
+            raw=bundle.raw_volume,
+        )
+
+    session.commit()
+    return {
+        "work": {
+            "id": str(work.id),
+            "title": work.title,
+            "created": created_work,
+        },
+        "edition": (
+            {
+                "id": edition_id,
+                "provider_id": bundle.volume_id,
+                "created": created_edition,
+            }
+            if edition_id
             else None
         ),
         "authors_processed": len(bundle.authors),

--- a/apps/api/app/services/google_books.py
+++ b/apps/api/app/services/google_books.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import datetime as dt
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+_YEAR_RE = re.compile(r"(\d{4})")
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class GoogleBooksSearchResult:
+    volume_id: str
+    title: str
+    author_names: list[str]
+    first_publish_year: int | None
+    cover_url: str | None
+    language: str | None
+    readable: bool
+    attribution_url: str | None
+
+
+@dataclass(frozen=True)
+class GoogleBooksSearchResponse:
+    items: list[GoogleBooksSearchResult]
+    query: str
+    limit: int
+    page: int
+    num_found: int | None
+    has_more: bool
+    next_page: int | None
+    cache_hit: bool
+
+
+@dataclass(frozen=True)
+class GoogleBooksWorkBundle:
+    volume_id: str
+    title: str
+    description: str | None
+    first_publish_year: int | None
+    cover_url: str | None
+    authors: list[str]
+    edition: dict[str, Any] | None
+    raw_volume: dict[str, Any]
+    attribution_url: str | None
+
+
+def _parse_publish_year(raw: Any) -> int | None:
+    if isinstance(raw, int):
+        return raw if 0 < raw < 10000 else None
+    if isinstance(raw, str):
+        matched = _YEAR_RE.search(raw)
+        if not matched:
+            return None
+        parsed = int(matched.group(1))
+        return parsed if 0 < parsed < 10000 else None
+    return None
+
+
+def _parse_publish_date(raw: Any) -> dt.date | None:
+    if not isinstance(raw, str):
+        return None
+    value = raw.strip()
+    if not _ISO_DATE_RE.match(value):
+        return None
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _normalize_cover_url(url: Any) -> str | None:
+    if not isinstance(url, str):
+        return None
+    value = url.strip()
+    if not value:
+        return None
+    if value.startswith("http://"):
+        return f"https://{value.removeprefix('http://')}"
+    return value
+
+
+def _extract_isbn(identifiers: Any, *, isbn_type: str) -> str | None:
+    if not isinstance(identifiers, list):
+        return None
+    for item in identifiers:
+        if not isinstance(item, dict):
+            continue
+        raw_type = item.get("type")
+        raw_value = item.get("identifier")
+        if not isinstance(raw_type, str) or not isinstance(raw_value, str):
+            continue
+        if raw_type.strip().upper() != isbn_type:
+            continue
+        value = raw_value.strip().replace("-", "")
+        if value:
+            return value
+    return None
+
+
+class GoogleBooksClient:
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        base_url: str = "https://www.googleapis.com/books/v1",
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._transport = transport
+
+    async def _request_json(
+        self,
+        path: str,
+        *,
+        params: dict[str, str | int] | None = None,
+    ) -> dict[str, Any]:
+        merged_params = dict(params or {})
+        if self._api_key:
+            merged_params["key"] = self._api_key
+        timeout = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            transport=self._transport,
+        ) as client:
+            response = await client.get(
+                f"{self._base_url}{path}",
+                params=merged_params,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("google books request returned non-object payload")
+        return payload
+
+    async def search_books(
+        self,
+        *,
+        query: str,
+        limit: int = 10,
+        page: int = 1,
+        author: str | None = None,
+        subject: str | None = None,
+        language: str | None = None,
+        first_publish_year_from: int | None = None,
+        first_publish_year_to: int | None = None,
+        sort: str = "relevance",
+    ) -> GoogleBooksSearchResponse:
+        trimmed = query.strip()
+        if not trimmed:
+            return GoogleBooksSearchResponse(
+                items=[],
+                query="",
+                limit=limit,
+                page=page,
+                num_found=0,
+                has_more=False,
+                next_page=None,
+                cache_hit=False,
+            )
+
+        max_results = max(1, min(limit, 40))
+        page_value = max(page, 1)
+        start_index = (page_value - 1) * max_results
+        q_parts = [trimmed]
+        if author:
+            q_parts.append(f"inauthor:{author.strip()}")
+        if subject:
+            q_parts.append(f"subject:{subject.strip()}")
+        q_value = " ".join(part for part in q_parts if part)
+        params: dict[str, str | int] = {
+            "q": q_value,
+            "maxResults": max_results,
+            "startIndex": start_index,
+            "printType": "books",
+        }
+        if language and language.strip():
+            params["langRestrict"] = language.strip().lower()
+        if sort == "new":
+            params["orderBy"] = "newest"
+
+        payload = await self._request_json("/volumes", params=params)
+        raw_items = payload.get("items")
+        total_items = payload.get("totalItems")
+        items: list[GoogleBooksSearchResult] = []
+        if isinstance(raw_items, list):
+            for raw_item in raw_items:
+                if not isinstance(raw_item, dict):
+                    continue
+                volume_id = raw_item.get("id")
+                if not isinstance(volume_id, str) or not volume_id.strip():
+                    continue
+                volume_info = raw_item.get("volumeInfo")
+                if not isinstance(volume_info, dict):
+                    continue
+                title = volume_info.get("title")
+                if not isinstance(title, str) or not title.strip():
+                    continue
+                published_date = volume_info.get("publishedDate")
+                first_publish_year = _parse_publish_year(published_date)
+                if (
+                    first_publish_year_from is not None
+                    and first_publish_year is not None
+                    and first_publish_year < first_publish_year_from
+                ):
+                    continue
+                if (
+                    first_publish_year_to is not None
+                    and first_publish_year is not None
+                    and first_publish_year > first_publish_year_to
+                ):
+                    continue
+
+                raw_authors = volume_info.get("authors")
+                author_names: list[str] = []
+                if isinstance(raw_authors, list):
+                    author_names = [
+                        author.strip()
+                        for author in raw_authors
+                        if isinstance(author, str) and author.strip()
+                    ]
+
+                image_links = volume_info.get("imageLinks")
+                thumbnail = (
+                    image_links.get("thumbnail")
+                    if isinstance(image_links, dict)
+                    else None
+                )
+                cover_url = _normalize_cover_url(thumbnail)
+                language_code = volume_info.get("language")
+                access_info = raw_item.get("accessInfo")
+                readable = False
+                if isinstance(access_info, dict):
+                    viewability = access_info.get("viewability")
+                    if isinstance(viewability, str):
+                        readable = viewability.upper() != "NO_PAGES"
+
+                info_link = volume_info.get("canonicalVolumeLink")
+                if not isinstance(info_link, str) or not info_link.strip():
+                    info_link = volume_info.get("infoLink")
+
+                items.append(
+                    GoogleBooksSearchResult(
+                        volume_id=volume_id,
+                        title=title.strip(),
+                        author_names=author_names,
+                        first_publish_year=first_publish_year,
+                        cover_url=cover_url,
+                        language=(
+                            language_code.strip().lower()
+                            if isinstance(language_code, str) and language_code.strip()
+                            else None
+                        ),
+                        readable=readable,
+                        attribution_url=(
+                            info_link.strip()
+                            if isinstance(info_link, str) and info_link.strip()
+                            else None
+                        ),
+                    )
+                )
+
+        num_found = total_items if isinstance(total_items, int) else None
+        has_more = (
+            bool(num_found is not None and start_index + len(items) < num_found)
+            if num_found is not None
+            else len(items) >= max_results
+        )
+        next_page = page_value + 1 if has_more else None
+
+        return GoogleBooksSearchResponse(
+            items=items,
+            query=trimmed,
+            limit=max_results,
+            page=page_value,
+            num_found=num_found,
+            has_more=has_more,
+            next_page=next_page,
+            cache_hit=False,
+        )
+
+    async def fetch_work_bundle(self, *, volume_id: str) -> GoogleBooksWorkBundle:
+        normalized_volume_id = volume_id.strip()
+        if not normalized_volume_id:
+            raise ValueError("volume_id is required")
+
+        payload = await self._request_json(f"/volumes/{normalized_volume_id}")
+        volume_info = payload.get("volumeInfo")
+        if not isinstance(volume_info, dict):
+            raise LookupError("google books volume missing volumeInfo")
+
+        title = volume_info.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise LookupError("google books volume missing title")
+
+        authors_raw = volume_info.get("authors")
+        authors = (
+            [
+                value.strip()
+                for value in authors_raw
+                if isinstance(value, str) and value.strip()
+            ]
+            if isinstance(authors_raw, list)
+            else []
+        )
+        image_links = volume_info.get("imageLinks")
+        cover_url = _normalize_cover_url(
+            image_links.get("thumbnail") if isinstance(image_links, dict) else None
+        )
+        language = volume_info.get("language")
+        identifiers = volume_info.get("industryIdentifiers")
+        published_date = volume_info.get("publishedDate")
+        publish_date_iso = _parse_publish_date(published_date)
+        first_publish_year = _parse_publish_year(published_date)
+        isbn10 = _extract_isbn(identifiers, isbn_type="ISBN_10")
+        isbn13 = _extract_isbn(identifiers, isbn_type="ISBN_13")
+        publisher = volume_info.get("publisher")
+        print_type = volume_info.get("printType")
+        info_link = volume_info.get("canonicalVolumeLink")
+        if not isinstance(info_link, str) or not info_link.strip():
+            info_link = volume_info.get("infoLink")
+
+        edition: dict[str, Any] | None = None
+        if isbn10 or isbn13 or publish_date_iso or publisher or language or print_type:
+            edition = {
+                "isbn10": isbn10,
+                "isbn13": isbn13,
+                "publisher": (
+                    publisher.strip()
+                    if isinstance(publisher, str) and publisher.strip()
+                    else None
+                ),
+                "publish_date_iso": publish_date_iso,
+                "language": (
+                    language.strip().lower()
+                    if isinstance(language, str) and language.strip()
+                    else None
+                ),
+                "format": (
+                    print_type.strip().lower()
+                    if isinstance(print_type, str) and print_type.strip()
+                    else None
+                ),
+            }
+
+        description = volume_info.get("description")
+        return GoogleBooksWorkBundle(
+            volume_id=normalized_volume_id,
+            title=title.strip(),
+            description=description.strip() if isinstance(description, str) else None,
+            first_publish_year=first_publish_year,
+            cover_url=cover_url,
+            authors=authors,
+            edition=edition,
+            raw_volume=payload,
+            attribution_url=info_link.strip() if isinstance(info_link, str) else None,
+        )

--- a/apps/api/app/services/user_library.py
+++ b/apps/api/app/services/user_library.py
@@ -56,6 +56,7 @@ def get_or_create_profile(session: Session, *, user_id: uuid.UUID) -> User:
         handle=_default_handle(user_id),
         display_name=None,
         avatar_url=None,
+        enable_google_books=False,
     )
     session.add(profile)
     session.commit()
@@ -69,6 +70,7 @@ def update_profile(
     handle: str | None,
     display_name: str | None,
     avatar_url: str | None,
+    enable_google_books: bool | None,
 ) -> User:
     profile = get_or_create_profile(session, user_id=user_id)
 
@@ -88,6 +90,9 @@ def update_profile(
 
     if avatar_url is not None:
         profile.avatar_url = avatar_url.strip() or None
+
+    if enable_google_books is not None:
+        profile.enable_google_books = enable_google_books
 
     session.commit()
     return profile

--- a/apps/api/app/services/work_covers.py
+++ b/apps/api/app/services/work_covers.py
@@ -7,10 +7,11 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from app.core.config import Settings
-from app.db.models.bibliography import Edition, Work
+from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
 from app.db.models.external_provider import ExternalId, SourceRecord
 from app.db.models.users import LibraryItem
 from app.services.covers import cache_cover_to_storage, cache_edition_cover_from_url
+from app.services.google_books import GoogleBooksClient
 from app.services.open_library import OpenLibraryClient
 
 
@@ -53,9 +54,9 @@ async def list_openlibrary_cover_candidates(
     if source is not None and isinstance(source.raw, dict):
         covers = source.raw.get("covers")
         if isinstance(covers, list):
-            for c in covers:
-                if isinstance(c, int) and c > 0:
-                    cover_ids.append(c)
+            for cover_id in covers:
+                if isinstance(cover_id, int) and cover_id > 0:
+                    cover_ids.append(cover_id)
 
     if not cover_ids:
         # Fall back to Open Library directly. Some works have covers only on editions.
@@ -63,7 +64,6 @@ async def list_openlibrary_cover_candidates(
             work_key=provider_id, editions_limit=50
         )
 
-    # Stable, de-duped ordering.
     seen: set[int] = set()
     items: list[dict[str, object]] = []
     for cover_id in cover_ids:
@@ -72,22 +72,154 @@ async def list_openlibrary_cover_candidates(
         seen.add(cover_id)
         items.append(
             {
+                "source": "openlibrary",
+                "source_id": str(cover_id),
                 "cover_id": cover_id,
                 "thumbnail_url": f"https://covers.openlibrary.org/b/id/{cover_id}-M.jpg",
                 "image_url": f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg",
+                "source_url": f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg",
             }
         )
     return items
 
 
-async def select_openlibrary_cover(
+def _list_isbn_queries(session: Session, *, work_id: uuid.UUID) -> list[str]:
+    rows = session.execute(
+        sa.select(Edition.isbn13, Edition.isbn10)
+        .where(Edition.work_id == work_id)
+        .order_by(Edition.created_at.desc(), Edition.id.desc())
+        .limit(8)
+    ).all()
+    values: list[str] = []
+    for isbn13, isbn10 in rows:
+        if isinstance(isbn13, str) and isbn13.strip():
+            values.append(isbn13.strip().replace("-", ""))
+        if isinstance(isbn10, str) and isbn10.strip():
+            values.append(isbn10.strip().replace("-", ""))
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _first_author_name(session: Session, *, work_id: uuid.UUID) -> str | None:
+    row = session.execute(
+        sa.select(Author.name)
+        .select_from(WorkAuthor)
+        .join(Author, Author.id == WorkAuthor.author_id)
+        .where(WorkAuthor.work_id == work_id)
+        .order_by(Author.name.asc())
+        .limit(1)
+    ).first()
+    if row is None:
+        return None
+    author_name = row[0]
+    if isinstance(author_name, str) and author_name.strip():
+        return author_name.strip()
+    return None
+
+
+async def list_googlebooks_cover_candidates(
+    session: Session,
+    *,
+    work_id: uuid.UUID,
+    google_books: GoogleBooksClient,
+) -> list[dict[str, object]]:
+    work = session.get(Work, work_id)
+    if work is None:
+        return []
+
+    items: list[dict[str, object]] = []
+    seen_urls: set[str] = set()
+
+    mapped_google_id = session.scalar(
+        sa.select(ExternalId.provider_id).where(
+            ExternalId.entity_type == "work",
+            ExternalId.entity_id == work_id,
+            ExternalId.provider == "googlebooks",
+        )
+    )
+    if isinstance(mapped_google_id, str) and mapped_google_id.strip():
+        bundle = await google_books.fetch_work_bundle(
+            volume_id=mapped_google_id.strip()
+        )
+        if bundle.cover_url:
+            seen_urls.add(bundle.cover_url)
+            items.append(
+                {
+                    "source": "googlebooks",
+                    "source_id": bundle.volume_id,
+                    "thumbnail_url": bundle.cover_url,
+                    "image_url": bundle.cover_url,
+                    "source_url": bundle.cover_url,
+                    "attribution": {
+                        "text": "Cover image from Google Books",
+                        "url": bundle.attribution_url,
+                    },
+                }
+            )
+
+    title_query = work.title.strip()
+    author_query = _first_author_name(session, work_id=work_id)
+    search_queries = [
+        f"isbn:{isbn}" for isbn in _list_isbn_queries(session, work_id=work_id)
+    ]
+    if title_query:
+        search_queries.append(title_query)
+
+    seen_queries: set[str] = set()
+    for query in search_queries:
+        normalized_query = query.strip()
+        if not normalized_query or normalized_query in seen_queries:
+            continue
+        seen_queries.add(normalized_query)
+        response = await google_books.search_books(
+            query=normalized_query,
+            limit=8,
+            page=1,
+            author=(None if normalized_query.startswith("isbn:") else author_query),
+            sort="relevance",
+        )
+        for candidate in response.items:
+            if not candidate.cover_url:
+                continue
+            if candidate.cover_url in seen_urls:
+                continue
+            seen_urls.add(candidate.cover_url)
+            items.append(
+                {
+                    "source": "googlebooks",
+                    "source_id": candidate.volume_id,
+                    "thumbnail_url": candidate.cover_url,
+                    "image_url": candidate.cover_url,
+                    "source_url": candidate.cover_url,
+                    "attribution": {
+                        "text": "Cover image from Google Books",
+                        "url": candidate.attribution_url,
+                    },
+                }
+            )
+            if len(items) >= 16:
+                return items
+    return items
+
+
+async def select_cover_from_url(
     session: Session,
     *,
     settings: Settings,
     user_id: uuid.UUID,
     work_id: uuid.UUID,
-    cover_id: int,
+    source_url: str,
 ) -> dict[str, object]:
+    normalized_url = source_url.strip()
+    if not normalized_url:
+        raise ValueError("source_url is required")
+
     item = session.scalar(
         sa.select(LibraryItem).where(
             LibraryItem.user_id == user_id,
@@ -97,9 +229,7 @@ async def select_openlibrary_cover(
     if item is None:
         raise PermissionError("book must be in your library to set a cover")
 
-    source_url = f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
     now = dt.datetime.now(tz=dt.UTC)
-
     if not _work_has_global_cover(session, work_id=work_id):
         edition_id = item.preferred_edition_id
         if edition_id is None:
@@ -109,18 +239,19 @@ async def select_openlibrary_cover(
                 .order_by(Edition.created_at.desc(), Edition.id.desc())
                 .limit(1)
             )
-
         if edition_id is not None:
             result = await cache_edition_cover_from_url(
                 session,
                 settings=settings,
                 edition_id=edition_id,
-                source_url=source_url,
+                source_url=normalized_url,
                 user_id=user_id,
             )
             return {"scope": "global", "cover_url": result.cover_url}
 
-        upload = await cache_cover_to_storage(settings=settings, source_url=source_url)
+        upload = await cache_cover_to_storage(
+            settings=settings, source_url=normalized_url
+        )
         work = session.get(Work, work_id)
         if work is None:
             raise LookupError("work not found")
@@ -131,10 +262,27 @@ async def select_openlibrary_cover(
         session.commit()
         return {"scope": "global", "cover_url": upload.public_url}
 
-    upload = await cache_cover_to_storage(settings=settings, source_url=source_url)
+    upload = await cache_cover_to_storage(settings=settings, source_url=normalized_url)
     item.cover_override_url = upload.public_url
     item.cover_override_storage_path = upload.path or None
     item.cover_override_set_by = user_id
     item.cover_override_set_at = now
     session.commit()
     return {"scope": "override", "cover_url": upload.public_url}
+
+
+async def select_openlibrary_cover(
+    session: Session,
+    *,
+    settings: Settings,
+    user_id: uuid.UUID,
+    work_id: uuid.UUID,
+    cover_id: int,
+) -> dict[str, object]:
+    return await select_cover_from_url(
+        session,
+        settings=settings,
+        user_id=user_id,
+        work_id=work_id,
+        source_url=f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg",
+    )

--- a/apps/api/scripts/dev_api_with_bitwarden.py
+++ b/apps/api/scripts/dev_api_with_bitwarden.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run the API with GOOGLE_BOOKS_API_KEY fetched from Bitwarden Secrets Manager."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _fetch_google_books_api_key() -> str:
+    try:
+        from bitwarden_sdk import (  # type: ignore[import-not-found]
+            BitwardenClient,
+            DeviceType,
+            client_settings_from_dict,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "bitwarden-sdk is not installed. Run: cd apps/api && uv add --dev bitwarden-sdk"
+        ) from exc
+
+    access_token = _require_env("BITWARDEN_ACCESS_TOKEN")
+    secret_id = _require_env("GOOGLE_BOOKS_API_KEY_SECRET_ID")
+
+    api_url = os.getenv("BITWARDEN_API_URL", "https://api.bitwarden.com").strip()
+    identity_url = os.getenv(
+        "BITWARDEN_IDENTITY_URL", "https://identity.bitwarden.com"
+    ).strip()
+    state_file = os.getenv("BITWARDEN_STATE_FILE", "").strip() or None
+
+    client = BitwardenClient(
+        client_settings_from_dict(
+            {
+                "apiUrl": api_url,
+                "deviceType": DeviceType.SDK,
+                "identityUrl": identity_url,
+                "userAgent": "chapterverse-api-dev",
+            }
+        )
+    )
+    client.auth().login_access_token(access_token, state_file)
+
+    response = client.secrets().get_by_ids([secret_id])
+    secrets = getattr(getattr(response, "data", None), "data", None)
+    if not secrets:
+        raise RuntimeError(
+            "Bitwarden returned no secrets for GOOGLE_BOOKS_API_KEY_SECRET_ID."
+        )
+
+    secret_value = getattr(secrets[0], "value", None)
+    if not isinstance(secret_value, str) or not secret_value.strip():
+        raise RuntimeError("Bitwarden secret value is empty.")
+    return secret_value.strip()
+
+
+def main() -> int:
+    try:
+        google_books_api_key = _fetch_google_books_api_key()
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    env = dict(os.environ)
+    env["GOOGLE_BOOKS_API_KEY"] = google_books_api_key
+    env.setdefault("BOOK_PROVIDER_GOOGLE_ENABLED", "true")
+
+    port = os.getenv("API_PORT", "8000").strip() or "8000"
+    cmd = [sys.executable, "-m", "uvicorn", "main:app", "--reload", "--port", port]
+
+    print("Starting API with Google Books key loaded from Bitwarden...")
+    os.execvpe(cmd[0], cmd, env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -11,8 +11,10 @@ from app.db.models.external_provider import ExternalId, SourceRecord
 from app.services.catalog import (
     _get_external_id,
     _upsert_source_record,
+    import_googlebooks_bundle,
     import_openlibrary_bundle,
 )
+from app.services.google_books import GoogleBooksWorkBundle
 from app.services.open_library import OpenLibraryWorkBundle
 
 
@@ -66,6 +68,27 @@ def _bundle() -> OpenLibraryWorkBundle:
         },
         raw_work={"k": "v"},
         raw_edition={"ek": "ev"},
+    )
+
+
+def _google_bundle() -> GoogleBooksWorkBundle:
+    return GoogleBooksWorkBundle(
+        volume_id="gb1",
+        title="Google Book",
+        description="Google Desc",
+        first_publish_year=2001,
+        cover_url="https://books.google.com/cover.jpg",
+        authors=["Google Author"],
+        edition={
+            "isbn10": "0123456789",
+            "isbn13": "9780123456789",
+            "publisher": "Google Pub",
+            "publish_date_iso": dt.date(2020, 1, 1),
+            "language": "en",
+            "format": "book",
+        },
+        raw_volume={"id": "gb1"},
+        attribution_url="https://books.google.com/gb1",
     )
 
 
@@ -336,3 +359,226 @@ def test_import_openlibrary_bundle_raises_when_external_missing_target() -> None
             raise AssertionError("expected RuntimeError")
     finally:
         catalog._get_external_id = original
+
+
+def test_import_googlebooks_bundle_creates_records() -> None:
+    session = FakeSession()
+    # work external id, work by isbn, source_record(work), author by name, work_author link,
+    # edition external id, edition by isbn, edition external link, source_record(edition)
+    session.scalar_values = [None] * 9
+
+    result = import_googlebooks_bundle(cast(Any, session), bundle=_google_bundle())
+
+    assert session.committed is True
+    assert result["work"]["created"] is True
+    assert result["edition"]["created"] is True
+    assert result["authors_processed"] == 1
+    assert result["authors_created"] == 1
+    assert any(
+        isinstance(obj, ExternalId)
+        and obj.provider == "googlebooks"
+        and obj.entity_type == "work"
+        for obj in session.added
+    )
+    assert any(
+        isinstance(obj, ExternalId)
+        and obj.provider == "googlebooks"
+        and obj.entity_type == "edition"
+        for obj in session.added
+    )
+
+
+def test_import_googlebooks_bundle_uses_existing_records() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    edition_id = uuid.uuid4()
+    work = Work(
+        id=work_id,
+        title="Existing",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    edition = Edition(
+        id=edition_id,
+        work_id=work_id,
+        isbn10=None,
+        isbn13=None,
+        publisher=None,
+        publish_date=None,
+        language=None,
+        format=None,
+        cover_url=None,
+    )
+    session.get_map = {(Work, work_id): work, (Edition, edition_id): edition}
+    session.scalar_values = [
+        ExternalId(
+            entity_type="work",
+            entity_id=work_id,
+            provider="googlebooks",
+            provider_id="gb1",
+        ),
+        None,
+        SourceRecord(
+            provider="googlebooks",
+            entity_type="work",
+            provider_id="gb1",
+            raw={},
+        ),
+        Author(id=uuid.uuid4(), name="Google Author"),
+        object(),
+        ExternalId(
+            entity_type="edition",
+            entity_id=edition_id,
+            provider="googlebooks",
+            provider_id="gb1",
+        ),
+        SourceRecord(
+            provider="googlebooks",
+            entity_type="edition",
+            provider_id="gb1",
+            raw={},
+        ),
+    ]
+
+    result = import_googlebooks_bundle(cast(Any, session), bundle=_google_bundle())
+
+    assert result["work"]["created"] is False
+    assert result["edition"]["created"] is False
+    assert work.description == "Google Desc"
+    assert work.first_publish_year == 2001
+    assert work.default_cover_url == "https://books.google.com/cover.jpg"
+    assert edition.isbn10 == "0123456789"
+    assert edition.isbn13 == "9780123456789"
+    assert edition.publisher == "Google Pub"
+    assert edition.publish_date == dt.date(2020, 1, 1)
+    assert edition.language == "en"
+    assert edition.format == "book"
+    assert edition.cover_url == "https://books.google.com/cover.jpg"
+
+
+def test_import_googlebooks_bundle_raises_when_external_missing_target() -> None:
+    session = FakeSession()
+    session.scalar_values = [
+        ExternalId(
+            entity_type="work",
+            entity_id=uuid.uuid4(),
+            provider="googlebooks",
+            provider_id="gb1",
+        )
+    ]
+    try:
+        import_googlebooks_bundle(cast(Any, session), bundle=_google_bundle())
+    except RuntimeError as exc:
+        assert "missing work" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_import_googlebooks_bundle_links_to_existing_work_by_isbn() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    work = Work(
+        id=work_id,
+        title="Existing",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    edition_id = uuid.uuid4()
+    edition = Edition(
+        id=edition_id,
+        work_id=work_id,
+        isbn10=None,
+        isbn13="9780123456789",
+        publisher=None,
+        publish_date=None,
+        language=None,
+        format=None,
+        cover_url=None,
+    )
+    session.get_map = {(Work, work_id): work}
+    session.scalar_values = [
+        None,
+        work_id,
+        None,
+        None,
+        None,
+        edition,
+        None,
+        None,
+    ]
+    base = _google_bundle()
+    bundle = GoogleBooksWorkBundle(
+        volume_id=base.volume_id,
+        title=base.title,
+        description=base.description,
+        first_publish_year=base.first_publish_year,
+        cover_url=base.cover_url,
+        authors=[],
+        edition={"isbn13": "9780123456789"},
+        raw_volume=base.raw_volume,
+        attribution_url=base.attribution_url,
+    )
+
+    result = import_googlebooks_bundle(cast(Any, session), bundle=bundle)
+
+    assert result["work"]["created"] is False
+    assert result["edition"] is not None
+    assert result["edition"]["created"] is False
+    assert any(
+        isinstance(obj, ExternalId)
+        and obj.entity_type == "work"
+        and obj.provider == "googlebooks"
+        for obj in session.added
+    )
+
+
+def test_import_googlebooks_bundle_raises_when_edition_external_missing_target() -> (
+    None
+):
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    work = Work(
+        id=work_id,
+        title="Existing",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    session.get_map = {(Work, work_id): work}
+    session.scalar_values = [
+        ExternalId(
+            entity_type="work",
+            entity_id=work_id,
+            provider="googlebooks",
+            provider_id="gb1",
+        ),
+        None,
+        None,
+        ExternalId(
+            entity_type="edition",
+            entity_id=uuid.uuid4(),
+            provider="googlebooks",
+            provider_id="gb1",
+        ),
+    ]
+    base = _google_bundle()
+    bundle = GoogleBooksWorkBundle(
+        volume_id=base.volume_id,
+        title=base.title,
+        description=base.description,
+        first_publish_year=base.first_publish_year,
+        cover_url=base.cover_url,
+        authors=[],
+        edition=base.edition,
+        raw_volume=base.raw_volume,
+        attribution_url=base.attribution_url,
+    )
+
+    try:
+        import_googlebooks_bundle(cast(Any, session), bundle=bundle)
+    except RuntimeError as exc:
+        assert "missing edition" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")

--- a/apps/api/tests/test_google_books_service.py
+++ b/apps/api/tests/test_google_books_service.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+
+import httpx
+
+from app.services.google_books import GoogleBooksClient
+
+
+def test_google_books_search_parses_results() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/volumes")
+        return httpx.Response(
+            200,
+            json={
+                "totalItems": 1,
+                "items": [
+                    {
+                        "id": "gb1",
+                        "volumeInfo": {
+                            "title": "Book",
+                            "authors": ["A"],
+                            "publishedDate": "2001-01-01",
+                            "language": "en",
+                            "imageLinks": {"thumbnail": "http://example.com/cover.jpg"},
+                            "canonicalVolumeLink": "https://books.google.com/gb1",
+                        },
+                        "accessInfo": {"viewability": "PARTIAL"},
+                    }
+                ],
+            },
+        )
+
+    client = GoogleBooksClient(
+        api_key="k",
+        transport=httpx.MockTransport(handler),
+    )
+    response = asyncio.run(client.search_books(query="book", limit=10, page=1))
+    assert response.items[0].volume_id == "gb1"
+    assert response.items[0].cover_url == "https://example.com/cover.jpg"
+    assert response.items[0].readable is True
+
+
+def test_google_books_fetch_work_bundle_parses_edition() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/volumes/gb1")
+        return httpx.Response(
+            200,
+            json={
+                "id": "gb1",
+                "volumeInfo": {
+                    "title": "Book",
+                    "authors": ["A"],
+                    "description": "D",
+                    "publishedDate": "2004-10-09",
+                    "publisher": "P",
+                    "language": "en",
+                    "printType": "BOOK",
+                    "industryIdentifiers": [
+                        {"type": "ISBN_10", "identifier": "0123456789"},
+                        {"type": "ISBN_13", "identifier": "9780123456789"},
+                    ],
+                    "imageLinks": {"thumbnail": "http://example.com/cover.jpg"},
+                    "infoLink": "https://books.google.com/gb1",
+                },
+            },
+        )
+
+    client = GoogleBooksClient(
+        api_key="k",
+        transport=httpx.MockTransport(handler),
+    )
+    bundle = asyncio.run(client.fetch_work_bundle(volume_id="gb1"))
+    assert bundle.volume_id == "gb1"
+    assert bundle.first_publish_year == 2004
+    assert bundle.cover_url == "https://example.com/cover.jpg"
+    assert bundle.edition is not None
+    assert bundle.edition["isbn10"] == "0123456789"
+    assert bundle.edition["isbn13"] == "9780123456789"
+    assert bundle.edition["publish_date_iso"] == dt.date(2004, 10, 9)
+
+
+def test_google_books_search_empty_query_returns_empty() -> None:
+    client = GoogleBooksClient(api_key="k")
+    response = asyncio.run(client.search_books(query="   ", limit=10, page=1))
+    assert response.items == []
+    assert response.has_more is False
+
+
+def test_google_books_search_filters_and_handles_missing_fields() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "totalItems": 3,
+                "items": [
+                    {"id": "missing-volume-info"},
+                    {
+                        "id": "filtered-year",
+                        "volumeInfo": {
+                            "title": "Old Book",
+                            "publishedDate": "1990",
+                        },
+                    },
+                    {
+                        "id": "kept",
+                        "volumeInfo": {
+                            "title": "Book",
+                            "authors": ["A", 1],
+                            "publishedDate": "2005",
+                            "language": "EN",
+                        },
+                        "accessInfo": {"viewability": "NO_PAGES"},
+                    },
+                ],
+            },
+        )
+
+    client = GoogleBooksClient(api_key="k", transport=httpx.MockTransport(handler))
+    response = asyncio.run(
+        client.search_books(
+            query="book",
+            limit=10,
+            page=1,
+            first_publish_year_from=2000,
+            first_publish_year_to=2010,
+            sort="new",
+        )
+    )
+    assert len(response.items) == 1
+    assert response.items[0].volume_id == "kept"
+    assert response.items[0].readable is False
+    assert response.items[0].language == "en"
+
+
+def test_google_books_fetch_work_bundle_handles_sparse_fields() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "gb2",
+                "volumeInfo": {
+                    "title": "Book",
+                    "publishedDate": "2004",
+                    "industryIdentifiers": [
+                        {"type": "ISBN_13", "identifier": "9780123456789"}
+                    ],
+                },
+            },
+        )
+
+    client = GoogleBooksClient(api_key="k", transport=httpx.MockTransport(handler))
+    bundle = asyncio.run(client.fetch_work_bundle(volume_id="gb2"))
+    assert bundle.first_publish_year == 2004
+    assert bundle.edition is not None
+    assert bundle.edition["isbn13"] == "9780123456789"
+    assert bundle.edition["publish_date_iso"] is None
+
+
+def test_google_books_search_raises_on_non_object_payload() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"id": "not-an-object"}])
+
+    client = GoogleBooksClient(api_key="k", transport=httpx.MockTransport(handler))
+    try:
+        asyncio.run(client.search_books(query="book", limit=10, page=1))
+    except RuntimeError as exc:
+        assert "non-object payload" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_google_books_fetch_work_bundle_validates_inputs_and_required_fields() -> None:
+    client = GoogleBooksClient(api_key="k")
+    try:
+        asyncio.run(client.fetch_work_bundle(volume_id="   "))
+    except ValueError as exc:
+        assert "volume_id is required" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+    async def missing_volume_info(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "gb3"})
+
+    client_missing_volume = GoogleBooksClient(
+        api_key="k",
+        transport=httpx.MockTransport(missing_volume_info),
+    )
+    try:
+        asyncio.run(client_missing_volume.fetch_work_bundle(volume_id="gb3"))
+    except LookupError as exc:
+        assert "volumeInfo" in str(exc)
+    else:
+        raise AssertionError("expected LookupError")
+
+
+def test_google_books_fetch_work_bundle_without_optional_metadata() -> None:
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "gb5",
+                "volumeInfo": {
+                    "title": "Book",
+                    "canonicalVolumeLink": "https://books.google.com/gb5",
+                },
+            },
+        )
+
+    client = GoogleBooksClient(api_key="k", transport=httpx.MockTransport(handler))
+    bundle = asyncio.run(client.fetch_work_bundle(volume_id="gb5"))
+    assert bundle.edition is None
+    assert bundle.attribution_url == "https://books.google.com/gb5"
+
+
+def test_google_books_search_includes_author_and_subject_filters() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.params.get("q", "")
+        assert "inauthor:Rowling" in query
+        assert "subject:Fantasy" in query
+        return httpx.Response(200, json={"totalItems": 0, "items": []})
+
+    client = GoogleBooksClient(api_key="k", transport=httpx.MockTransport(handler))
+    response = asyncio.run(
+        client.search_books(
+            query="harry",
+            limit=10,
+            page=1,
+            author="Rowling",
+            subject="Fantasy",
+            language="eng",
+            sort="new",
+        )
+    )
+    assert response.items == []
+
+    async def missing_title(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "gb4", "volumeInfo": {}})
+
+    client_missing_title = GoogleBooksClient(
+        api_key="k",
+        transport=httpx.MockTransport(missing_title),
+    )
+    try:
+        asyncio.run(client_missing_title.fetch_work_bundle(volume_id="gb4"))
+    except LookupError as exc:
+        assert "missing title" in str(exc)
+    else:
+        raise AssertionError("expected LookupError")

--- a/apps/api/tests/test_user_library_models.py
+++ b/apps/api/tests/test_user_library_models.py
@@ -24,6 +24,7 @@ def test_users_table_schema() -> None:
         "handle",
         "display_name",
         "avatar_url",
+        "enable_google_books",
         "actor_uri",
         "created_at",
         "updated_at",
@@ -35,6 +36,7 @@ def test_users_table_schema() -> None:
     assert isinstance(table.columns["display_name"].type, sa.String)
     assert table.columns["display_name"].type.length == 255
     assert isinstance(table.columns["avatar_url"].type, sa.Text)
+    assert isinstance(table.columns["enable_google_books"].type, sa.Boolean)
 
     created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
     updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)

--- a/apps/api/tests/test_user_library_service.py
+++ b/apps/api/tests/test_user_library_service.py
@@ -144,6 +144,7 @@ def test_update_profile_validates_handle() -> None:
             handle="   ",
             display_name=None,
             avatar_url=None,
+            enable_google_books=None,
         )
 
 
@@ -160,6 +161,7 @@ def test_update_profile_rejects_duplicate_handle() -> None:
             handle="taken",
             display_name=None,
             avatar_url=None,
+            enable_google_books=None,
         )
 
 
@@ -175,11 +177,13 @@ def test_update_profile_updates_fields() -> None:
         handle="fresh",
         display_name=" Name ",
         avatar_url=" https://example.com/avatar.png ",
+        enable_google_books=True,
     )
     assert updated is profile
     assert updated.handle == "fresh"
     assert updated.display_name == "Name"
     assert updated.avatar_url == "https://example.com/avatar.png"
+    assert updated.enable_google_books is True
 
 
 def test_create_or_get_library_item_handles_missing_work() -> None:

--- a/apps/api/tests/test_work_covers_service.py
+++ b/apps/api/tests/test_work_covers_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -14,7 +14,9 @@ from app.services import work_covers
 from app.services.covers import CoverCacheResult
 from app.services.storage import StorageUploadResult
 from app.services.work_covers import (
+    list_googlebooks_cover_candidates,
     list_openlibrary_cover_candidates,
+    select_cover_from_url,
     select_openlibrary_cover,
 )
 
@@ -76,6 +78,7 @@ def test_list_openlibrary_cover_candidates_parses_source_record() -> None:
     assert [i["cover_id"] for i in items] == [10, 11]
     assert "thumbnail_url" in items[0]
     assert "image_url" in items[0]
+    assert items[0]["source"] == "openlibrary"
 
 
 def test_list_openlibrary_cover_candidates_returns_empty_when_missing() -> None:
@@ -141,6 +144,291 @@ def test_list_openlibrary_cover_candidates_returns_empty_when_covers_invalid() -
     assert [i["cover_id"] for i in items] == [10, 11]
 
 
+def test_list_googlebooks_cover_candidates_by_isbn() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    work = Work(
+        id=work_id,
+        title="Book",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    session.get_map[(Work, work_id)] = work
+    session.scalar_values = [None]
+
+    def _execute(_stmt: Any) -> Any:
+        class _Res:
+            @staticmethod
+            def all() -> list[tuple[str, str | None]]:
+                return [("9780000000001", None)]
+
+            @staticmethod
+            def first() -> tuple[str] | None:
+                return None
+
+        return _Res()
+
+    session.execute = _execute  # type: ignore[attr-defined]
+
+    class _Google:
+        async def search_books(self, **kwargs: Any) -> Any:
+            query = kwargs["query"]
+            if query != "isbn:9780000000001":
+                return type("Resp", (), {"items": []})()
+            return type(
+                "Resp",
+                (),
+                {
+                    "items": [
+                        type(
+                            "Item",
+                            (),
+                            {
+                                "volume_id": "gb1",
+                                "cover_url": "https://books.google.com/cover.jpg",
+                                "attribution_url": "https://books.google.com/books?id=gb1",
+                            },
+                        )()
+                    ]
+                },
+            )()
+
+        async def fetch_work_bundle(self, **_kwargs: Any) -> Any:
+            raise AssertionError("should not fetch bundle without mapped google id")
+
+    items = asyncio.run(
+        list_googlebooks_cover_candidates(
+            session, work_id=work_id, google_books=_Google()  # type: ignore[arg-type]
+        )
+    )
+    assert len(items) == 1
+    assert items[0]["source"] == "googlebooks"
+    assert items[0]["source_id"] == "gb1"
+
+
+def test_list_googlebooks_cover_candidates_returns_empty_when_work_missing() -> None:
+    session = FakeSession()
+
+    class _Google:
+        async def fetch_work_bundle(self, **_kwargs: Any) -> Any:
+            raise AssertionError("should not be called")
+
+        async def search_books(self, **_kwargs: Any) -> Any:
+            raise AssertionError("should not be called")
+
+    items = asyncio.run(
+        list_googlebooks_cover_candidates(
+            cast(Any, session),
+            work_id=uuid.uuid4(),
+            google_books=_Google(),  # type: ignore[arg-type]
+        )
+    )
+    assert items == []
+
+
+def test_list_googlebooks_cover_candidates_prefers_mapped_bundle_and_dedupes() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    session.get_map[(Work, work_id)] = Work(
+        id=work_id,
+        title="Book",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    session.scalar_values = ["gb1"]
+
+    def _execute(_stmt: Any) -> Any:
+        class _Res:
+            @staticmethod
+            def all() -> list[tuple[str, str | None]]:
+                return [("9780000000001", None)]
+
+            @staticmethod
+            def first() -> tuple[str] | None:
+                return (" Author ",)
+
+        return _Res()
+
+    session.execute = _execute  # type: ignore[attr-defined]
+
+    class _Google:
+        async def fetch_work_bundle(self, **_kwargs: Any) -> Any:
+            return type(
+                "Bundle",
+                (),
+                {
+                    "volume_id": "gb1",
+                    "cover_url": "https://books.google.com/cover.jpg",
+                    "attribution_url": "https://books.google.com/books?id=gb1",
+                },
+            )()
+
+        async def search_books(self, **_kwargs: Any) -> Any:
+            return type(
+                "Resp",
+                (),
+                {
+                    "items": [
+                        type(
+                            "Item",
+                            (),
+                            {
+                                "volume_id": "gb2",
+                                "cover_url": "https://books.google.com/cover.jpg",
+                                "attribution_url": "https://books.google.com/books?id=gb2",
+                            },
+                        )(),
+                        type(
+                            "Item",
+                            (),
+                            {
+                                "volume_id": "gb3",
+                                "cover_url": "https://books.google.com/cover-2.jpg",
+                                "attribution_url": "https://books.google.com/books?id=gb3",
+                            },
+                        )(),
+                    ]
+                },
+            )()
+
+    items = asyncio.run(
+        list_googlebooks_cover_candidates(
+            session, work_id=work_id, google_books=_Google()  # type: ignore[arg-type]
+        )
+    )
+    assert [item["source_id"] for item in items] == ["gb1", "gb3"]
+
+
+def test_list_googlebooks_cover_candidates_limits_and_skips_invalid_entries() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    session.get_map[(Work, work_id)] = Work(
+        id=work_id,
+        title="isbn:9780000000001",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    session.scalar_values = ["gb0"]
+
+    def _execute(_stmt: Any) -> Any:
+        class _Res:
+            @staticmethod
+            def all() -> list[tuple[str, str | None]]:
+                return [
+                    ("9780000000001", "1-234-56789-0"),
+                    ("9780000000001", "1-234-56789-0"),
+                ]
+
+            @staticmethod
+            def first() -> tuple[int] | None:
+                return (123,)
+
+        return _Res()
+
+    session.execute = _execute  # type: ignore[attr-defined]
+
+    class _Google:
+        async def fetch_work_bundle(self, **_kwargs: Any) -> Any:
+            return type(
+                "Bundle",
+                (),
+                {
+                    "volume_id": "gb0",
+                    "cover_url": None,
+                    "attribution_url": "https://books.google.com/books?id=gb0",
+                },
+            )()
+
+        async def search_books(self, **_kwargs: Any) -> Any:
+            dynamic_items = [
+                type(
+                    "Item",
+                    (),
+                    {
+                        "volume_id": f"gb{idx}",
+                        "cover_url": f"https://books.google.com/cover-{idx}.jpg",
+                        "attribution_url": f"https://books.google.com/books?id=gb{idx}",
+                    },
+                )()
+                for idx in range(1, 18)
+            ]
+            return type(
+                "Resp",
+                (),
+                {
+                    "items": [
+                        type(
+                            "Item",
+                            (),
+                            {
+                                "volume_id": "missing-cover",
+                                "cover_url": None,
+                                "attribution_url": None,
+                            },
+                        )(),
+                        *dynamic_items,
+                    ]
+                },
+            )()
+
+    items = asyncio.run(
+        list_googlebooks_cover_candidates(
+            session, work_id=work_id, google_books=_Google()  # type: ignore[arg-type]
+        )
+    )
+    assert len(items) == 16
+    assert items[0]["source_id"] == "gb1"
+
+
+def test_list_googlebooks_cover_candidates_skips_blank_and_duplicate_queries() -> None:
+    session = FakeSession()
+    work_id = uuid.uuid4()
+    session.get_map[(Work, work_id)] = Work(
+        id=work_id,
+        title="   ",
+        description=None,
+        first_publish_year=None,
+        default_cover_url=None,
+    )
+    session.scalar_values = [None]
+
+    def _execute(_stmt: Any) -> Any:
+        class _Res:
+            @staticmethod
+            def all() -> list[tuple[str, str | None]]:
+                return [("-", None), ("9780000000001", None), ("9780000000001", None)]
+
+            @staticmethod
+            def first() -> tuple[str] | None:
+                return None
+
+        return _Res()
+
+    session.execute = _execute  # type: ignore[attr-defined]
+    queries: list[str] = []
+
+    class _Google:
+        async def fetch_work_bundle(self, **_kwargs: Any) -> Any:
+            raise AssertionError("should not fetch bundle without mapped google id")
+
+        async def search_books(self, **kwargs: Any) -> Any:
+            queries.append(str(kwargs["query"]))
+            return type("Resp", (), {"items": []})()
+
+    items = asyncio.run(
+        list_googlebooks_cover_candidates(
+            cast(Any, session),
+            work_id=work_id,
+            google_books=_Google(),  # type: ignore[arg-type]
+        )
+    )
+    assert items == []
+    assert queries == ["isbn:", "isbn:9780000000001"]
+
+
 def test_select_openlibrary_cover_sets_override_when_global_cover_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -190,6 +478,75 @@ def test_select_openlibrary_cover_sets_override_when_global_cover_exists(
     assert result["scope"] == "override"
     assert item.cover_override_url is not None
     assert session.committed is True
+
+
+def test_select_cover_from_url_rejects_blank_source_url() -> None:
+    session = FakeSession()
+    with pytest.raises(ValueError):
+        asyncio.run(
+            select_cover_from_url(
+                session,  # type: ignore[arg-type]
+                settings=_settings(),
+                user_id=uuid.uuid4(),
+                work_id=uuid.uuid4(),
+                source_url="   ",
+            )
+        )
+
+
+def test_select_cover_from_url_requires_library_item() -> None:
+    session = FakeSession()
+    with pytest.raises(PermissionError):
+        asyncio.run(
+            select_cover_from_url(
+                session,  # type: ignore[arg-type]
+                settings=_settings(),
+                user_id=uuid.uuid4(),
+                work_id=uuid.uuid4(),
+                source_url="https://example.com/cover.jpg",
+            )
+        )
+
+
+def test_select_cover_from_url_raises_when_work_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = FakeSession()
+    user_id = uuid.uuid4()
+    work_id = uuid.uuid4()
+    item = LibraryItem(
+        user_id=user_id,
+        work_id=work_id,
+        preferred_edition_id=None,
+        status="to_read",
+        visibility="private",
+        rating=None,
+        tags=None,
+    )
+    # item lookup, any_edition_cover lookup, latest edition lookup
+    session.scalar_values = [item, None, None]
+
+    async def fake_cache_cover_to_storage(**_kwargs: Any) -> StorageUploadResult:
+        return StorageUploadResult(
+            public_url="https://example.supabase.co/storage/v1/object/public/covers/openlibrary/x.jpg",
+            bucket="covers",
+            path="openlibrary/x.jpg",
+        )
+
+    monkeypatch.setattr(
+        work_covers, "cache_cover_to_storage", fake_cache_cover_to_storage
+    )
+
+    with pytest.raises(LookupError):
+        asyncio.run(
+            select_cover_from_url(
+                session,  # type: ignore[arg-type]
+                settings=_settings(),
+                user_id=user_id,
+                work_id=work_id,
+                source_url="https://example.com/cover.jpg",
+            )
+        )
 
 
 def test_select_openlibrary_cover_sets_global_when_missing(

--- a/apps/web/app/components/shell/AppBreadcrumbs.vue
+++ b/apps/web/app/components/shell/AppBreadcrumbs.vue
@@ -32,6 +32,9 @@ const items = computed<BreadcrumbItem[]>(() => {
   if (path.startsWith('/books/')) {
     return [{ label: 'Library', to: '/library' }, { label: 'Book' }];
   }
+  if (path === '/settings') {
+    return [{ label: 'Library', to: '/library' }, { label: 'Settings' }];
+  }
   return [];
 });
 </script>

--- a/apps/web/app/components/shell/AppTopBar.vue
+++ b/apps/web/app/components/shell/AppTopBar.vue
@@ -185,7 +185,15 @@ const accountItems = computed(() => [
     : { label: 'Not signed in', icon: 'pi pi-user', disabled: true },
   { separator: true },
   ...(userEmail.value
-    ? [{ label: 'Sign out', icon: 'pi pi-sign-out', command: () => void signOut() }]
+    ? [
+        {
+          label: 'Settings',
+          icon: 'pi pi-cog',
+          command: () => void navigateTo('/settings'),
+        },
+        { separator: true },
+        { label: 'Sign out', icon: 'pi pi-sign-out', command: () => void signOut() },
+      ]
     : [
         {
           label: 'Sign in',

--- a/apps/web/app/pages/library/index.vue
+++ b/apps/web/app/pages/library/index.vue
@@ -754,20 +754,14 @@
 definePageMeta({ layout: 'app', middleware: 'auth' });
 
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import MarkdownIt from 'markdown-it';
 import { useToast } from 'primevue/usetoast';
 import { ApiClientError, apiRequest } from '~/utils/api';
+import { renderDescriptionHtml } from '~/utils/description';
 import { libraryStatusLabel } from '~/utils/libraryStatus';
 import CoverPlaceholder from '~/components/CoverPlaceholder.vue';
 import EmptyState from '~/components/EmptyState.vue';
 
 const toast = useToast();
-const markdownRenderer = new MarkdownIt({
-  html: false,
-  linkify: true,
-  typographer: true,
-  breaks: true,
-});
 const EMPTY_DESCRIPTION_LABEL = 'No description available.';
 
 type LibraryViewMode = 'current' | 'grid' | 'table';
@@ -1023,7 +1017,7 @@ const descriptionSnippet = (value?: string | null) => {
 const renderDescriptionSnippet = (value?: string | null) => {
   const snippet = descriptionSnippet(value);
   if (snippet === EMPTY_DESCRIPTION_LABEL) return snippet;
-  return markdownRenderer.renderInline(snippet);
+  return renderDescriptionHtml(snippet, { inline: true });
 };
 
 const ratingValue = (value?: number | null) => {

--- a/apps/web/app/pages/settings.vue
+++ b/apps/web/app/pages/settings.vue
@@ -1,0 +1,154 @@
+<template>
+  <Card data-test="settings-card">
+    <template #title>
+      <div class="flex items-center gap-3">
+        <i class="pi pi-cog text-primary" aria-hidden="true" />
+        <div>
+          <p class="font-serif text-xl font-semibold tracking-tight">Profile and settings</p>
+          <p class="text-sm text-[var(--p-text-muted-color)]">
+            Manage your profile and external book search preferences.
+          </p>
+        </div>
+      </div>
+    </template>
+    <template #content>
+      <div class="flex flex-col gap-4">
+        <Message v-if="error" severity="error" :closable="false" data-test="settings-error">
+          {{ error }}
+        </Message>
+        <Message v-if="saved" severity="success" :closable="false" data-test="settings-saved">
+          Settings saved.
+        </Message>
+
+        <div class="grid gap-3 md:grid-cols-2">
+          <div class="flex flex-col gap-2">
+            <label class="text-sm font-medium" for="settings-handle">Handle</label>
+            <InputText
+              id="settings-handle"
+              v-model="handle"
+              data-test="settings-handle"
+              placeholder="reader_handle"
+            />
+          </div>
+          <div class="flex flex-col gap-2">
+            <label class="text-sm font-medium" for="settings-display-name">Display name</label>
+            <InputText
+              id="settings-display-name"
+              v-model="displayName"
+              data-test="settings-display-name"
+              placeholder="Display name"
+            />
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label class="text-sm font-medium" for="settings-avatar-url">Avatar URL</label>
+          <InputText
+            id="settings-avatar-url"
+            v-model="avatarUrl"
+            data-test="settings-avatar-url"
+            placeholder="https://example.com/avatar.jpg"
+          />
+        </div>
+
+        <Card>
+          <template #content>
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <p class="m-0 text-sm font-medium">Use Google Books</p>
+                <p class="m-0 text-xs text-[var(--p-text-muted-color)]">
+                  Opt in to include Google Books in global search and import results.
+                </p>
+              </div>
+              <input
+                v-model="enableGoogleBooks"
+                data-test="settings-enable-google-books"
+                type="checkbox"
+                class="mt-1 h-4 w-4"
+              />
+            </div>
+          </template>
+        </Card>
+
+        <div class="flex justify-end">
+          <Button
+            :disabled="saving || loading"
+            :label="saving ? 'Saving...' : 'Save settings'"
+            data-test="settings-save"
+            @click="save"
+          />
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import Button from 'primevue/button';
+import Card from 'primevue/card';
+import InputText from 'primevue/inputtext';
+import Message from 'primevue/message';
+import { ApiClientError, apiRequest } from '~/utils/api';
+
+definePageMeta({ layout: 'app', middleware: 'auth' });
+
+type MeProfile = {
+  handle: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  enable_google_books: boolean;
+};
+
+const loading = ref(false);
+const saving = ref(false);
+const saved = ref(false);
+const error = ref('');
+
+const handle = ref('');
+const displayName = ref('');
+const avatarUrl = ref('');
+const enableGoogleBooks = ref(false);
+
+const loadProfile = async () => {
+  loading.value = true;
+  error.value = '';
+  try {
+    const data = await apiRequest<MeProfile>('/api/v1/me');
+    handle.value = data.handle;
+    displayName.value = data.display_name ?? '';
+    avatarUrl.value = data.avatar_url ?? '';
+    enableGoogleBooks.value = Boolean(data.enable_google_books);
+  } catch (err) {
+    error.value = err instanceof ApiClientError ? err.message : 'Unable to load settings.';
+  } finally {
+    loading.value = false;
+  }
+};
+
+const save = async () => {
+  saving.value = true;
+  saved.value = false;
+  error.value = '';
+  try {
+    await apiRequest('/api/v1/me', {
+      method: 'PATCH',
+      body: {
+        handle: handle.value,
+        display_name: displayName.value,
+        avatar_url: avatarUrl.value,
+        enable_google_books: enableGoogleBooks.value,
+      },
+    });
+    saved.value = true;
+  } catch (err) {
+    error.value = err instanceof ApiClientError ? err.message : 'Unable to save settings.';
+  } finally {
+    saving.value = false;
+  }
+};
+
+onMounted(() => {
+  void loadProfile();
+});
+</script>

--- a/apps/web/app/utils/description.ts
+++ b/apps/web/app/utils/description.ts
@@ -1,0 +1,94 @@
+import MarkdownIt from 'markdown-it';
+import sanitizeHtml from 'sanitize-html';
+
+const markdownInline = new MarkdownIt({
+  html: false,
+  linkify: true,
+  typographer: true,
+  breaks: true,
+});
+
+const markdownBlock = new MarkdownIt({
+  html: false,
+  linkify: true,
+  typographer: true,
+  breaks: true,
+});
+
+const containsHtmlTags = (value: string): boolean => /<\/?[a-z][\s\S]*>/i.test(value);
+const hasLikelyGoogleMarkdownArtifacts = (value: string): boolean =>
+  /(^|\n)\*["“]/m.test(value) ||
+  /["”]\*(\n|$)/m.test(value) ||
+  /(^|\n)\*{1,3}\s*(\n|$)/m.test(value);
+
+const cleanupGoogleMarkdownArtifacts = (value: string): string =>
+  value
+    .split(/\r?\n/)
+    .map((line) => {
+      const trimmed = line.trim();
+      if (/^\*{1,3}$/.test(trimmed)) return '';
+      return line.replace(/^\*+(?=\S)/, '').replace(/(?<=\S)\*+$/, '');
+    })
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+const renderPlainTextWithBreaks = (value: string): string =>
+  escapeHtml(value).replace(/\n/g, '<br>');
+
+const sanitizeDescriptionHtml = (value: string): string =>
+  sanitizeHtml(value, {
+    allowedTags: ['a', 'b', 'blockquote', 'br', 'code', 'em', 'i', 'li', 'ol', 'p', 'strong', 'ul'],
+    allowedAttributes: {
+      a: ['href', 'target', 'rel'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+    transformTags: {
+      a: (_tagName, attribs) => ({
+        tagName: 'a',
+        attribs: {
+          href: attribs.href ?? '',
+          rel: 'noopener noreferrer nofollow',
+          target: '_blank',
+        },
+      }),
+    },
+  }).trim();
+
+export const renderDescriptionHtml = (
+  value?: string | null,
+  options: { inline?: boolean } = {},
+): string => {
+  if (!value) return '';
+  const normalized = value.trim();
+  if (!normalized) return '';
+
+  const renderMarkdown = options.inline
+    ? markdownInline.renderInline.bind(markdownInline)
+    : markdownBlock.render.bind(markdownBlock);
+
+  if (!containsHtmlTags(normalized)) {
+    if (hasLikelyGoogleMarkdownArtifacts(normalized)) {
+      const cleaned = cleanupGoogleMarkdownArtifacts(normalized);
+      return cleaned ? renderPlainTextWithBreaks(cleaned) : '';
+    }
+    return renderMarkdown(normalized);
+  }
+
+  const sanitized = sanitizeDescriptionHtml(normalized);
+  if (!sanitized) return '';
+
+  // For mixed strings where tags are stripped out completely, keep markdown formatting support.
+  if (!containsHtmlTags(sanitized)) {
+    return renderMarkdown(sanitized);
+  }
+  return sanitized;
+};

--- a/apps/web/app/utils/navigation.ts
+++ b/apps/web/app/utils/navigation.ts
@@ -9,4 +9,5 @@ export type NavItem = {
 
 export const appNavItems: NavItem[] = [
   { label: 'Library', to: '/library', icon: 'pi pi-book', visibility: 'all' },
+  { label: 'Settings', to: '/settings', icon: 'pi pi-cog', visibility: 'all' },
 ];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "nuxt": "^4.2.2",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.3",
+    "sanitize-html": "^2.17.0",
     "vue": "^3.5.26",
     "vue-router": "^4.6.4"
   },

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       primevue:
         specifier: ^4.3.3
         version: 4.5.4(vue@3.5.26(typescript@5.9.3))
+      sanitize-html:
+        specifier: ^2.17.0
+        version: 2.17.0
       vue:
         specifier: ^3.5.26
         version: 3.5.26(typescript@5.9.3)
@@ -2961,6 +2964,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
   http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
     engines: {node: '>= 0.8'}
@@ -3138,6 +3144,10 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3765,6 +3775,9 @@ packages:
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse-url@9.2.0:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
@@ -4286,6 +4299,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.0:
+    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
   sax@1.4.3:
     resolution: {integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==}
@@ -8223,6 +8239,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
   http-assert@1.5.0:
     dependencies:
       deep-equal: 1.0.1
@@ -8396,6 +8419,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-path-inside@4.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -9290,6 +9315,8 @@ snapshots:
     dependencies:
       protocols: 2.0.2
 
+  parse-srcset@1.0.2: {}
+
   parse-url@9.2.0:
     dependencies:
       '@types/parse-path': 7.1.0
@@ -9778,6 +9805,15 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.0:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   sax@1.4.3: {}
 

--- a/apps/web/tests/unit/components/app-breadcrumbs.test.ts
+++ b/apps/web/tests/unit/components/app-breadcrumbs.test.ts
@@ -91,6 +91,11 @@ describe('AppBreadcrumbs', () => {
     expect(wrapper.get('[data-test="item-Library"] a').attributes('href')).toBe('/library');
     expect(wrapper.get('[data-test="item-Book"]').text()).toContain('Book');
 
+    routeState.path = '/settings';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get('[data-test="item-Library"] a').attributes('href')).toBe('/library');
+    expect(wrapper.get('[data-test="item-Settings"]').text()).toContain('Settings');
+
     routeState.path = '/unknown';
     await wrapper.vm.$nextTick();
     expect(wrapper.get('[data-test="home"]').findAll('a').length).toBe(0);

--- a/apps/web/tests/unit/components/app-topbar.test.ts
+++ b/apps/web/tests/unit/components/app-topbar.test.ts
@@ -220,6 +220,30 @@ describe('AppTopBar', () => {
     expect(navigateToMock).toHaveBeenCalledWith('/');
   });
 
+  it('navigates to settings from the account menu when authed', async () => {
+    const wrapper = mount(AppTopBar, {
+      global: {
+        plugins: [[PrimeVue, { ripple: false }]],
+        stubs: {
+          Menubar: MenubarStub,
+          Button: ButtonStub,
+          Menu: MenuStub,
+          NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+          AppTopBarBookSearch: defineComponent({
+            name: 'AppTopBarBookSearch',
+            setup: () => () => h('div'),
+          }),
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await nextTick();
+    await wrapper.get('[data-test="menu-item-Settings"]').trigger('click');
+
+    expect(navigateToMock).toHaveBeenCalledWith('/settings');
+  });
+
   it('executes sign-in navigation from the account menu when not authed', async () => {
     getUserMock.mockResolvedValueOnce({ data: { user: null } } as any);
 

--- a/apps/web/tests/unit/pages/library.test.ts
+++ b/apps/web/tests/unit/pages/library.test.ts
@@ -1005,7 +1005,38 @@ describe('library page', () => {
 
     expect(wrapper.find('[data-test="library-item-description"] script').exists()).toBe(false);
     expect(wrapper.find('[data-test="library-item-description"] strong').exists()).toBe(true);
-    expect(wrapper.text()).toContain('<script>alert(1)</script> bold');
+    expect(wrapper.text()).toContain('bold');
+    expect(wrapper.text()).not.toContain('alert(1)');
+  });
+
+  it('renders common html description tags from providers safely', async () => {
+    apiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'item-1',
+          work_id: 'work-1',
+          work_title: 'HTML Description Book',
+          work_description: '<b>Bold</b><br><i>Italic</i>',
+          author_names: ['Author A'],
+          cover_url: null,
+          status: 'reading',
+          visibility: 'private',
+          tags: [],
+          created_at: '2026-02-09T00:00:00Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const description = wrapper.get('[data-test="library-item-description"]');
+    expect(description.text()).toContain('Bold');
+    expect(description.text()).toContain('Italic');
+    expect(description.find('b, strong').exists()).toBe(true);
+    expect(description.find('i, em').exists()).toBe(true);
+    expect(description.find('script').exists()).toBe(false);
   });
 
   it('uses title-only link styling and keeps author/description as plain text', async () => {

--- a/apps/web/tests/unit/pages/settings.test.ts
+++ b/apps/web/tests/unit/pages/settings.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+
+const apiRequest = vi.hoisted(() => vi.fn());
+const ApiClientErrorMock = vi.hoisted(
+  () =>
+    class ApiClientError extends Error {
+      code: string;
+      status?: number;
+
+      constructor(message: string, code: string, status?: number) {
+        super(message);
+        this.code = code;
+        this.status = status;
+      }
+    },
+);
+
+vi.mock('~/utils/api', () => ({
+  apiRequest,
+  ApiClientError: ApiClientErrorMock,
+}));
+
+import SettingsPage from '../../../app/pages/settings.vue';
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  emits: ['click'],
+  setup:
+    (_props, { attrs, slots, emit }) =>
+    () =>
+      h(
+        'button',
+        { ...attrs, onClick: (e: unknown) => emit('click', e) },
+        slots.default?.() ?? attrs['label'] ?? '',
+      ),
+});
+
+const InputTextStub = defineComponent({
+  name: 'InputText',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  setup:
+    (props, { attrs, emit }) =>
+    () =>
+      h('input', {
+        ...attrs,
+        value: props.modelValue ?? '',
+        onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value),
+      }),
+});
+
+const CardStub = defineComponent({
+  name: 'Card',
+  setup:
+    (_props, { slots, attrs }) =>
+    () =>
+      h('div', { ...attrs }, [slots.title?.(), slots.content?.(), slots.default?.()]),
+});
+
+const MessageStub = defineComponent({
+  name: 'Message',
+  setup:
+    (_props, { slots, attrs }) =>
+    () =>
+      h('div', { ...attrs }, slots.default?.()),
+});
+
+describe('settings page', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+  });
+
+  const mountPage = () =>
+    mount(SettingsPage, {
+      global: {
+        plugins: [[PrimeVue, { ripple: false }]],
+        stubs: {
+          Button: ButtonStub,
+          InputText: InputTextStub,
+          Card: CardStub,
+          Message: MessageStub,
+        },
+      },
+    });
+
+  it('loads current profile and allows saving google books preference', async () => {
+    apiRequest.mockImplementation(async (path: string) => {
+      if (path === '/api/v1/me') {
+        return {
+          handle: 'seed',
+          display_name: 'Seed',
+          avatar_url: null,
+          enable_google_books: false,
+        };
+      }
+      return {};
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get('[data-test="settings-handle"]').setValue('new-handle');
+    await wrapper.get('[data-test="settings-display-name"]').setValue('New Name');
+    await wrapper.get('[data-test="settings-avatar-url"]').setValue('https://example.com/new.png');
+    const toggle = wrapper.get('[data-test="settings-enable-google-books"]');
+    await toggle.setValue(true);
+    await wrapper.get('[data-test="settings-save"]').trigger('click');
+
+    const patchCall = apiRequest.mock.calls.find((call) => call[0] === '/api/v1/me' && call[1]);
+    expect(patchCall).toBeTruthy();
+    expect(patchCall?.[1]).toMatchObject({
+      method: 'PATCH',
+      body: expect.objectContaining({ enable_google_books: true }),
+    });
+    expect(wrapper.find('[data-test="settings-saved"]').exists()).toBe(true);
+  });
+
+  it('shows an error when profile load fails', async () => {
+    apiRequest.mockRejectedValueOnce(new ApiClientErrorMock('No profile', 'bad_request', 400));
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get('[data-test="settings-error"]').text()).toContain('No profile');
+  });
+
+  it('shows a generic error when profile load fails without API details', async () => {
+    apiRequest.mockRejectedValueOnce(new Error('boom'));
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get('[data-test="settings-error"]').text()).toContain(
+      'Unable to load settings.',
+    );
+  });
+
+  it('shows an error when save fails', async () => {
+    apiRequest
+      .mockResolvedValueOnce({
+        handle: 'seed',
+        display_name: 'Seed',
+        avatar_url: null,
+        enable_google_books: false,
+      })
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get('[data-test="settings-save"]').trigger('click');
+    expect(wrapper.get('[data-test="settings-error"]').text()).toContain(
+      'Unable to save settings.',
+    );
+  });
+
+  it('shows API error details when save fails with ApiClientError', async () => {
+    apiRequest
+      .mockResolvedValueOnce({
+        handle: 'seed',
+        display_name: 'Seed',
+        avatar_url: null,
+        enable_google_books: false,
+      })
+      .mockRejectedValueOnce(new ApiClientErrorMock('Denied', 'denied', 403));
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get('[data-test="settings-save"]').trigger('click');
+    expect(wrapper.get('[data-test="settings-error"]').text()).toContain('Denied');
+  });
+});

--- a/apps/web/tests/unit/utils/description.test.ts
+++ b/apps/web/tests/unit/utils/description.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderDescriptionHtml } from '../../../app/utils/description';
+
+describe('description utils', () => {
+  it('returns empty for nullish/blank inputs', () => {
+    expect(renderDescriptionHtml()).toBe('');
+    expect(renderDescriptionHtml('   ')).toBe('');
+  });
+
+  it('renders markdown when no html tags are present', () => {
+    const block = renderDescriptionHtml('This is **bold** text.');
+    expect(block).toContain('<strong>bold</strong>');
+    const inline = renderDescriptionHtml('This is **bold** text.', { inline: true });
+    expect(inline).toContain('<strong>bold</strong>');
+    expect(inline).not.toContain('<p>');
+  });
+
+  it('sanitizes and preserves supported html tags', () => {
+    const input = '<b>Bold</b> and <i>italics</i><br>line 2';
+    const rendered = renderDescriptionHtml(input);
+    expect(rendered).toContain('<b>Bold</b>');
+    expect(rendered).toContain('<i>italics</i>');
+    expect(rendered).toContain('<br');
+  });
+
+  it('strips unsafe tags and still supports markdown in mixed content', () => {
+    const input = '<script>alert(1)</script> **bold**';
+    const rendered = renderDescriptionHtml(input, { inline: true });
+    expect(rendered).not.toContain('<script>');
+    expect(rendered).not.toContain('alert(1)');
+    expect(rendered).toContain('<strong>bold</strong>');
+  });
+
+  it('drops disallowed/unsafe links and normalizes safe links', () => {
+    const unsafeLink = renderDescriptionHtml('<a href="javascript:alert(1)">bad</a>');
+    expect(unsafeLink).toContain('target="_blank"');
+    expect(unsafeLink).toContain('rel="noopener noreferrer nofollow"');
+    expect(unsafeLink).not.toContain('javascript:');
+
+    const safeLink = renderDescriptionHtml('<a href="https://example.com">ok</a>');
+    expect(safeLink).toContain('href="https://example.com"');
+
+    const missingHref = renderDescriptionHtml('<a>no href</a>');
+    expect(missingHref).not.toContain('href=');
+    expect(missingHref).toContain('target="_blank"');
+  });
+
+  it('returns empty when html input is fully stripped', () => {
+    const rendered = renderDescriptionHtml('<script>alert(1)</script>');
+    expect(rendered).toBe('');
+  });
+
+  it('cleans malformed star artifacts and renders plain text breaks', () => {
+    const input = `*“Nolan is a skillful satirist.”—“Review”*
+“A self-assured debut.”—“Kirkus”
+**
+“A stunner.”—“Julia Phillips”**`;
+    const rendered = renderDescriptionHtml(input);
+    expect(rendered).toContain('“Nolan is a skillful satirist.”—“Review”');
+    expect(rendered).not.toContain('<ul>');
+    expect(rendered).not.toContain('**');
+    expect(rendered).not.toMatch(/(^|>)\*($|<)/);
+  });
+});

--- a/supabase/migrations/20260213120000_add_users_google_books_pref.sql
+++ b/supabase/migrations/20260213120000_add_users_google_books_pref.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.users
+ADD COLUMN IF NOT EXISTS enable_google_books boolean NOT NULL DEFAULT false;
+


### PR DESCRIPTION
## Summary
- Adds optional Google Books provider integration behind an environment toggle plus a per-user setting.
- Adds provider-aware work cover candidate flow, including Google candidates only when enabled.
- Adds/updates settings UX and UI gating so Google controls and results stay hidden when disabled.
- Updates the book detail cover chooser button label to `Choose from Search`.

## Testing
- `make quality`
