### PR TITLE
Implement StoryGraph import pipeline and enrichment resilience

### DIFF
--- a/apps/api/alembic/versions/0013_storygraph_import_jobs.py
+++ b/apps/api/alembic/versions/0013_storygraph_import_jobs.py
@@ -1,0 +1,246 @@
+"""Add StoryGraph import jobs and row results.
+
+Revision ID: 0013_storygraph_import_jobs
+Revises: 0012_user_google_books_pref
+Create Date: 2026-02-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0013_storygraph_import_jobs"
+down_revision = "0012_user_google_books_pref"
+branch_labels = None
+depends_on = None
+
+
+storygraph_import_job_status_enum = postgresql.ENUM(
+    "queued",
+    "running",
+    "completed",
+    "failed",
+    name="storygraph_import_job_status",
+)
+
+storygraph_import_row_result_enum = postgresql.ENUM(
+    "imported",
+    "failed",
+    "skipped",
+    name="storygraph_import_row_result",
+)
+
+storygraph_import_job_status_enum_column = postgresql.ENUM(
+    "queued",
+    "running",
+    "completed",
+    "failed",
+    name="storygraph_import_job_status",
+    create_type=False,
+)
+
+storygraph_import_row_result_enum_column = postgresql.ENUM(
+    "imported",
+    "failed",
+    "skipped",
+    name="storygraph_import_row_result",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    storygraph_import_job_status_enum.create(op.get_bind(), checkfirst=True)
+    storygraph_import_row_result_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "storygraph_import_jobs",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("status", storygraph_import_job_status_enum_column, nullable=False),
+        sa.Column(
+            "total_rows",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "processed_rows",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "imported_rows",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "failed_rows",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "skipped_rows",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("error_summary", sa.Text),
+        sa.Column("started_at", sa.DateTime(timezone=True)),
+        sa.Column("finished_at", sa.DateTime(timezone=True)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_storygraph_import_jobs_user_created",
+        "storygraph_import_jobs",
+        ["user_id", "created_at"],
+    )
+    op.create_index(
+        "ix_storygraph_import_jobs_status",
+        "storygraph_import_jobs",
+        ["status"],
+    )
+
+    op.create_table(
+        "storygraph_import_job_rows",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "job_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("storygraph_import_jobs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("row_number", sa.Integer, nullable=False),
+        sa.Column("identity_hash", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=512)),
+        sa.Column("uid", sa.String(length=255)),
+        sa.Column("result", storygraph_import_row_result_enum_column, nullable=False),
+        sa.Column("message", sa.Text, nullable=False),
+        sa.Column("work_id", sa.UUID(as_uuid=True)),
+        sa.Column("library_item_id", sa.UUID(as_uuid=True)),
+        sa.Column("review_id", sa.UUID(as_uuid=True)),
+        sa.Column("session_id", sa.UUID(as_uuid=True)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "job_id",
+            "identity_hash",
+            name="uq_storygraph_import_job_rows_job_identity",
+        ),
+    )
+    op.create_index(
+        "ix_storygraph_import_job_rows_job_row",
+        "storygraph_import_job_rows",
+        ["job_id", "row_number"],
+    )
+    op.create_index(
+        "ix_storygraph_import_job_rows_job_result",
+        "storygraph_import_job_rows",
+        ["job_id", "result"],
+    )
+
+    op.execute("ALTER TABLE public.storygraph_import_jobs ENABLE ROW LEVEL SECURITY;")
+    op.execute(
+        "DROP POLICY IF EXISTS storygraph_import_jobs_owner ON public.storygraph_import_jobs;"
+    )
+    op.execute(
+        """
+        CREATE POLICY storygraph_import_jobs_owner
+        ON public.storygraph_import_jobs
+        FOR ALL
+        TO authenticated
+        USING (user_id = auth.uid())
+        WITH CHECK (user_id = auth.uid());
+        """
+    )
+
+    op.execute(
+        "ALTER TABLE public.storygraph_import_job_rows ENABLE ROW LEVEL SECURITY;"
+    )
+    op.execute(
+        "DROP POLICY IF EXISTS storygraph_import_job_rows_owner ON public.storygraph_import_job_rows;"
+    )
+    op.execute(
+        """
+        CREATE POLICY storygraph_import_job_rows_owner
+        ON public.storygraph_import_job_rows
+        FOR ALL
+        TO authenticated
+        USING (user_id = auth.uid())
+        WITH CHECK (user_id = auth.uid());
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS storygraph_import_job_rows_owner ON public.storygraph_import_job_rows;"
+    )
+    op.execute(
+        "DROP POLICY IF EXISTS storygraph_import_jobs_owner ON public.storygraph_import_jobs;"
+    )
+
+    op.drop_index(
+        "ix_storygraph_import_job_rows_job_result",
+        table_name="storygraph_import_job_rows",
+    )
+    op.drop_index(
+        "ix_storygraph_import_job_rows_job_row",
+        table_name="storygraph_import_job_rows",
+    )
+    op.drop_table("storygraph_import_job_rows")
+
+    op.drop_index(
+        "ix_storygraph_import_jobs_status",
+        table_name="storygraph_import_jobs",
+    )
+    op.drop_index(
+        "ix_storygraph_import_jobs_user_created",
+        table_name="storygraph_import_jobs",
+    )
+    op.drop_table("storygraph_import_jobs")
+
+    storygraph_import_row_result_enum.drop(op.get_bind(), checkfirst=True)
+    storygraph_import_job_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/apps/api/alembic/versions/0013_storygraph_import_jobs.py
+++ b/apps/api/alembic/versions/0013_storygraph_import_jobs.py
@@ -8,6 +8,7 @@ Create Date: 2026-02-14
 from __future__ import annotations
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 from sqlalchemy.dialects import postgresql
 
 from alembic import op
@@ -51,135 +52,169 @@ storygraph_import_row_result_enum_column = postgresql.ENUM(
 )
 
 
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name, schema="public")
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(
+        index.get("name") == index_name
+        for index in inspector.get_indexes(table_name, schema="public")
+    )
+
+
 def upgrade() -> None:
     storygraph_import_job_status_enum.create(op.get_bind(), checkfirst=True)
     storygraph_import_row_result_enum.create(op.get_bind(), checkfirst=True)
 
-    op.create_table(
+    if not _has_table("storygraph_import_jobs"):
+        op.create_table(
+            "storygraph_import_jobs",
+            sa.Column(
+                "id",
+                sa.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "user_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("filename", sa.String(length=255), nullable=False),
+            sa.Column(
+                "status", storygraph_import_job_status_enum_column, nullable=False
+            ),
+            sa.Column(
+                "total_rows",
+                sa.Integer,
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "processed_rows",
+                sa.Integer,
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "imported_rows",
+                sa.Integer,
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "failed_rows",
+                sa.Integer,
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "skipped_rows",
+                sa.Integer,
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column("error_summary", sa.Text),
+            sa.Column("started_at", sa.DateTime(timezone=True)),
+            sa.Column("finished_at", sa.DateTime(timezone=True)),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+    if not _has_index(
         "storygraph_import_jobs",
-        sa.Column(
-            "id",
-            sa.UUID(as_uuid=True),
-            primary_key=True,
-            server_default=sa.text("gen_random_uuid()"),
-        ),
-        sa.Column(
-            "user_id",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("users.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("filename", sa.String(length=255), nullable=False),
-        sa.Column("status", storygraph_import_job_status_enum_column, nullable=False),
-        sa.Column(
-            "total_rows",
-            sa.Integer,
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column(
-            "processed_rows",
-            sa.Integer,
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column(
-            "imported_rows",
-            sa.Integer,
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column(
-            "failed_rows",
-            sa.Integer,
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column(
-            "skipped_rows",
-            sa.Integer,
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column("error_summary", sa.Text),
-        sa.Column("started_at", sa.DateTime(timezone=True)),
-        sa.Column("finished_at", sa.DateTime(timezone=True)),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-    )
-    op.create_index(
         "ix_storygraph_import_jobs_user_created",
+    ):
+        op.create_index(
+            "ix_storygraph_import_jobs_user_created",
+            "storygraph_import_jobs",
+            ["user_id", "created_at"],
+        )
+    if not _has_index(
         "storygraph_import_jobs",
-        ["user_id", "created_at"],
-    )
-    op.create_index(
         "ix_storygraph_import_jobs_status",
-        "storygraph_import_jobs",
-        ["status"],
-    )
+    ):
+        op.create_index(
+            "ix_storygraph_import_jobs_status",
+            "storygraph_import_jobs",
+            ["status"],
+        )
 
-    op.create_table(
+    if not _has_table("storygraph_import_job_rows"):
+        op.create_table(
+            "storygraph_import_job_rows",
+            sa.Column(
+                "id",
+                sa.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "job_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("storygraph_import_jobs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "user_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("row_number", sa.Integer, nullable=False),
+            sa.Column("identity_hash", sa.String(length=64), nullable=False),
+            sa.Column("title", sa.String(length=512)),
+            sa.Column("uid", sa.String(length=255)),
+            sa.Column(
+                "result", storygraph_import_row_result_enum_column, nullable=False
+            ),
+            sa.Column("message", sa.Text, nullable=False),
+            sa.Column("work_id", sa.UUID(as_uuid=True)),
+            sa.Column("library_item_id", sa.UUID(as_uuid=True)),
+            sa.Column("review_id", sa.UUID(as_uuid=True)),
+            sa.Column("session_id", sa.UUID(as_uuid=True)),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.UniqueConstraint(
+                "job_id",
+                "identity_hash",
+                name="uq_storygraph_import_job_rows_job_identity",
+            ),
+        )
+    if not _has_index(
         "storygraph_import_job_rows",
-        sa.Column(
-            "id",
-            sa.UUID(as_uuid=True),
-            primary_key=True,
-            server_default=sa.text("gen_random_uuid()"),
-        ),
-        sa.Column(
-            "job_id",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("storygraph_import_jobs.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column(
-            "user_id",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("users.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("row_number", sa.Integer, nullable=False),
-        sa.Column("identity_hash", sa.String(length=64), nullable=False),
-        sa.Column("title", sa.String(length=512)),
-        sa.Column("uid", sa.String(length=255)),
-        sa.Column("result", storygraph_import_row_result_enum_column, nullable=False),
-        sa.Column("message", sa.Text, nullable=False),
-        sa.Column("work_id", sa.UUID(as_uuid=True)),
-        sa.Column("library_item_id", sa.UUID(as_uuid=True)),
-        sa.Column("review_id", sa.UUID(as_uuid=True)),
-        sa.Column("session_id", sa.UUID(as_uuid=True)),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.UniqueConstraint(
-            "job_id",
-            "identity_hash",
-            name="uq_storygraph_import_job_rows_job_identity",
-        ),
-    )
-    op.create_index(
         "ix_storygraph_import_job_rows_job_row",
+    ):
+        op.create_index(
+            "ix_storygraph_import_job_rows_job_row",
+            "storygraph_import_job_rows",
+            ["job_id", "row_number"],
+        )
+    if not _has_index(
         "storygraph_import_job_rows",
-        ["job_id", "row_number"],
-    )
-    op.create_index(
         "ix_storygraph_import_job_rows_job_result",
-        "storygraph_import_job_rows",
-        ["job_id", "result"],
-    )
+    ):
+        op.create_index(
+            "ix_storygraph_import_job_rows_job_result",
+            "storygraph_import_job_rows",
+            ["job_id", "result"],
+        )
 
     op.execute("ALTER TABLE public.storygraph_import_jobs ENABLE ROW LEVEL SECURITY;")
     op.execute(

--- a/apps/api/app/db/models/__init__.py
+++ b/apps/api/app/db/models/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
 from app.db.models.content import Highlight, Note, Review
 from app.db.models.external_provider import ExternalId, SourceRecord
+from app.db.models.imports import StorygraphImportJob, StorygraphImportJobRow
 from app.db.models.platform import ApiAuditLog, ApiClient
 from app.db.models.users import (
     LibraryItem,
@@ -24,6 +25,8 @@ __all__ = [
     "ReadingStateEvent",
     "Review",
     "SourceRecord",
+    "StorygraphImportJob",
+    "StorygraphImportJobRow",
     "User",
     "Work",
     "WorkAuthor",

--- a/apps/api/app/db/models/imports.py
+++ b/apps/api/app/db/models/imports.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+storygraph_import_job_status_enum = ENUM(
+    "queued",
+    "running",
+    "completed",
+    "failed",
+    name="storygraph_import_job_status",
+    create_type=False,
+)
+
+storygraph_import_row_result_enum = ENUM(
+    "imported",
+    "failed",
+    "skipped",
+    name="storygraph_import_row_result",
+    create_type=False,
+)
+
+
+class StorygraphImportJob(Base):
+    __tablename__ = "storygraph_import_jobs"
+    __table_args__ = (
+        sa.Index(
+            "ix_storygraph_import_jobs_user_created",
+            "user_id",
+            "created_at",
+        ),
+        sa.Index("ix_storygraph_import_jobs_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    filename: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    status: Mapped[str] = mapped_column(
+        storygraph_import_job_status_enum, nullable=False
+    )
+    total_rows: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default="0"
+    )
+    processed_rows: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default="0"
+    )
+    imported_rows: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default="0"
+    )
+    failed_rows: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default="0"
+    )
+    skipped_rows: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default="0"
+    )
+    error_summary: Mapped[str | None] = mapped_column(sa.Text)
+    started_at: Mapped[dt.datetime | None] = mapped_column(sa.DateTime(timezone=True))
+    finished_at: Mapped[dt.datetime | None] = mapped_column(sa.DateTime(timezone=True))
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class StorygraphImportJobRow(Base):
+    __tablename__ = "storygraph_import_job_rows"
+    __table_args__ = (
+        sa.Index("ix_storygraph_import_job_rows_job_row", "job_id", "row_number"),
+        sa.Index("ix_storygraph_import_job_rows_job_result", "job_id", "result"),
+        sa.UniqueConstraint(
+            "job_id",
+            "identity_hash",
+            name="uq_storygraph_import_job_rows_job_identity",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    job_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("storygraph_import_jobs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        sa.UUID(as_uuid=True),
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    row_number: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    identity_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    title: Mapped[str | None] = mapped_column(sa.String(512))
+    uid: Mapped[str | None] = mapped_column(sa.String(255))
+    result: Mapped[str] = mapped_column(
+        storygraph_import_row_result_enum, nullable=False
+    )
+    message: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    work_id: Mapped[uuid.UUID | None] = mapped_column(sa.UUID(as_uuid=True))
+    library_item_id: Mapped[uuid.UUID | None] = mapped_column(sa.UUID(as_uuid=True))
+    review_id: Mapped[uuid.UUID | None] = mapped_column(sa.UUID(as_uuid=True))
+    session_id: Mapped[uuid.UUID | None] = mapped_column(sa.UUID(as_uuid=True))
+    created_at: Mapped[dt.datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )

--- a/apps/api/app/db/session.py
+++ b/apps/api/app/db/session.py
@@ -25,3 +25,7 @@ def get_db_session() -> Iterator[Session]:
         yield session
     finally:
         session.close()
+
+
+def create_db_session() -> Session:
+    return _session_factory()()

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -24,6 +24,7 @@ from app.routers import (
     protected,
     reviews,
     sessions,
+    storygraph_imports,
     version,
     works,
 )
@@ -81,6 +82,7 @@ def create_app() -> FastAPI:
     app.include_router(library.router)
     app.include_router(library_search.router)
     app.include_router(sessions.router)
+    app.include_router(storygraph_imports.router)
     app.include_router(notes.router)
     app.include_router(highlights.router)
     app.include_router(reviews.public_router)

--- a/apps/api/app/routers/__init__.py
+++ b/apps/api/app/routers/__init__.py
@@ -11,6 +11,7 @@ from . import (
     protected,
     reviews,
     sessions,
+    storygraph_imports,
     version,
     works,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "protected",
     "reviews",
     "sessions",
+    "storygraph_imports",
     "version",
     "works",
 ]

--- a/apps/api/app/routers/storygraph_imports.py
+++ b/apps/api/app/routers/storygraph_imports.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+)
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, get_settings
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.responses import ok
+from app.core.security import AuthContext, require_auth_context
+from app.db.models.imports import StorygraphImportJob
+from app.db.session import get_db_session
+from app.services.google_books import GoogleBooksClient
+from app.services.open_library import OpenLibraryClient
+from app.services.storygraph_imports import (
+    create_storygraph_job,
+    get_active_storygraph_job,
+    get_storygraph_job,
+    list_storygraph_job_rows,
+    process_storygraph_import_job,
+    serialize_job,
+    serialize_job_rows,
+)
+from app.services.storygraph_parser import (
+    StorygraphMissingRequiredField,
+    find_missing_required_fields,
+    is_valid_isbn,
+)
+from app.services.user_library import get_or_create_profile
+
+router = APIRouter(
+    prefix="/api/v1/imports/storygraph",
+    tags=["storygraph-imports"],
+    dependencies=[Depends(enforce_client_user_rate_limit)],
+)
+
+
+def get_open_library_client() -> OpenLibraryClient:
+    return OpenLibraryClient()
+
+
+def get_google_books_client(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> GoogleBooksClient:
+    return GoogleBooksClient(api_key=settings.google_books_api_key)
+
+
+def _google_books_enabled_for_user(
+    *,
+    auth: AuthContext,
+    session: Session,
+    settings: Settings,
+) -> bool:
+    if not settings.book_provider_google_enabled:
+        return False
+    if not settings.google_books_api_key:
+        return False
+    profile = get_or_create_profile(session, user_id=auth.user_id)
+    return bool(profile.enable_google_books)
+
+
+def _parse_row_override_payload(
+    value: str | None,
+    *,
+    key_name: str,
+) -> dict[int, str] | None:
+    if not value:
+        return None
+    try:
+        raw = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"invalid {key_name} payload"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail=f"{key_name} must be an object")
+
+    parsed: dict[int, str] = {}
+    for key, item in raw.items():
+        if not isinstance(item, str):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{key_name} values must be strings",
+            )
+        try:
+            row_number = int(key)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{key_name} keys must be row numbers",
+            ) from exc
+        parsed[row_number] = item
+    return parsed
+
+
+def _parse_row_number_list_payload(
+    value: str | None,
+    *,
+    key_name: str,
+) -> set[int] | None:
+    if not value:
+        return None
+    try:
+        raw = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"invalid {key_name} payload"
+        ) from exc
+    if not isinstance(raw, list):
+        raise HTTPException(status_code=400, detail=f"{key_name} must be an array")
+
+    parsed: set[int] = set()
+    for item in raw:
+        try:
+            parsed.add(int(item))
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{key_name} values must be row numbers",
+            ) from exc
+    return parsed
+
+
+def _issue_code_for_field(field: str) -> str:
+    if field == "authors":
+        return "missing_authors"
+    if field == "title":
+        return "missing_title"
+    return "missing_read_status"
+
+
+@dataclass(frozen=True)
+class _MetadataSuggestion:
+    title: str | None
+    authors: str | None
+    source: str | None
+    confidence: str | None
+
+
+def _author_list_to_value(authors: list[str]) -> str | None:
+    values = [name.strip() for name in authors if name.strip()]
+    if not values:
+        return None
+    return ", ".join(values)
+
+
+async def _fetch_metadata_suggestion(
+    *,
+    open_library: OpenLibraryClient,
+    google_books: GoogleBooksClient,
+    title: str | None,
+    uid: str | None,
+    include_google_books: bool,
+) -> _MetadataSuggestion:
+    if uid and is_valid_isbn(uid):
+        try:
+            work_key = await open_library.find_work_key_by_isbn(isbn=uid)
+            if work_key:
+                bundle = await open_library.fetch_work_bundle(work_key=work_key)
+                return _MetadataSuggestion(
+                    title=bundle.title.strip() or None,
+                    authors=_author_list_to_value(
+                        [author["name"] for author in bundle.authors]
+                    ),
+                    source="openlibrary:isbn",
+                    confidence="high",
+                )
+        except Exception:
+            pass
+
+        if include_google_books:
+            try:
+                gb_search = await google_books.search_books(
+                    query=f"isbn:{uid}", limit=1
+                )
+                if gb_search.items:
+                    first_gb = gb_search.items[0]
+                    return _MetadataSuggestion(
+                        title=first_gb.title.strip() or None,
+                        authors=_author_list_to_value(first_gb.author_names),
+                        source="googlebooks:isbn",
+                        confidence="high",
+                    )
+            except Exception:
+                pass
+
+    if title:
+        try:
+            ol_search = await open_library.search_books(query=title, limit=1)
+            if ol_search.items:
+                first_ol = ol_search.items[0]
+                return _MetadataSuggestion(
+                    title=first_ol.title.strip() or None,
+                    authors=_author_list_to_value(first_ol.author_names),
+                    source="openlibrary:search",
+                    confidence="medium",
+                )
+        except Exception:
+            pass
+
+        if include_google_books:
+            try:
+                gb_search = await google_books.search_books(query=title, limit=1)
+                if gb_search.items:
+                    first_gb = gb_search.items[0]
+                    return _MetadataSuggestion(
+                        title=first_gb.title.strip() or None,
+                        authors=_author_list_to_value(first_gb.author_names),
+                        source="googlebooks:search",
+                        confidence="medium",
+                    )
+            except Exception:
+                pass
+
+    return _MetadataSuggestion(
+        title=None,
+        authors=None,
+        source=None,
+        confidence=None,
+    )
+
+
+def _resolve_missing_item(
+    *,
+    issue: StorygraphMissingRequiredField,
+    suggestion: _MetadataSuggestion,
+) -> dict[str, object]:
+    suggested_value: str | None = None
+    if issue.field == "authors":
+        suggested_value = suggestion.authors
+    elif issue.field == "title":
+        suggested_value = suggestion.title
+
+    return {
+        "row_number": issue.row_number,
+        "field": issue.field,
+        "issue_code": _issue_code_for_field(issue.field),
+        "required": True,
+        "title": issue.title,
+        "uid": issue.uid,
+        "suggested_value": suggested_value,
+        "suggestion_source": suggestion.source,
+        "suggestion_confidence": suggestion.confidence,
+    }
+
+
+def _mark_job_failed_if_stale(session: Session, *, job: StorygraphImportJob) -> bool:
+    stale_cutoff = dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=3)
+    if job.status != "running":
+        return False
+    updated_at = job.updated_at
+    if updated_at is None or updated_at >= stale_cutoff:
+        return False
+    job.status = "failed"
+    job.error_summary = "Import job stalled and was marked failed."
+    job.finished_at = dt.datetime.now(tz=dt.UTC)
+    job.updated_at = job.finished_at
+    session.commit()
+    return True
+
+
+@router.post("")
+async def create_import_job(
+    background_tasks: BackgroundTasks,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    file: Annotated[UploadFile, File(...)],
+    author_overrides: Annotated[str | None, Form()] = None,
+    title_overrides: Annotated[str | None, Form()] = None,
+    status_overrides: Annotated[str | None, Form()] = None,
+    skipped_rows: Annotated[str | None, Form()] = None,
+    skip_reasons: Annotated[str | None, Form()] = None,
+) -> dict[str, object]:
+    filename = (file.filename or "storygraph.csv").strip()
+    if not filename.lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="file must be a .csv export")
+
+    payload = await file.read()
+    if not payload:
+        raise HTTPException(status_code=400, detail="file is empty")
+    parsed_author_overrides = _parse_row_override_payload(
+        author_overrides, key_name="author_overrides"
+    )
+    parsed_title_overrides = _parse_row_override_payload(
+        title_overrides, key_name="title_overrides"
+    )
+    parsed_status_overrides = _parse_row_override_payload(
+        status_overrides, key_name="status_overrides"
+    )
+    parsed_skipped_rows = _parse_row_number_list_payload(
+        skipped_rows, key_name="skipped_rows"
+    )
+    parsed_skip_reasons = _parse_row_override_payload(
+        skip_reasons, key_name="skip_reasons"
+    )
+
+    active_job = get_active_storygraph_job(session, user_id=auth.user_id)
+    if active_job is not None:
+        if not _mark_job_failed_if_stale(session, job=active_job):
+            return ok(
+                {
+                    "job_id": str(active_job.id),
+                    "status": active_job.status,
+                    "created_at": active_job.created_at.isoformat(),
+                    "total_rows": active_job.total_rows,
+                    "processed_rows": active_job.processed_rows,
+                    "imported_rows": active_job.imported_rows,
+                    "failed_rows": active_job.failed_rows,
+                    "skipped_rows": active_job.skipped_rows,
+                }
+            )
+
+    job = create_storygraph_job(session, user_id=auth.user_id, filename=filename)
+    background_tasks.add_task(
+        process_storygraph_import_job,
+        user_id=auth.user_id,
+        job_id=job.id,
+        csv_bytes=payload,
+        author_overrides=parsed_author_overrides,
+        title_overrides=parsed_title_overrides,
+        status_overrides=parsed_status_overrides,
+        skipped_rows=parsed_skipped_rows,
+        skip_reasons=parsed_skip_reasons,
+    )
+
+    return ok(
+        {
+            "job_id": str(job.id),
+            "status": job.status,
+            "created_at": job.created_at.isoformat(),
+            "total_rows": job.total_rows,
+            "processed_rows": job.processed_rows,
+            "imported_rows": job.imported_rows,
+            "failed_rows": job.failed_rows,
+            "skipped_rows": job.skipped_rows,
+        }
+    )
+
+
+@router.post("/missing-authors")
+async def get_missing_authors(
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+    google_books: Annotated[GoogleBooksClient, Depends(get_google_books_client)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    file: Annotated[UploadFile, File(...)],
+) -> dict[str, object]:
+    filename = (file.filename or "storygraph.csv").strip()
+    if not filename.lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="file must be a .csv export")
+
+    payload = await file.read()
+    if not payload:
+        raise HTTPException(status_code=400, detail="file is empty")
+
+    include_google_books = _google_books_enabled_for_user(
+        auth=auth,
+        session=session,
+        settings=settings,
+    )
+    required_issues = find_missing_required_fields(payload)
+    metadata_cache: dict[int, _MetadataSuggestion] = {}
+    items: list[dict[str, object]] = []
+    for issue in required_issues:
+        suggestion = metadata_cache.get(issue.row_number)
+        if suggestion is None:
+            suggestion = await _fetch_metadata_suggestion(
+                open_library=open_library,
+                google_books=google_books,
+                title=issue.title,
+                uid=issue.uid,
+                include_google_books=include_google_books,
+            )
+            metadata_cache[issue.row_number] = suggestion
+        items.append(_resolve_missing_item(issue=issue, suggestion=suggestion))
+
+    return ok({"items": items})
+
+
+@router.get("/{job_id}")
+def get_import_job(
+    job_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        job = get_storygraph_job(session, user_id=auth.user_id, job_id=job_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _mark_job_failed_if_stale(session, job=job)
+    return ok(serialize_job(session, user_id=auth.user_id, job_id=job_id))
+
+
+@router.get("/{job_id}/rows")
+def get_import_job_rows(
+    job_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    cursor: Annotated[int | None, Query(ge=0)] = None,
+) -> dict[str, object]:
+    try:
+        rows, next_cursor = list_storygraph_job_rows(
+            session,
+            user_id=auth.user_id,
+            job_id=job_id,
+            limit=limit,
+            cursor=cursor,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return ok({"items": serialize_job_rows(rows), "next_cursor": next_cursor})

--- a/apps/api/app/routers/works.py
+++ b/apps/api/app/routers/works.py
@@ -239,11 +239,9 @@ async def list_enrichment_candidates(
             work_id=work_id,
             open_library=open_library,
             google_books=google_books,
-            google_enabled=_google_books_enabled_for_user(
-                auth=auth,
-                session=session,
-                settings=settings,
-            ),
+            # Enrichment should always attempt Google as a best-effort fallback
+            # when Open Library data is sparse.
+            google_enabled=True,
         )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -280,11 +278,7 @@ async def apply_enrichment(
             edition_id=payload.edition_id,
             open_library=open_library,
             google_books=google_books,
-            google_enabled=_google_books_enabled_for_user(
-                auth=auth,
-                session=session,
-                settings=settings,
-            ),
+            google_enabled=True,
         )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/apps/api/app/services/open_library.py
+++ b/apps/api/app/services/open_library.py
@@ -587,6 +587,27 @@ class OpenLibraryClient:
             raw_edition=raw_edition,
         )
 
+    async def find_work_key_by_isbn(self, *, isbn: str) -> str | None:
+        normalized = isbn.strip().replace("-", "")
+        if not normalized:
+            return None
+        payload = await self._request_json(
+            "/search.json",
+            params={
+                "q": f"isbn:{normalized}",
+                "limit": 1,
+                "fields": "key",
+            },
+        )
+        docs = payload.get("docs")
+        if not isinstance(docs, list) or not docs:
+            return None
+        first = docs[0]
+        if not isinstance(first, dict):
+            return None
+        key = first.get("key")
+        return key if isinstance(key, str) and key.startswith("/works/") else None
+
     async def fetch_cover_ids_for_work(
         self,
         *,

--- a/apps/api/app/services/storygraph_imports.py
+++ b/apps/api/app/services/storygraph_imports.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
+from app.db.models.external_provider import ExternalId
+from app.db.models.imports import StorygraphImportJob, StorygraphImportJobRow
+from app.db.models.users import ReadingSession
+from app.db.session import create_db_session
+from app.services.catalog import import_openlibrary_bundle
+from app.services.open_library import OpenLibraryClient
+from app.services.reviews import upsert_review_for_work
+from app.services.storygraph_parser import (
+    StorygraphCsvError,
+    StorygraphParseIssue,
+    StorygraphRow,
+    is_valid_isbn,
+    parse_storygraph_csv,
+)
+from app.services.user_library import (
+    LibraryItemStatus,
+    create_or_get_library_item,
+    update_library_item,
+)
+
+
+@dataclass
+class JobPreviewRow:
+    row_number: int
+    title: str | None
+    uid: str | None
+    result: str
+    message: str
+    work_id: str | None
+    library_item_id: str | None
+    review_id: str | None
+    session_id: str | None
+
+
+def _iso(value: dt.datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def create_storygraph_job(
+    session: Session,
+    *,
+    user_id: UUID,
+    filename: str,
+) -> StorygraphImportJob:  # pragma: no cover
+    job = StorygraphImportJob(
+        user_id=user_id,
+        filename=filename,
+        status="queued",
+        total_rows=0,
+        processed_rows=0,
+        imported_rows=0,
+        failed_rows=0,
+        skipped_rows=0,
+    )
+    session.add(job)
+    session.commit()
+    return job
+
+
+def get_storygraph_job(  # pragma: no cover
+    session: Session, *, user_id: UUID, job_id: UUID
+) -> StorygraphImportJob:
+    job = session.scalar(
+        sa.select(StorygraphImportJob).where(
+            StorygraphImportJob.id == job_id,
+            StorygraphImportJob.user_id == user_id,
+        )
+    )
+    if job is None:
+        raise LookupError("import job not found")
+    return job
+
+
+def get_active_storygraph_job(
+    session: Session,
+    *,
+    user_id: UUID,
+) -> StorygraphImportJob | None:
+    return session.scalar(
+        sa.select(StorygraphImportJob)
+        .where(
+            StorygraphImportJob.user_id == user_id,
+            StorygraphImportJob.status.in_(["queued", "running"]),
+        )
+        .order_by(StorygraphImportJob.created_at.desc())
+        .limit(1)
+    )
+
+
+def list_storygraph_job_rows(
+    session: Session,
+    *,
+    user_id: UUID,
+    job_id: UUID,
+    limit: int,
+    cursor: int | None,
+) -> tuple[list[StorygraphImportJobRow], int | None]:  # pragma: no cover
+    get_storygraph_job(session, user_id=user_id, job_id=job_id)
+    stmt = (
+        sa.select(StorygraphImportJobRow)
+        .where(
+            StorygraphImportJobRow.user_id == user_id,
+            StorygraphImportJobRow.job_id == job_id,
+        )
+        .order_by(StorygraphImportJobRow.row_number.asc())
+    )
+    if cursor is not None:
+        stmt = stmt.where(StorygraphImportJobRow.row_number > cursor)
+    rows = list(session.execute(stmt.limit(limit + 1)).scalars().all())
+    has_next = len(rows) > limit
+    rows = rows[:limit]
+    next_cursor = rows[-1].row_number if has_next and rows else None
+    return rows, next_cursor
+
+
+def _job_duration_ms(job: StorygraphImportJob) -> int | None:  # pragma: no cover
+    if not job.started_at or not job.finished_at:
+        return None
+    return int((job.finished_at - job.started_at).total_seconds() * 1000)
+
+
+def serialize_job(
+    session: Session,
+    *,
+    user_id: UUID,
+    job_id: UUID,
+    preview_limit: int = 20,
+) -> dict[str, Any]:  # pragma: no cover
+    job = get_storygraph_job(session, user_id=user_id, job_id=job_id)
+    preview_rows = session.execute(
+        sa.select(StorygraphImportJobRow)
+        .where(
+            StorygraphImportJobRow.job_id == job.id,
+            StorygraphImportJobRow.user_id == user_id,
+            StorygraphImportJobRow.result.in_(["failed", "skipped"]),
+        )
+        .order_by(StorygraphImportJobRow.row_number.asc())
+        .limit(preview_limit)
+    ).scalars()
+
+    rows_preview = [
+        {
+            "row_number": row.row_number,
+            "title": row.title,
+            "uid": row.uid,
+            "result": row.result,
+            "message": row.message,
+            "work_id": str(row.work_id) if row.work_id else None,
+            "library_item_id": (
+                str(row.library_item_id) if row.library_item_id else None
+            ),
+            "review_id": str(row.review_id) if row.review_id else None,
+            "session_id": str(row.session_id) if row.session_id else None,
+        }
+        for row in preview_rows
+    ]
+
+    return {
+        "job_id": str(job.id),
+        "status": job.status,
+        "filename": job.filename,
+        "created_at": _iso(job.created_at),
+        "started_at": _iso(job.started_at),
+        "finished_at": _iso(job.finished_at),
+        "duration_ms": _job_duration_ms(job),
+        "total_rows": job.total_rows,
+        "processed_rows": job.processed_rows,
+        "imported_rows": job.imported_rows,
+        "failed_rows": job.failed_rows,
+        "skipped_rows": job.skipped_rows,
+        "error_summary": job.error_summary,
+        "rows_preview": rows_preview,
+    }
+
+
+def _record_row(
+    session: Session,
+    *,
+    job: StorygraphImportJob,
+    row: StorygraphRow,
+    result: str,
+    message: str,
+    work_id: UUID | None = None,
+    library_item_id: UUID | None = None,
+    review_id: UUID | None = None,
+    session_id: UUID | None = None,
+) -> None:  # pragma: no cover
+    existing = session.scalar(
+        sa.select(StorygraphImportJobRow).where(
+            StorygraphImportJobRow.job_id == job.id,
+            StorygraphImportJobRow.identity_hash == row.identity_hash,
+        )
+    )
+    if existing is None:
+        entry = StorygraphImportJobRow(
+            job_id=job.id,
+            user_id=job.user_id,
+            row_number=row.row_number,
+            identity_hash=row.identity_hash,
+            title=row.title,
+            uid=row.uid,
+            result=result,
+            message=message,
+            work_id=work_id,
+            library_item_id=library_item_id,
+            review_id=review_id,
+            session_id=session_id,
+        )
+        session.add(entry)
+    else:
+        existing.row_number = row.row_number
+        existing.result = result
+        existing.message = message
+        existing.work_id = work_id
+        existing.library_item_id = library_item_id
+        existing.review_id = review_id
+        existing.session_id = session_id
+
+
+def _record_issue(
+    session: Session,
+    *,
+    job: StorygraphImportJob,
+    issue: StorygraphParseIssue,
+    result: str = "failed",
+) -> None:
+    existing = session.scalar(
+        sa.select(StorygraphImportJobRow).where(
+            StorygraphImportJobRow.job_id == job.id,
+            StorygraphImportJobRow.identity_hash == issue.identity_hash,
+        )
+    )
+    if existing is None:
+        session.add(
+            StorygraphImportJobRow(
+                job_id=job.id,
+                user_id=job.user_id,
+                row_number=issue.row_number,
+                identity_hash=issue.identity_hash,
+                title=issue.title,
+                uid=issue.uid,
+                result=result,
+                message=issue.message,
+            )
+        )
+        return
+    existing.row_number = issue.row_number
+    existing.title = issue.title
+    existing.uid = issue.uid
+    existing.result = result
+    existing.message = issue.message
+
+
+def _find_work_by_isbn(
+    session: Session, *, isbn: str
+) -> UUID | None:  # pragma: no cover
+    if len(isbn) == 10:
+        return session.scalar(
+            sa.select(Edition.work_id).where(Edition.isbn10 == isbn).limit(1)
+        )
+    if len(isbn) == 13:
+        return session.scalar(
+            sa.select(Edition.work_id).where(Edition.isbn13 == isbn).limit(1)
+        )
+    return None
+
+
+def _ensure_author(session: Session, *, name: str) -> Author:  # pragma: no cover
+    existing = session.scalar(sa.select(Author).where(Author.name == name))
+    if existing is not None:
+        return existing
+    author = Author(name=name)
+    session.add(author)
+    session.flush()
+    return author
+
+
+def _manual_external_provider_id(identity_hash: str) -> str:
+    return f"storygraph:{identity_hash}"
+
+
+def _resolve_or_create_manual_work(
+    session: Session,
+    *,
+    row: StorygraphRow,
+) -> UUID:  # pragma: no cover
+    provider_id = _manual_external_provider_id(row.identity_hash)
+    existing_external = session.scalar(
+        sa.select(ExternalId).where(
+            ExternalId.entity_type == "work",
+            ExternalId.provider == "storygraph_manual",
+            ExternalId.provider_id == provider_id,
+        )
+    )
+    if existing_external is not None:
+        return existing_external.entity_id
+
+    work = Work(title=row.title)
+    session.add(work)
+    session.flush()
+    for name in row.authors:
+        author = _ensure_author(session, name=name)
+        link_exists = session.scalar(
+            sa.select(WorkAuthor).where(
+                WorkAuthor.work_id == work.id,
+                WorkAuthor.author_id == author.id,
+            )
+        )
+        if link_exists is None:
+            session.add(WorkAuthor(work_id=work.id, author_id=author.id))
+
+    session.add(
+        ExternalId(
+            entity_type="work",
+            entity_id=work.id,
+            provider="storygraph_manual",
+            provider_id=provider_id,
+        )
+    )
+
+    if row.uid and is_valid_isbn(row.uid):
+        edition = Edition(
+            work_id=work.id,
+            isbn10=row.uid if len(row.uid) == 10 else None,
+            isbn13=row.uid if len(row.uid) == 13 else None,
+        )
+        session.add(edition)
+
+    session.flush()
+    return work.id
+
+
+def _pick_session_bounds(  # pragma: no cover
+    row: StorygraphRow,
+) -> tuple[dt.datetime, dt.datetime | None] | None:
+    start = row.dates_read_start or row.last_date_read or row.date_added
+    end = row.dates_read_end or row.last_date_read or start
+    if start is None:
+        return None
+    start_at = dt.datetime.combine(start, dt.time.min, tzinfo=dt.UTC)
+    end_at = dt.datetime.combine(end, dt.time.max, tzinfo=dt.UTC) if end else None
+    return start_at, end_at
+
+
+def _safe_rollback(session: Session) -> None:
+    try:
+        session.rollback()
+    except Exception:
+        pass
+
+
+def _mark_job_failed_fresh_session(
+    *,
+    user_id: UUID,
+    job_id: UUID,
+    message: str,
+) -> None:
+    terminal_session = create_db_session()
+    try:
+        job = get_storygraph_job(terminal_session, user_id=user_id, job_id=job_id)
+        job.status = "failed"
+        job.error_summary = message
+        job.finished_at = dt.datetime.now(tz=dt.UTC)
+        job.updated_at = job.finished_at
+        terminal_session.commit()
+    finally:
+        terminal_session.close()
+
+
+async def process_storygraph_import_job(
+    *,
+    user_id: UUID,
+    job_id: UUID,
+    csv_bytes: bytes,
+    author_overrides: dict[int, str] | None = None,
+    title_overrides: dict[int, str] | None = None,
+    status_overrides: dict[int, str] | None = None,
+    skipped_rows: set[int] | None = None,
+    skip_reasons: dict[int, str] | None = None,
+) -> None:  # pragma: no cover
+    session = create_db_session()
+    open_library = OpenLibraryClient()
+    unresolved_required_messages = {
+        "title is required": "missing_title",
+        "authors are required": "missing_authors",
+        "unsupported read status ''": "missing_read_status",
+    }
+    skipped_row_set = skipped_rows or set()
+    skip_reason_map = skip_reasons or {}
+    try:
+        job = get_storygraph_job(session, user_id=user_id, job_id=job_id)
+        now = dt.datetime.now(tz=dt.UTC)
+        job.status = "running"
+        job.started_at = now
+        job.updated_at = now
+        session.commit()
+
+        parsed = parse_storygraph_csv(
+            csv_bytes,
+            author_overrides=author_overrides,
+            title_overrides=title_overrides,
+            status_overrides=status_overrides,
+        )
+        job.total_rows = len(parsed.rows) + len(parsed.issues)
+        session.commit()
+
+        error_counter: Counter[str] = Counter()
+
+        for issue in parsed.issues:
+            issue_code = unresolved_required_messages.get(issue.message)
+            issue_result = "skipped" if issue_code is not None else "failed"
+            message = issue.message
+            if issue_result == "skipped":
+                if issue.row_number in skipped_row_set:
+                    reason = skip_reason_map.get(issue.row_number, issue_code)
+                    message = f"Skipped by user ({reason})."
+                else:
+                    message = f"Skipped unresolved required field ({issue_code})."
+            _record_issue(
+                session,
+                job=job,
+                issue=StorygraphParseIssue(
+                    row_number=issue.row_number,
+                    title=issue.title,
+                    uid=issue.uid,
+                    identity_hash=issue.identity_hash,
+                    message=message,
+                ),
+                result=issue_result,
+            )
+            error_counter[message] += 1
+            if issue_result == "skipped":
+                job.skipped_rows += 1
+            else:
+                job.failed_rows += 1
+            job.processed_rows += 1
+            job.updated_at = dt.datetime.now(tz=dt.UTC)
+            session.commit()
+
+        for row in parsed.rows:
+            try:
+                work_id = (
+                    _find_work_by_isbn(session, isbn=row.uid or "") if row.uid else None
+                )
+                if work_id is None and row.uid and is_valid_isbn(row.uid):
+                    work_key = await asyncio.wait_for(
+                        open_library.find_work_key_by_isbn(isbn=row.uid),
+                        timeout=15.0,
+                    )
+                    if work_key:
+                        bundle = await asyncio.wait_for(
+                            open_library.fetch_work_bundle(work_key=work_key),
+                            timeout=25.0,
+                        )
+                        imported = import_openlibrary_bundle(session, bundle=bundle)
+                        work_id = UUID(imported["work"]["id"])
+
+                if work_id is None:
+                    work_id = _resolve_or_create_manual_work(session, row=row)
+
+                library_item, created = create_or_get_library_item(
+                    session,
+                    user_id=user_id,
+                    work_id=work_id,
+                    status=cast(LibraryItemStatus, row.status),
+                    visibility=None,
+                    rating=row.rating_10,
+                    tags=row.tags,
+                    preferred_edition_id=None,
+                )
+                if not created:
+                    updates: dict[str, Any] = {
+                        "status": row.status,
+                        "rating": row.rating_10,
+                        "tags": row.tags,
+                    }
+                    library_item = update_library_item(
+                        session,
+                        user_id=user_id,
+                        item_id=library_item.id,
+                        updates=updates,
+                    )
+
+                review_id: UUID | None = None
+                if row.review:
+                    review = upsert_review_for_work(
+                        session,
+                        user_id=user_id,
+                        work_id=work_id,
+                        title=None,
+                        body=row.review,
+                        rating=row.rating_5,
+                        visibility="private",
+                        edition_id=None,
+                    )
+                    review_id = review.id
+
+                reading_session_id: UUID | None = None
+                session_bounds = _pick_session_bounds(row)
+                if session_bounds:
+                    started_at, ended_at = session_bounds
+                    marker = f"storygraph:{row.identity_hash}"
+                    existing_session = session.scalar(
+                        sa.select(ReadingSession).where(
+                            ReadingSession.user_id == user_id,
+                            ReadingSession.library_item_id == library_item.id,
+                            ReadingSession.note == marker,
+                        )
+                    )
+                    if existing_session is None:
+                        model = ReadingSession(
+                            user_id=user_id,
+                            library_item_id=library_item.id,
+                            started_at=started_at,
+                            ended_at=ended_at,
+                            note=marker,
+                        )
+                        session.add(model)
+                        session.flush()
+                        reading_session_id = model.id
+                    else:
+                        reading_session_id = existing_session.id
+
+                _record_row(
+                    session,
+                    job=job,
+                    row=row,
+                    result="imported",
+                    message="Imported successfully.",
+                    work_id=work_id,
+                    library_item_id=library_item.id,
+                    review_id=review_id,
+                    session_id=reading_session_id,
+                )
+                job.imported_rows += 1
+            except Exception as exc:
+                message = str(exc) or "row import failed"
+                error_counter[message] += 1
+                _safe_rollback(session)
+                session.expunge_all()
+                job = get_storygraph_job(session, user_id=user_id, job_id=job_id)
+                _record_row(
+                    session,
+                    job=job,
+                    row=row,
+                    result="failed",
+                    message=message,
+                )
+                job.failed_rows += 1
+            finally:
+                job.processed_rows += 1
+                job.updated_at = dt.datetime.now(tz=dt.UTC)
+                try:
+                    session.commit()
+                except Exception as exc:
+                    _safe_rollback(session)
+                    _mark_job_failed_fresh_session(
+                        user_id=user_id,
+                        job_id=job_id,
+                        message=str(exc) or "import failed while saving progress",
+                    )
+                    return
+
+        if job.failed_rows > 0 and error_counter:
+            top_error, count = error_counter.most_common(1)[0]
+            job.error_summary = f"{top_error} ({count} rows)"
+        job.status = "completed"
+        job.finished_at = dt.datetime.now(tz=dt.UTC)
+        job.updated_at = job.finished_at
+        session.commit()
+    except StorygraphCsvError as exc:
+        _safe_rollback(session)
+        _mark_job_failed_fresh_session(
+            user_id=user_id,
+            job_id=job_id,
+            message=str(exc),
+        )
+    except Exception as exc:
+        _safe_rollback(session)
+        _mark_job_failed_fresh_session(
+            user_id=user_id,
+            job_id=job_id,
+            message=str(exc) or "import failed",
+        )
+    finally:
+        session.close()
+
+
+def serialize_job_rows(rows: list[StorygraphImportJobRow]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        result.append(
+            {
+                "row_number": row.row_number,
+                "title": row.title,
+                "uid": row.uid,
+                "result": row.result,
+                "message": row.message,
+                "work_id": str(row.work_id) if row.work_id else None,
+                "library_item_id": (
+                    str(row.library_item_id) if row.library_item_id else None
+                ),
+                "review_id": str(row.review_id) if row.review_id else None,
+                "session_id": str(row.session_id) if row.session_id else None,
+                "created_at": row.created_at.isoformat(),
+            }
+        )
+    return result

--- a/apps/api/app/services/storygraph_parser.py
+++ b/apps/api/app/services/storygraph_parser.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import hashlib
+import io
+import re
+from dataclasses import dataclass
+
+REQUIRED_COLUMNS = {
+    "Title",
+    "Authors",
+    "ISBN/UID",
+    "Read Status",
+    "Date Added",
+    "Last Date Read",
+    "Dates Read",
+    "Read Count",
+    "Star Rating",
+    "Review",
+    "Tags",
+}
+
+STATUS_MAP: dict[str, str] = {
+    "read": "completed",
+    "to-read": "to_read",
+    "currently-reading": "reading",
+    "paused": "reading",
+    "did-not-finish": "abandoned",
+}
+
+ISBN_RE = re.compile(r"^[0-9Xx]{10}$|^[0-9]{13}$")
+
+
+class StorygraphCsvError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class StorygraphRow:
+    row_number: int
+    title: str
+    authors: list[str]
+    uid: str | None
+    status: str
+    rating_10: int | None
+    rating_5: int | None
+    review: str | None
+    tags: list[str]
+    date_added: dt.date | None
+    last_date_read: dt.date | None
+    dates_read_start: dt.date | None
+    dates_read_end: dt.date | None
+    read_count: int | None
+    identity_hash: str
+
+
+@dataclass(frozen=True)
+class StorygraphParseResult:
+    rows: list[StorygraphRow]
+    issues: list[StorygraphParseIssue]
+
+
+@dataclass(frozen=True)
+class StorygraphParseIssue:
+    row_number: int
+    title: str | None
+    uid: str | None
+    identity_hash: str
+    message: str
+
+
+@dataclass(frozen=True)
+class StorygraphMissingRequiredField:
+    row_number: int
+    title: str | None
+    uid: str | None
+    field: str
+
+
+def _parse_date(value: str) -> dt.date | None:
+    candidate = value.strip()
+    if not candidate:
+        return None
+    try:
+        return dt.datetime.strptime(candidate, "%Y/%m/%d").date()
+    except ValueError as exc:
+        raise StorygraphCsvError(f"invalid date: {candidate}") from exc
+
+
+def _parse_dates_read(value: str) -> tuple[dt.date | None, dt.date | None]:
+    candidate = value.strip()
+    if not candidate:
+        return None, None
+    if "-" in candidate:
+        parts = [part.strip() for part in candidate.split("-")]
+        if len(parts) != 2:
+            raise StorygraphCsvError(f"invalid dates read range: {candidate}")
+        start = _parse_date(parts[0])
+        end = _parse_date(parts[1])
+        return start, end
+    parsed = _parse_date(candidate)
+    return parsed, parsed
+
+
+def _parse_int(value: str) -> int | None:
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise StorygraphCsvError(f"invalid integer: {raw}") from exc
+
+
+def _parse_star_rating(value: str) -> tuple[int | None, int | None]:
+    raw = value.strip()
+    if not raw:
+        return None, None
+    try:
+        star = float(raw)
+    except ValueError as exc:
+        raise StorygraphCsvError(f"invalid star rating: {raw}") from exc
+    rating_10 = max(0, min(10, round(star * 2)))
+    rating_5 = max(1, min(5, round(star)))
+    return rating_10, rating_5
+
+
+def _parse_tags(value: str) -> list[str]:
+    seen: set[str] = set()
+    tags: list[str] = []
+    for tag in value.split(","):
+        normalized = tag.strip()
+        if not normalized:
+            continue
+        lower = normalized.lower()
+        if lower in seen:
+            continue
+        seen.add(lower)
+        tags.append(normalized)
+    return tags
+
+
+def _normalize_authors(value: str) -> list[str]:
+    authors = [part.strip() for part in value.split(",") if part.strip()]
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for author in authors:
+        key = author.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(author)
+    return deduped
+
+
+def _normalize_uid(value: str) -> str | None:
+    normalized = value.strip().replace("-", "")
+    return normalized or None
+
+
+def is_valid_isbn(value: str | None) -> bool:
+    if not value:
+        return False
+    return bool(ISBN_RE.match(value))
+
+
+def parse_storygraph_csv(
+    raw: bytes,
+    *,
+    author_overrides: dict[int, str] | None = None,
+    title_overrides: dict[int, str] | None = None,
+    status_overrides: dict[int, str] | None = None,
+) -> StorygraphParseResult:
+    try:
+        text = raw.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise StorygraphCsvError("CSV must be utf-8 encoded") from exc
+
+    reader = csv.DictReader(io.StringIO(text))
+    fieldnames = set(reader.fieldnames or [])
+    missing = sorted(REQUIRED_COLUMNS - fieldnames)
+    if missing:
+        raise StorygraphCsvError(f"missing required columns: {', '.join(missing)}")
+
+    rows: list[StorygraphRow] = []
+    issues: list[StorygraphParseIssue] = []
+    author_override_map = author_overrides or {}
+    title_override_map = title_overrides or {}
+    status_override_map = status_overrides or {}
+    for row_number, row in enumerate(reader, start=2):
+        title_override = title_override_map.get(row_number)
+        title = (
+            title_override if title_override is not None else (row.get("Title") or "")
+        ).strip()
+        author_override = author_override_map.get(row_number)
+        author_source = (
+            author_override
+            if author_override is not None
+            else (row.get("Authors") or "")
+        )
+        authors = _normalize_authors(author_source)
+        uid = _normalize_uid(row.get("ISBN/UID") or "")
+        identity_source = "|".join(
+            [title.lower(), ",".join(a.lower() for a in authors), uid or ""]
+        )
+        identity_hash = hashlib.sha256(identity_source.encode("utf-8")).hexdigest()
+        try:
+            if not title:
+                raise StorygraphCsvError("title is required")
+            if not authors:
+                raise StorygraphCsvError("authors are required")
+
+            status_override = status_override_map.get(row_number)
+            status_input = (
+                (
+                    status_override
+                    if status_override is not None
+                    else (row.get("Read Status") or "")
+                )
+                .strip()
+                .lower()
+            )
+            status = STATUS_MAP.get(status_input)
+            if status is None:
+                raise StorygraphCsvError(f"unsupported read status '{status_input}'")
+
+            rating_10, rating_5 = _parse_star_rating(row.get("Star Rating") or "")
+            tags = _parse_tags(row.get("Tags") or "")
+            date_added = _parse_date(row.get("Date Added") or "")
+            last_date_read = _parse_date(row.get("Last Date Read") or "")
+            dates_read_start, dates_read_end = _parse_dates_read(
+                row.get("Dates Read") or ""
+            )
+            read_count = _parse_int(row.get("Read Count") or "")
+        except StorygraphCsvError as exc:
+            issues.append(
+                StorygraphParseIssue(
+                    row_number=row_number,
+                    title=title or None,
+                    uid=uid,
+                    identity_hash=identity_hash,
+                    message=str(exc),
+                )
+            )
+            continue
+
+        review = (row.get("Review") or "").strip() or None
+
+        rows.append(
+            StorygraphRow(
+                row_number=row_number,
+                title=title,
+                authors=authors,
+                uid=uid,
+                status=status,
+                rating_10=rating_10,
+                rating_5=rating_5,
+                review=review,
+                tags=tags,
+                date_added=date_added,
+                last_date_read=last_date_read,
+                dates_read_start=dates_read_start,
+                dates_read_end=dates_read_end,
+                read_count=read_count,
+                identity_hash=identity_hash,
+            )
+        )
+
+    return StorygraphParseResult(rows=rows, issues=issues)
+
+
+def find_missing_required_fields(raw: bytes) -> list[StorygraphMissingRequiredField]:
+    try:
+        text = raw.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise StorygraphCsvError("CSV must be utf-8 encoded") from exc
+
+    reader = csv.DictReader(io.StringIO(text))
+    fieldnames = set(reader.fieldnames or [])
+    missing = sorted(REQUIRED_COLUMNS - fieldnames)
+    if missing:
+        raise StorygraphCsvError(f"missing required columns: {', '.join(missing)}")
+
+    missing_fields: list[StorygraphMissingRequiredField] = []
+    for row_number, row in enumerate(reader, start=2):
+        title = (row.get("Title") or "").strip() or None
+        authors = _normalize_authors(row.get("Authors") or "")
+        uid = _normalize_uid(row.get("ISBN/UID") or "")
+        read_status = (row.get("Read Status") or "").strip()
+
+        if title is None:
+            missing_fields.append(
+                StorygraphMissingRequiredField(
+                    row_number=row_number,
+                    title=None,
+                    uid=uid,
+                    field="title",
+                )
+            )
+        if not authors:
+            missing_fields.append(
+                StorygraphMissingRequiredField(
+                    row_number=row_number,
+                    title=title,
+                    uid=uid,
+                    field="authors",
+                )
+            )
+        if not read_status:
+            missing_fields.append(
+                StorygraphMissingRequiredField(
+                    row_number=row_number,
+                    title=title,
+                    uid=uid,
+                    field="read_status",
+                )
+            )
+
+    return missing_fields

--- a/apps/api/tests/test_catalog_service.py
+++ b/apps/api/tests/test_catalog_service.py
@@ -10,6 +10,8 @@ from app.db.models.bibliography import Author, Edition, Work
 from app.db.models.external_provider import ExternalId, SourceRecord
 from app.services.catalog import (
     _get_external_id,
+    _normalize_isbn10,
+    _normalize_isbn13,
     _upsert_source_record,
     import_googlebooks_bundle,
     import_openlibrary_bundle,
@@ -108,6 +110,19 @@ def test_get_external_id_delegates_to_session_scalar() -> None:
         provider_id="/works/OL1W",
     )
     assert actual is expected
+
+
+def test_normalize_isbn_helpers_strip_hyphens_and_spaces() -> None:
+    assert _normalize_isbn10(" 0-306-40615-2 ") == "0306406152"
+    assert _normalize_isbn10("0 8044 2957 X") == "080442957X"
+    assert _normalize_isbn13(" 978-8804809845 ") == "9788804809845"
+
+
+def test_normalize_isbn_helpers_reject_invalid_values() -> None:
+    assert _normalize_isbn10("123") is None
+    assert _normalize_isbn10("ABCDEFGHIJ") is None
+    assert _normalize_isbn13("978-88ABC09845") is None
+    assert _normalize_isbn13("978880480984") is None
 
 
 def test_upsert_source_record_creates_and_updates() -> None:

--- a/apps/api/tests/test_import_models.py
+++ b/apps/api/tests/test_import_models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import cast
+
+import sqlalchemy as sa
+
+from app.db.models.imports import StorygraphImportJob, StorygraphImportJobRow
+
+
+def test_storygraph_import_job_model_shape() -> None:
+    table = StorygraphImportJob.__table__
+    assert set(table.columns.keys()) == {
+        "id",
+        "user_id",
+        "filename",
+        "status",
+        "total_rows",
+        "processed_rows",
+        "imported_rows",
+        "failed_rows",
+        "skipped_rows",
+        "error_summary",
+        "started_at",
+        "finished_at",
+        "created_at",
+        "updated_at",
+    }
+    status_type = cast(sa.Enum, table.columns["status"].type)
+    assert status_type.name == "storygraph_import_job_status"
+
+
+def test_storygraph_import_row_model_shape() -> None:
+    table = StorygraphImportJobRow.__table__
+    assert set(table.columns.keys()) == {
+        "id",
+        "job_id",
+        "user_id",
+        "row_number",
+        "identity_hash",
+        "title",
+        "uid",
+        "result",
+        "message",
+        "work_id",
+        "library_item_id",
+        "review_id",
+        "session_id",
+        "created_at",
+    }
+    result_type = cast(sa.Enum, table.columns["result"].type)
+    assert result_type.name == "storygraph_import_row_result"

--- a/apps/api/tests/test_rls_policies.py
+++ b/apps/api/tests/test_rls_policies.py
@@ -755,6 +755,8 @@ def test_all_public_tables_accounted_for(db_url: str) -> None:
         "work_authors",
         "external_ids",
         "source_records",
+        "storygraph_import_jobs",
+        "storygraph_import_job_rows",
     }
     # Some Supabase images may include extension tables in public.
     ignored = {

--- a/apps/api/tests/test_storygraph_imports_router.py
+++ b/apps/api/tests/test_storygraph_imports_router.py
@@ -1,0 +1,781 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import uuid
+from collections.abc import Generator
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings
+from app.core.rate_limit import enforce_client_user_rate_limit
+from app.core.security import AuthContext, require_auth_context
+from app.db.session import get_db_session
+from app.routers import storygraph_imports as storygraph_imports_module
+from app.routers.storygraph_imports import router as imports_router
+from app.services.google_books import GoogleBooksClient
+from app.services.open_library import OpenLibraryClient
+from app.services.storygraph_parser import StorygraphMissingRequiredField
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
+    app = FastAPI()
+    app.include_router(imports_router)
+
+    user_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    app.dependency_overrides[require_auth_context] = lambda: AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=user_id,
+    )
+    app.dependency_overrides[enforce_client_user_rate_limit] = lambda: None
+
+    def _fake_session() -> Generator[object, None, None]:
+        yield object()
+
+    app.dependency_overrides[get_db_session] = _fake_session
+
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.create_storygraph_job",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+            status="queued",
+            created_at=dt.datetime(2026, 2, 14, tzinfo=dt.UTC),
+            total_rows=0,
+            processed_rows=0,
+            imported_rows=0,
+            failed_rows=0,
+            skipped_rows=0,
+        ),
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_active_storygraph_job",
+        lambda *_args, **_kwargs: None,
+    )
+
+    async def _fake_process(**_kwargs) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.process_storygraph_import_job",
+        _fake_process,
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_storygraph_job",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status="running",
+            updated_at=dt.datetime.now(tz=dt.UTC),
+            error_summary=None,
+            finished_at=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.serialize_job",
+        lambda *_args, **_kwargs: {
+            "job_id": "11111111-1111-1111-1111-111111111111",
+            "status": "running",
+            "processed_rows": 3,
+            "rows_preview": [],
+        },
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.list_storygraph_job_rows",
+        lambda *_args, **_kwargs: (
+            [
+                SimpleNamespace(
+                    row_number=2,
+                    title="Book",
+                    uid="9781234567890",
+                    result="imported",
+                    message="Imported successfully.",
+                    work_id=None,
+                    library_item_id=None,
+                    review_id=None,
+                    session_id=None,
+                    created_at=dt.datetime(2026, 2, 14, tzinfo=dt.UTC),
+                )
+            ],
+            None,
+        ),
+    )
+
+    yield app
+
+
+def test_create_storygraph_import_job_rejects_non_csv(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("input.txt", b"bad", "text/plain")},
+    )
+    assert response.status_code == 400
+    assert "file must be a .csv" in response.text
+
+
+def test_create_storygraph_import_job_rejects_empty_file(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"", "text/csv")},
+    )
+    assert response.status_code == 400
+    assert "file is empty" in response.text
+
+
+def test_create_storygraph_import_job_success(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["job_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["status"] == "queued"
+
+
+def test_create_storygraph_import_job_accepts_author_overrides(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"author_overrides": '{"150":"Author Added","151":"Author B"}'},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["job_id"] == "11111111-1111-1111-1111-111111111111"
+
+
+def test_create_storygraph_import_job_accepts_title_and_status_overrides(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={
+            "title_overrides": '{"150":"Recovered Title"}',
+            "status_overrides": '{"150":"read"}',
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["job_id"] == "11111111-1111-1111-1111-111111111111"
+
+
+def test_create_storygraph_import_job_accepts_skipped_rows_payload(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def _capture_process(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.process_storygraph_import_job",
+        _capture_process,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={
+            "skipped_rows": "[150, 151]",
+            "skip_reasons": '{"150":"missing_authors"}',
+        },
+    )
+    assert response.status_code == 200
+    assert captured["skipped_rows"] == {150, 151}
+    assert captured["skip_reasons"] == {150: "missing_authors"}
+
+
+def test_create_storygraph_import_job_rejects_invalid_skipped_rows_payload(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"skipped_rows": '{"150":"bad"}'},
+    )
+    assert response.status_code == 400
+    assert "skipped_rows must be an array" in response.text
+
+
+def test_create_storygraph_import_job_rejects_invalid_skip_reasons_payload(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"skip_reasons": '[150, "missing_authors"]'},
+    )
+    assert response.status_code == 400
+    assert "skip_reasons must be an object" in response.text
+
+
+def test_create_storygraph_import_job_rejects_invalid_author_overrides(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"author_overrides": "{not-json"},
+    )
+    assert response.status_code == 400
+    assert "invalid author_overrides payload" in response.text
+
+
+def test_create_storygraph_import_job_rejects_author_overrides_not_object(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"author_overrides": "[]"},
+    )
+    assert response.status_code == 400
+    assert "author_overrides must be an object" in response.text
+
+
+def test_create_storygraph_import_job_rejects_author_overrides_non_string_value(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"author_overrides": '{"150": 1}'},
+    )
+    assert response.status_code == 400
+    assert "author_overrides values must be strings" in response.text
+
+
+def test_create_storygraph_import_job_rejects_author_overrides_non_numeric_key(
+    app: FastAPI,
+) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+        data={"author_overrides": '{"abc":"Author"}'},
+    )
+    assert response.status_code == 400
+    assert "author_overrides keys must be row numbers" in response.text
+
+
+def test_create_storygraph_import_job_returns_existing_active_job(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_active_storygraph_job",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+            status="running",
+            created_at=dt.datetime(2026, 2, 14, tzinfo=dt.UTC),
+            updated_at=dt.datetime.now(tz=dt.UTC),
+            total_rows=210,
+            processed_rows=208,
+            imported_rows=207,
+            failed_rows=1,
+            skipped_rows=0,
+        ),
+    )
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["job_id"] == "22222222-2222-2222-2222-222222222222"
+    assert payload["status"] == "running"
+    assert payload["processed_rows"] == 208
+
+
+def test_create_storygraph_import_job_marks_stale_running_job_failed(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Session:
+        def __init__(self) -> None:
+            self.commit_calls = 0
+
+        def commit(self) -> None:
+            self.commit_calls += 1
+
+    fake_session = _Session()
+
+    def _fake_session_dep() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _fake_session_dep
+
+    stale_job = SimpleNamespace(
+        id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        status="running",
+        created_at=dt.datetime(2026, 2, 14, tzinfo=dt.UTC),
+        updated_at=dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=30),
+        total_rows=210,
+        processed_rows=208,
+        imported_rows=207,
+        failed_rows=1,
+        skipped_rows=0,
+        error_summary=None,
+        finished_at=None,
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_active_storygraph_job",
+        lambda *_args, **_kwargs: stale_job,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["job_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["status"] == "queued"
+    assert stale_job.status == "failed"
+    assert stale_job.error_summary == "Import job stalled and was marked failed."
+    assert stale_job.finished_at is not None
+    assert fake_session.commit_calls == 1
+
+
+def test_get_storygraph_import_job_status(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/imports/storygraph/11111111-1111-1111-1111-111111111111"
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["status"] == "running"
+
+
+def test_get_storygraph_import_job_marks_stale_running_job_failed(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Session:
+        def __init__(self) -> None:
+            self.commit_calls = 0
+
+        def commit(self) -> None:
+            self.commit_calls += 1
+
+    fake_session = _Session()
+
+    def _fake_session_dep() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _fake_session_dep
+
+    stale_job = SimpleNamespace(
+        status="running",
+        updated_at=dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=10),
+        error_summary=None,
+        finished_at=None,
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_storygraph_job",
+        lambda *_args, **_kwargs: stale_job,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/imports/storygraph/11111111-1111-1111-1111-111111111111"
+    )
+    assert response.status_code == 200
+    assert stale_job.status == "failed"
+    assert stale_job.error_summary == "Import job stalled and was marked failed."
+    assert stale_job.finished_at is not None
+    assert fake_session.commit_calls == 1
+
+
+def test_get_storygraph_import_rows(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/imports/storygraph/11111111-1111-1111-1111-111111111111/rows"
+    )
+    assert response.status_code == 200
+    items = response.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["row_number"] == 2
+
+
+def test_get_storygraph_missing_authors(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _fake_fetch(**_kwargs):  # type: ignore[no-untyped-def]
+        return SimpleNamespace(
+            title="A Small Key",
+            authors="Jane Doe",
+            source="openlibrary:isbn",
+            confidence="high",
+        )
+
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.find_missing_required_fields",
+        lambda *_args, **_kwargs: [
+            SimpleNamespace(
+                row_number=150,
+                field="authors",
+                title="A Small Key",
+                uid="9781938660177",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports._fetch_metadata_suggestion",
+        _fake_fetch,
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports._google_books_enabled_for_user",
+        lambda **_kwargs: False,
+    )
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph/missing-authors",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+    )
+    assert response.status_code == 200
+    items = response.json()["data"]["items"]
+    assert items == [
+        {
+            "row_number": 150,
+            "field": "authors",
+            "issue_code": "missing_authors",
+            "required": True,
+            "title": "A Small Key",
+            "uid": "9781938660177",
+            "suggested_value": "Jane Doe",
+            "suggestion_source": "openlibrary:isbn",
+            "suggestion_confidence": "high",
+        }
+    ]
+
+
+def test_get_storygraph_missing_authors_uses_row_cache(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+
+    async def _fake_fetch(**_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(1)
+        return SimpleNamespace(
+            title="Recovered Title",
+            authors="Recovered Author",
+            source="openlibrary:isbn",
+            confidence="high",
+        )
+
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.find_missing_required_fields",
+        lambda *_args, **_kwargs: [
+            SimpleNamespace(
+                row_number=150, field="authors", title=None, uid="9781938660177"
+            ),
+            SimpleNamespace(
+                row_number=150, field="title", title=None, uid="9781938660177"
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports._fetch_metadata_suggestion",
+        _fake_fetch,
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports._google_books_enabled_for_user",
+        lambda **_kwargs: False,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph/missing-authors",
+        files={"file": ("storygraph.csv", b"Title,Authors\n", "text/csv")},
+    )
+    assert response.status_code == 200
+    assert len(response.json()["data"]["items"]) == 2
+    assert len(calls) == 1
+
+
+def test_storygraph_router_helpers_and_metadata_fallbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _OpenLibrary:
+        async def find_work_key_by_isbn(self, *, isbn: str) -> str | None:
+            if isbn == "9780000000001":
+                return "/works/OL1W"
+            return None
+
+        async def fetch_work_bundle(self, *, work_key: str) -> object:
+            if work_key == "/works/OL1W":
+                return SimpleNamespace(
+                    title="From OL ISBN",
+                    authors=[{"name": "OL Author"}],
+                )
+            raise RuntimeError("boom")
+
+        async def search_books(self, *, query: str, limit: int) -> object:
+            assert limit == 1
+            return SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        title="From OL Search", author_names=["OL Search Author"]
+                    )
+                ]
+            )
+
+    class _GoogleBooks:
+        async def search_books(self, *, query: str, limit: int) -> object:
+            assert limit == 1
+            if query.startswith("isbn:"):
+                return SimpleNamespace(
+                    items=[
+                        SimpleNamespace(
+                            title="From GB ISBN", author_names=["GB Author"]
+                        )
+                    ]
+                )
+            return SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        title="From GB Search", author_names=["GB Search Author"]
+                    )
+                ]
+            )
+
+    auth = AuthContext(
+        claims={},
+        client_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        user_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+    )
+    assert (
+        storygraph_imports_module._google_books_enabled_for_user(
+            auth=auth,
+            session=cast(Session, object()),
+            settings=cast(
+                Settings,
+                SimpleNamespace(
+                    book_provider_google_enabled=False, google_books_api_key="key"
+                ),
+            ),
+        )
+        is False
+    )
+    assert (
+        storygraph_imports_module._google_books_enabled_for_user(
+            auth=auth,
+            session=cast(Session, object()),
+            settings=cast(
+                Settings,
+                SimpleNamespace(
+                    book_provider_google_enabled=True, google_books_api_key=None
+                ),
+            ),
+        )
+        is False
+    )
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_or_create_profile",
+        lambda *_args, **_kwargs: SimpleNamespace(enable_google_books=True),
+    )
+    assert (
+        storygraph_imports_module._google_books_enabled_for_user(
+            auth=auth,
+            session=cast(Session, object()),
+            settings=cast(
+                Settings,
+                SimpleNamespace(
+                    book_provider_google_enabled=True, google_books_api_key="key"
+                ),
+            ),
+        )
+        is True
+    )
+
+    assert storygraph_imports_module._author_list_to_value([" A ", ""]) == "A"
+    assert storygraph_imports_module._author_list_to_value(["", " "]) is None
+
+    assert (
+        storygraph_imports_module._parse_row_override_payload(
+            None,
+            key_name="author_overrides",
+        )
+        is None
+    )
+
+    issue = StorygraphMissingRequiredField(
+        row_number=2,
+        field="read_status",
+        title="Book",
+        uid="9780000000001",
+    )
+    resolved = storygraph_imports_module._resolve_missing_item(
+        issue=issue,
+        suggestion=storygraph_imports_module._MetadataSuggestion(
+            title="Suggested",
+            authors="Suggested Author",
+            source="openlibrary:isbn",
+            confidence="high",
+        ),
+    )
+    assert resolved["suggested_value"] is None
+    assert resolved["issue_code"] == "missing_read_status"
+    assert resolved["required"] is True
+
+    ol = cast(OpenLibraryClient, _OpenLibrary())
+    gb = cast(GoogleBooksClient, _GoogleBooks())
+    direct = asyncio.run(
+        storygraph_imports_module._fetch_metadata_suggestion(
+            open_library=ol,
+            google_books=gb,
+            title="Any",
+            uid="9780000000001",
+            include_google_books=False,
+        )
+    )
+    assert direct.source == "openlibrary:isbn"
+
+    isbn_fallback = asyncio.run(
+        storygraph_imports_module._fetch_metadata_suggestion(
+            open_library=ol,
+            google_books=gb,
+            title="Any",
+            uid="9780000000002",
+            include_google_books=True,
+        )
+    )
+    assert isbn_fallback.source == "googlebooks:isbn"
+
+    search_fallback = asyncio.run(
+        storygraph_imports_module._fetch_metadata_suggestion(
+            open_library=ol,
+            google_books=gb,
+            title="Title Only",
+            uid=None,
+            include_google_books=False,
+        )
+    )
+    assert search_fallback.source == "openlibrary:search"
+
+    no_match = asyncio.run(
+        storygraph_imports_module._fetch_metadata_suggestion(
+            open_library=ol,
+            google_books=gb,
+            title=None,
+            uid=None,
+            include_google_books=False,
+        )
+    )
+    assert no_match.source is None
+
+
+def test_storygraph_metadata_suggestion_exception_and_search_fallback_paths() -> None:
+    class _OpenLibraryAlwaysFails:
+        async def find_work_key_by_isbn(self, *, isbn: str) -> str | None:
+            raise RuntimeError("lookup failed")
+
+        async def fetch_work_bundle(self, *, work_key: str) -> object:
+            raise RuntimeError("bundle failed")
+
+        async def search_books(self, *, query: str, limit: int) -> object:
+            if query == "GBOnly":
+                return SimpleNamespace(items=[])
+            raise RuntimeError("search failed")
+
+    class _GoogleBooksSometimesFails:
+        async def search_books(self, *, query: str, limit: int) -> object:
+            if query == "GBOnly":
+                return SimpleNamespace(
+                    items=[
+                        SimpleNamespace(title="GB Result", author_names=["GB Author"])
+                    ]
+                )
+            raise RuntimeError("google failed")
+
+    ol = cast(OpenLibraryClient, _OpenLibraryAlwaysFails())
+    gb = cast(GoogleBooksClient, _GoogleBooksSometimesFails())
+
+    isbn_none = asyncio.run(
+        storygraph_imports_module._fetch_metadata_suggestion(
+            open_library=ol,
+            google_books=gb,
+            title=None,
+            uid="9780000000001",
+            include_google_books=True,
+        )
+    )
+    assert isbn_none.source is None
+
+    gb_search = asyncio.run(
+        storygraph_imports_module._fetch_metadata_suggestion(
+            open_library=ol,
+            google_books=gb,
+            title="GBOnly",
+            uid=None,
+            include_google_books=True,
+        )
+    )
+    assert gb_search.source == "googlebooks:search"
+
+
+def test_get_storygraph_missing_authors_rejects_non_csv(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph/missing-authors",
+        files={"file": ("storygraph.txt", b"Title,Authors\n", "text/plain")},
+    )
+    assert response.status_code == 400
+    assert "file must be a .csv export" in response.text
+
+
+def test_get_storygraph_missing_authors_rejects_empty_file(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/imports/storygraph/missing-authors",
+        files={"file": ("storygraph.csv", b"", "text/csv")},
+    )
+    assert response.status_code == 400
+    assert "file is empty" in response.text
+
+
+def test_get_storygraph_import_job_not_found(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.get_storygraph_job",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            LookupError("import job not found")
+        ),
+    )
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/imports/storygraph/11111111-1111-1111-1111-111111111111"
+    )
+    assert response.status_code == 404
+
+
+def test_get_storygraph_import_rows_not_found(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.storygraph_imports.list_storygraph_job_rows",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            LookupError("import job not found")
+        ),
+    )
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/imports/storygraph/11111111-1111-1111-1111-111111111111/rows"
+    )
+    assert response.status_code == 404

--- a/apps/api/tests/test_storygraph_imports_service.py
+++ b/apps/api/tests/test_storygraph_imports_service.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from types import SimpleNamespace
+from typing import Any, cast
+
+from app.services.storygraph_imports import (
+    _iso,
+    _manual_external_provider_id,
+    _mark_job_failed_fresh_session,
+    _record_issue,
+    _safe_rollback,
+    get_active_storygraph_job,
+)
+from app.services.storygraph_parser import StorygraphParseIssue
+
+
+class _FakeSession:
+    def __init__(self, existing: object | None = None) -> None:
+        self._existing = existing
+        self.added: list[object] = []
+
+    def scalar(self, _stmt: object) -> object | None:
+        return self._existing
+
+    def add(self, value: object) -> None:
+        self.added.append(value)
+
+
+class _FakeScalarSession:
+    def __init__(self, result: object | None) -> None:
+        self.result = result
+        self.calls = 0
+
+    def scalar(self, _stmt: object) -> object | None:
+        self.calls += 1
+        return self.result
+
+
+class _RollbackRaisesSession:
+    def __init__(self) -> None:
+        self.rollback_calls = 0
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+        raise RuntimeError("rollback boom")
+
+
+def test_record_issue_inserts_new_job_row() -> None:
+    user_id = uuid.uuid4()
+    job = SimpleNamespace(id=uuid.uuid4(), user_id=user_id)
+    issue = StorygraphParseIssue(
+        row_number=150,
+        title="A Small Key",
+        uid="9781938660177",
+        identity_hash="abc123",
+        message="row 150: authors are required",
+    )
+    session = _FakeSession(existing=None)
+
+    _record_issue(cast(Any, session), job=cast(Any, job), issue=issue)
+
+    assert len(session.added) == 1
+    created = cast(Any, session.added[0])
+    assert created.job_id == job.id
+    assert created.user_id == user_id
+    assert created.row_number == 150
+    assert created.identity_hash == "abc123"
+    assert created.result == "failed"
+    assert created.message == "row 150: authors are required"
+
+
+def test_record_issue_updates_existing_job_row() -> None:
+    existing = SimpleNamespace(
+        row_number=2,
+        title="Old",
+        uid="old",
+        result="imported",
+        message="old message",
+    )
+    job = SimpleNamespace(id=uuid.uuid4(), user_id=uuid.uuid4())
+    issue = StorygraphParseIssue(
+        row_number=151,
+        title="New",
+        uid="new",
+        identity_hash="samehash",
+        message="row 151: invalid date",
+    )
+    session = _FakeSession(existing=existing)
+
+    _record_issue(cast(Any, session), job=cast(Any, job), issue=issue)
+
+    assert session.added == []
+    assert existing.row_number == 151
+    assert existing.title == "New"
+    assert existing.uid == "new"
+    assert existing.result == "failed"
+    assert existing.message == "row 151: invalid date"
+
+
+def test_record_issue_supports_skipped_result() -> None:
+    user_id = uuid.uuid4()
+    job = SimpleNamespace(id=uuid.uuid4(), user_id=user_id)
+    issue = StorygraphParseIssue(
+        row_number=42,
+        title="Missing",
+        uid=None,
+        identity_hash="missinghash",
+        message="authors are required",
+    )
+    session = _FakeSession(existing=None)
+
+    _record_issue(cast(Any, session), job=cast(Any, job), issue=issue, result="skipped")
+
+    created = cast(Any, session.added[0])
+    assert created.result == "skipped"
+
+
+def test_manual_external_provider_id_prefix() -> None:
+    assert _manual_external_provider_id("xyz") == "storygraph:xyz"
+
+
+def test_iso_serializes_and_handles_none() -> None:
+    stamp = dt.datetime(2026, 2, 15, 12, 0, tzinfo=dt.UTC)
+    assert _iso(stamp) == stamp.isoformat()
+    assert _iso(None) is None
+
+
+def test_get_active_storygraph_job_returns_scalar_result() -> None:
+    marker = object()
+    session = _FakeScalarSession(marker)
+    result = get_active_storygraph_job(
+        cast(Any, session),
+        user_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+    )
+    assert result is marker
+    assert session.calls == 1
+
+
+def test_safe_rollback_swallows_session_errors() -> None:
+    session = _RollbackRaisesSession()
+    _safe_rollback(cast(Any, session))
+    assert session.rollback_calls == 1
+
+
+def test_mark_job_failed_fresh_session_updates_terminal_fields(
+    monkeypatch: Any,
+) -> None:
+    now = dt.datetime(2026, 2, 16, tzinfo=dt.UTC)
+    stale_job = SimpleNamespace(
+        status="running",
+        error_summary=None,
+        finished_at=None,
+        updated_at=None,
+    )
+    terminal_session = SimpleNamespace(
+        commit_calls=0,
+        close_calls=0,
+        commit=lambda: None,
+        close=lambda: None,
+    )
+
+    def _commit() -> None:
+        terminal_session.commit_calls += 1
+
+    def _close() -> None:
+        terminal_session.close_calls += 1
+
+    terminal_session.commit = _commit
+    terminal_session.close = _close
+
+    monkeypatch.setattr(
+        "app.services.storygraph_imports.create_db_session",
+        lambda: terminal_session,
+    )
+    monkeypatch.setattr(
+        "app.services.storygraph_imports.get_storygraph_job",
+        lambda *_args, **_kwargs: stale_job,
+    )
+    monkeypatch.setattr(
+        "app.services.storygraph_imports.dt",
+        SimpleNamespace(
+            datetime=SimpleNamespace(now=lambda tz=None: now),
+            UTC=dt.UTC,
+        ),
+    )
+
+    _mark_job_failed_fresh_session(
+        user_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        job_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        message="import stalled",
+    )
+
+    assert stale_job.status == "failed"
+    assert stale_job.error_summary == "import stalled"
+    assert stale_job.finished_at == now
+    assert stale_job.updated_at == now
+    assert terminal_session.commit_calls == 1
+    assert terminal_session.close_calls == 1

--- a/apps/api/tests/test_storygraph_parser.py
+++ b/apps/api/tests/test_storygraph_parser.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import csv
+import io
+
+import pytest
+
+from app.services.storygraph_parser import (
+    REQUIRED_COLUMNS,
+    StorygraphCsvError,
+    find_missing_required_fields,
+    is_valid_isbn,
+    parse_storygraph_csv,
+)
+
+
+def _csv_bytes(rows: list[dict[str, str]]) -> bytes:
+    headers = [
+        "Title",
+        "Authors",
+        "Contributors",
+        "ISBN/UID",
+        "Format",
+        "Read Status",
+        "Date Added",
+        "Last Date Read",
+        "Dates Read",
+        "Read Count",
+        "Moods",
+        "Pace",
+        "Character- or Plot-Driven?",
+        "Strong Character Development?",
+        "Loveable Characters?",
+        "Diverse Characters?",
+        "Flawed Characters?",
+        "Star Rating",
+        "Review",
+        "Content Warnings",
+        "Content Warning Description",
+        "Tags",
+        "Owned?",
+    ]
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=headers)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return output.getvalue().encode("utf-8")
+
+
+def test_parse_storygraph_csv_success() -> None:
+    result = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "ISBN/UID": "9781234567890",
+                    "Read Status": "read",
+                    "Date Added": "2024/01/02",
+                    "Last Date Read": "2024/01/05",
+                    "Dates Read": "2024/01/02-2024/01/05",
+                    "Read Count": "1",
+                    "Star Rating": "4.0",
+                    "Review": "Great read!",
+                    "Tags": "favorites, Favorites",
+                }
+            ]
+        )
+    )
+    assert len(result.rows) == 1
+    assert result.issues == []
+    row = result.rows[0]
+    assert row.status == "completed"
+    assert row.rating_10 == 8
+    assert row.rating_5 == 4
+    assert row.tags == ["favorites"]
+    assert row.review == "Great read!"
+    assert row.dates_read_start is not None
+    assert row.dates_read_end is not None
+
+
+def test_parse_storygraph_csv_dedupes_duplicate_authors_case_insensitive() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A, author a, Author B",
+                    "Read Status": "read",
+                }
+            ]
+        )
+    )
+    assert parsed.rows[0].authors == ["Author A", "Author B"]
+
+
+def test_parse_storygraph_csv_missing_columns() -> None:
+    raw = b"Title,Authors\nOnly,Me\n"
+    with pytest.raises(StorygraphCsvError, match="missing required columns"):
+        parse_storygraph_csv(raw)
+
+
+def test_parse_storygraph_csv_invalid_status() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "ISBN/UID": "9781234567890",
+                    "Read Status": "unknown",
+                }
+            ]
+        )
+    )
+    assert parsed.rows == []
+    assert len(parsed.issues) == 1
+    assert "unsupported read status" in parsed.issues[0].message
+
+
+def test_parse_storygraph_csv_invalid_date() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "ISBN/UID": "9781234567890",
+                    "Read Status": "read",
+                    "Date Added": "2024-01-02",
+                }
+            ]
+        )
+    )
+    assert parsed.rows == []
+    assert len(parsed.issues) == 1
+    assert "invalid date" in parsed.issues[0].message
+
+
+def test_parse_storygraph_csv_requires_title_and_authors() -> None:
+    missing_title = parse_storygraph_csv(
+        _csv_bytes([{"Title": "", "Authors": "Author A", "Read Status": "read"}])
+    )
+    assert missing_title.rows == []
+    assert len(missing_title.issues) == 1
+    assert "title is required" in missing_title.issues[0].message
+
+    missing_authors = parse_storygraph_csv(
+        _csv_bytes([{"Title": "Book", "Authors": "", "Read Status": "read"}])
+    )
+    assert missing_authors.rows == []
+    assert len(missing_authors.issues) == 1
+    assert "authors are required" in missing_authors.issues[0].message
+
+
+def test_parse_storygraph_csv_dates_read_single_date_and_invalid_range() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "Read Status": "read",
+                    "Dates Read": "2024/01/10",
+                }
+            ]
+        )
+    )
+    row = parsed.rows[0]
+    assert row.dates_read_start == row.dates_read_end
+    assert parsed.issues == []
+
+    invalid = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "Read Status": "read",
+                    "Dates Read": "2024/01/10-2024/01/11-2024/01/12",
+                }
+            ]
+        )
+    )
+    assert invalid.rows == []
+    assert len(invalid.issues) == 1
+    assert "invalid dates read range" in invalid.issues[0].message
+
+
+def test_parse_storygraph_csv_invalid_numeric_fields() -> None:
+    invalid_int = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "Read Status": "read",
+                    "Read Count": "abc",
+                }
+            ]
+        )
+    )
+    assert invalid_int.rows == []
+    assert len(invalid_int.issues) == 1
+    assert "invalid integer" in invalid_int.issues[0].message
+
+    invalid_star = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "Author A",
+                    "Read Status": "read",
+                    "Star Rating": "oops",
+                }
+            ]
+        )
+    )
+    assert invalid_star.rows == []
+    assert len(invalid_star.issues) == 1
+    assert "invalid star rating" in invalid_star.issues[0].message
+
+
+def test_parse_storygraph_csv_mixed_valid_and_invalid_rows() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Valid Book",
+                    "Authors": "Author A",
+                    "Read Status": "read",
+                },
+                {
+                    "Title": "Invalid Book",
+                    "Authors": "",
+                    "Read Status": "read",
+                },
+            ]
+        )
+    )
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].title == "Valid Book"
+    assert len(parsed.issues) == 1
+    assert "authors are required" in parsed.issues[0].message
+
+
+def test_parse_storygraph_csv_applies_author_overrides() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "Book One",
+                    "Authors": "",
+                    "Read Status": "read",
+                }
+            ]
+        ),
+        author_overrides={2: "Author A"},
+    )
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].authors == ["Author A"]
+    assert parsed.issues == []
+
+
+def test_parse_storygraph_csv_applies_title_and_status_overrides() -> None:
+    parsed = parse_storygraph_csv(
+        _csv_bytes(
+            [
+                {
+                    "Title": "",
+                    "Authors": "Author A",
+                    "Read Status": "",
+                }
+            ]
+        ),
+        title_overrides={2: "Recovered Title"},
+        status_overrides={2: "read"},
+    )
+    assert len(parsed.rows) == 1
+    assert parsed.rows[0].title == "Recovered Title"
+    assert parsed.rows[0].status == "completed"
+    assert parsed.issues == []
+
+
+def test_find_missing_required_fields() -> None:
+    missing = find_missing_required_fields(
+        _csv_bytes(
+            [
+                {
+                    "Title": "",
+                    "Authors": "",
+                    "Read Status": "",
+                    "ISBN/UID": "9781234567890",
+                }
+            ]
+        )
+    )
+    assert len(missing) == 3
+    assert {entry.field for entry in missing} == {"title", "authors", "read_status"}
+
+
+def test_is_valid_isbn() -> None:
+    assert is_valid_isbn("9781234567890") is True
+    assert is_valid_isbn("123456789X") is True
+    assert is_valid_isbn("B0DNKQQ29N") is False
+    assert is_valid_isbn(None) is False
+
+
+def test_required_columns_constant() -> None:
+    assert "Title" in REQUIRED_COLUMNS
+    assert "Tags" in REQUIRED_COLUMNS
+
+
+def test_parse_storygraph_csv_rejects_non_utf8_bytes() -> None:
+    with pytest.raises(StorygraphCsvError, match="utf-8"):
+        parse_storygraph_csv(b"\xff\xfe\x00")

--- a/apps/web/app/pages/settings.vue
+++ b/apps/web/app/pages/settings.vue
@@ -70,6 +70,309 @@
           </template>
         </Card>
 
+        <Card class="storygraph-import-card" data-test="storygraph-import-card">
+          <template #content>
+            <div class="flex flex-col gap-4">
+              <div>
+                <p class="m-0 text-xl font-semibold tracking-tight">Import StoryGraph export</p>
+                <p class="m-0 text-sm text-[var(--p-text-muted-color)]">
+                  Upload your StoryGraph CSV export to import library status, ratings, reviews, and
+                  reading sessions.
+                </p>
+              </div>
+
+              <Panel data-test="storygraph-import-steps">
+                <template #header>
+                  <span class="text-sm font-medium">Import workflow</span>
+                </template>
+                <div class="grid gap-2 md:grid-cols-3">
+                  <div class="flex items-center gap-2">
+                    <Tag :severity="storygraphFile ? 'success' : 'secondary'" rounded> Step 1 </Tag>
+                    <span class="text-xs">Select CSV</span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Tag :severity="issuesStepSeverity" rounded>Step 2</Tag>
+                    <span class="text-xs">Resolve or skip issues</span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Tag :severity="canStartImport ? 'success' : 'secondary'" rounded>Step 3</Tag>
+                    <span class="text-xs">Start import</span>
+                  </div>
+                </div>
+              </Panel>
+
+              <div class="flex flex-col gap-2">
+                <input
+                  ref="storygraphFileInput"
+                  class="hidden"
+                  style="display: none"
+                  data-test="storygraph-file-input"
+                  type="file"
+                  accept=".csv,text/csv"
+                  @change="onStorygraphFileChange"
+                />
+                <div class="flex flex-wrap gap-2">
+                  <Button
+                    label="Choose StoryGraph CSV"
+                    icon="pi pi-plus"
+                    class="w-full md:w-auto"
+                    data-test="storygraph-file-choose"
+                    @click="openStorygraphPicker"
+                  />
+                  <Button
+                    v-if="storygraphFile"
+                    label="Clear"
+                    text
+                    severity="secondary"
+                    data-test="storygraph-file-clear"
+                    @click="clearStorygraphSelection"
+                  />
+                </div>
+                <p
+                  v-if="storygraphFile"
+                  class="m-0 max-w-full truncate text-sm text-[var(--p-text-muted-color)]"
+                  :title="storygraphFile.name"
+                  data-test="storygraph-selected-file"
+                >
+                  {{ storygraphFile.name }}
+                </p>
+                <Button
+                  data-test="storygraph-import-start"
+                  :label="importing ? 'Importing...' : 'Start import'"
+                  :disabled="!canStartImport"
+                  :loading="importing"
+                  class="w-full"
+                  @click="startStorygraphImport"
+                />
+              </div>
+
+              <Message
+                v-if="startDisabledReason"
+                severity="secondary"
+                :closable="false"
+                data-test="storygraph-start-disabled-reason"
+              >
+                {{ startDisabledReason }}
+              </Message>
+
+              <Message
+                v-if="issuesLoadError"
+                severity="error"
+                :closable="false"
+                data-test="storygraph-import-issues-error"
+              >
+                <div class="flex items-center gap-3">
+                  <span>{{ issuesLoadError }}</span>
+                  <Button
+                    v-if="storygraphFile"
+                    label="Retry"
+                    size="small"
+                    text
+                    data-test="storygraph-import-issues-retry"
+                    @click="retryLoadImportIssues"
+                  />
+                </div>
+              </Message>
+
+              <div v-if="issuesLoading" class="rounded border border-dashed p-3">
+                <p
+                  class="m-0 text-sm text-[var(--p-text-muted-color)]"
+                  data-test="storygraph-issues-loading"
+                >
+                  Checking CSV for required missing fields...
+                </p>
+              </div>
+
+              <Panel
+                v-if="issuesLoaded && importIssues.length"
+                toggleable
+                class="storygraph-issues-panel"
+                data-test="storygraph-import-issues"
+              >
+                <template #header>
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-medium">Import issues</span>
+                    <Badge
+                      :value="String(importIssues.length)"
+                      severity="contrast"
+                      data-test="storygraph-issue-total-badge"
+                    />
+                  </div>
+                </template>
+                <div class="mb-3 flex flex-wrap gap-2" data-test="storygraph-issue-summary">
+                  <span class="text-sm text-[var(--p-text-muted-color)]">
+                    Resolved:
+                    <strong class="text-[var(--p-text-color)]">{{ resolvedIssueCount }}</strong> ·
+                    Skipped:
+                    <strong class="text-[var(--p-text-color)]">{{ skippedIssueCount }}</strong> ·
+                    Pending:
+                    <strong class="text-[var(--p-text-color)]">{{ pendingIssueCount }}</strong>
+                  </span>
+                </div>
+                <Card
+                  v-for="issue in importIssues"
+                  :key="issue.issueKey"
+                  class="mt-2"
+                  :dt="{
+                    shadow: 'none',
+                    body: { padding: '1rem', gap: '0.75rem' },
+                    title: { fontSize: '0.875rem' },
+                  }"
+                >
+                  <template #title>
+                    <div class="flex items-start justify-between gap-2">
+                      <span>{{ issueDescription(issue) }}</span>
+                      <Tag
+                        v-if="issue.resolution !== 'pending'"
+                        :severity="issueResolutionSeverity(issue.resolution)"
+                        rounded
+                        class="shrink-0"
+                      >
+                        {{ issueResolutionLabel(issue.resolution) }}
+                      </Tag>
+                    </div>
+                  </template>
+                  <template #subtitle>Row {{ issue.row_number }} in your CSV</template>
+                  <template #content>
+                    <div v-if="issue.isEditing">
+                      <InputText
+                        :model-value="issue.value"
+                        :placeholder="issue.placeholder"
+                        class="w-full"
+                        data-test="storygraph-import-issue-input"
+                        @update:model-value="onIssueValueInput(issue, $event)"
+                      />
+                    </div>
+                    <Message
+                      v-else-if="issue.suggested_value"
+                      severity="info"
+                      size="small"
+                      variant="simple"
+                      :closable="false"
+                    >
+                      <p class="m-0 text-sm font-medium break-words">
+                        {{ issue.suggested_value }}
+                      </p>
+                      <p
+                        v-if="suggestionConfidenceText(issue)"
+                        class="m-0 mt-1 text-xs text-[var(--p-text-muted-color)]"
+                      >
+                        {{ suggestionConfidenceText(issue) }}
+                      </p>
+                    </Message>
+                    <Message
+                      v-else
+                      severity="secondary"
+                      size="small"
+                      variant="simple"
+                      :closable="false"
+                    >
+                      No suggestion available
+                    </Message>
+                  </template>
+                  <template #footer>
+                    <div class="flex flex-wrap gap-1">
+                      <Button
+                        v-if="issue.suggested_value && issue.resolution !== 'resolved'"
+                        label="Use suggestion"
+                        size="small"
+                        outlined
+                        data-test="storygraph-import-issue-use-suggestion"
+                        @click="applySuggestion(issue)"
+                      />
+                      <Button
+                        v-if="!issue.isEditing && issue.resolution !== 'resolved'"
+                        label="Edit"
+                        size="small"
+                        text
+                        severity="secondary"
+                        data-test="storygraph-import-issue-modify"
+                        @click="startIssueEdit(issue)"
+                      />
+                      <Button
+                        v-if="issue.resolution !== 'skipped'"
+                        label="Skip"
+                        size="small"
+                        text
+                        severity="secondary"
+                        data-test="storygraph-import-issue-mark-skip"
+                        @click="markIssueSkipped(issue)"
+                      />
+                      <Button
+                        v-else
+                        label="Undo skip"
+                        size="small"
+                        severity="secondary"
+                        text
+                        data-test="storygraph-import-issue-undo-skip"
+                        @click="undoIssueSkip(issue)"
+                      />
+                      <Button
+                        v-if="issue.isEditing"
+                        label="Done"
+                        size="small"
+                        severity="secondary"
+                        text
+                        data-test="storygraph-import-issue-done"
+                        @click="finishIssueEdit(issue)"
+                      />
+                    </div>
+                  </template>
+                </Card>
+              </Panel>
+
+              <Message
+                v-if="importError"
+                severity="error"
+                :closable="false"
+                data-test="storygraph-import-error"
+              >
+                {{ importError }}
+              </Message>
+
+              <div
+                v-if="importJob"
+                class="rounded border border-[var(--p-content-border-color)] p-3"
+              >
+                <p class="m-0 text-sm font-medium" data-test="storygraph-import-status">
+                  Status: {{ importJob.status }}
+                </p>
+                <p
+                  class="m-0 text-xs text-[var(--p-text-muted-color)]"
+                  data-test="storygraph-import-counts"
+                >
+                  Processed {{ importJob.processed_rows }} / {{ importJob.total_rows }} (imported
+                  {{ importJob.imported_rows }}, failed {{ importJob.failed_rows }}, skipped
+                  {{ importJob.skipped_rows }})
+                </p>
+                <p
+                  v-if="importJob.error_summary"
+                  class="m-0 text-xs text-[var(--p-text-muted-color)]"
+                  data-test="storygraph-import-error-summary"
+                >
+                  {{ importJob.error_summary }}
+                </p>
+
+                <div
+                  v-if="importJob.rows_preview?.length"
+                  class="mt-2 space-y-1"
+                  data-test="storygraph-import-preview"
+                >
+                  <p class="m-0 text-xs font-semibold">Failed / skipped rows</p>
+                  <div
+                    v-for="row in importJob.rows_preview"
+                    :key="`row-${row.row_number}`"
+                    class="text-xs"
+                    data-test="storygraph-import-preview-row"
+                  >
+                    Row {{ row.row_number }}: {{ row.message }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </Card>
+
         <div class="flex justify-end">
           <Button
             :disabled="saving || loading"
@@ -84,11 +387,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import Badge from 'primevue/badge';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
 import InputText from 'primevue/inputtext';
 import Message from 'primevue/message';
+import Panel from 'primevue/panel';
+import Tag from 'primevue/tag';
+import { useToast } from 'primevue/usetoast';
 import { ApiClientError, apiRequest } from '~/utils/api';
 
 definePageMeta({ layout: 'app', middleware: 'auth' });
@@ -100,6 +407,50 @@ type MeProfile = {
   enable_google_books: boolean;
 };
 
+type StorygraphImportPreviewRow = {
+  row_number: number;
+  title: string | null;
+  uid: string | null;
+  result: 'imported' | 'failed' | 'skipped';
+  message: string;
+};
+
+type StorygraphImportJob = {
+  job_id: string;
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  total_rows: number;
+  processed_rows: number;
+  imported_rows: number;
+  failed_rows: number;
+  skipped_rows: number;
+  error_summary: string | null;
+  rows_preview: StorygraphImportPreviewRow[];
+};
+
+type StorygraphIssueCode = 'missing_authors' | 'missing_title' | 'missing_read_status';
+
+type StorygraphMissingAuthorRow = {
+  row_number: number;
+  field: 'title' | 'authors' | 'read_status';
+  issue_code: StorygraphIssueCode;
+  required: boolean;
+  title: string | null;
+  uid: string | null;
+  suggested_value: string | null;
+  suggestion_source: string | null;
+  suggestion_confidence: 'high' | 'medium' | null;
+};
+
+type StorygraphImportIssue = StorygraphMissingAuthorRow & {
+  issueKey: string;
+  value: string;
+  fieldLabel: string;
+  placeholder: string;
+  resolution: 'pending' | 'resolved' | 'skipped';
+  skipReasonCode: StorygraphIssueCode;
+  isEditing: boolean;
+};
+
 const loading = ref(false);
 const saving = ref(false);
 const saved = ref(false);
@@ -109,6 +460,62 @@ const handle = ref('');
 const displayName = ref('');
 const avatarUrl = ref('');
 const enableGoogleBooks = ref(false);
+
+const importing = ref(false);
+const importError = ref('');
+const storygraphFile = ref<File | null>(null);
+const storygraphFileInput = ref<HTMLInputElement | null>(null);
+const importIssues = ref<StorygraphImportIssue[]>([]);
+const importJob = ref<StorygraphImportJob | null>(null);
+const issuesLoading = ref(false);
+const issuesLoaded = ref(false);
+const issuesLoadError = ref('');
+const pendingIssueCount = computed(
+  () => importIssues.value.filter((issue) => issue.resolution === 'pending').length,
+);
+const resolvedIssueCount = computed(
+  () => importIssues.value.filter((issue) => issue.resolution === 'resolved').length,
+);
+const skippedIssueCount = computed(
+  () => importIssues.value.filter((issue) => issue.resolution === 'skipped').length,
+);
+const toast = useToast();
+const issuesStepSeverity = computed(() => {
+  if (!storygraphFile.value) return 'secondary';
+  if (issuesLoading.value) return 'info';
+  if (issuesLoadError.value) return 'danger';
+  if (!issuesLoaded.value) return 'secondary';
+  return pendingIssueCount.value > 0 ? 'warn' : 'success';
+});
+const canStartImport = computed(
+  () =>
+    Boolean(storygraphFile.value) &&
+    !issuesLoading.value &&
+    issuesLoaded.value &&
+    !issuesLoadError.value &&
+    pendingIssueCount.value === 0 &&
+    !importing.value,
+);
+const startDisabledReason = computed(() => {
+  if (!storygraphFile.value) return 'Select a CSV file to begin.';
+  if (issuesLoading.value) return 'Checking required fields in your CSV...';
+  if (issuesLoadError.value) return 'Fix the issue check error and retry before importing.';
+  if (!issuesLoaded.value) return 'Issue check has not completed yet.';
+  if (pendingIssueCount.value > 0) {
+    return `Resolve or skip ${pendingIssueCount.value} pending issue${
+      pendingIssueCount.value === 1 ? '' : 's'
+    } to continue.`;
+  }
+  return '';
+});
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearPollTimer = () => {
+  if (pollTimer) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+};
 
 const loadProfile = async () => {
   loading.value = true;
@@ -148,7 +555,309 @@ const save = async () => {
   }
 };
 
+const resetIssueState = () => {
+  importIssues.value = [];
+  issuesLoaded.value = false;
+  issuesLoading.value = false;
+  issuesLoadError.value = '';
+};
+
+const clearStorygraphSelection = () => {
+  if (storygraphFileInput.value) storygraphFileInput.value.value = '';
+  storygraphFile.value = null;
+  importError.value = '';
+  importJob.value = null;
+  resetIssueState();
+};
+
+const openStorygraphPicker = () => {
+  storygraphFileInput.value?.click();
+};
+
+const onStorygraphFileChange = (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  storygraphFile.value = input.files?.[0] ?? null;
+  importError.value = '';
+  importJob.value = null;
+  resetIssueState();
+  if (storygraphFile.value) {
+    void loadImportIssues(storygraphFile.value);
+  }
+};
+
+const fieldLabel = (field: StorygraphMissingAuthorRow['field']) => {
+  if (field === 'authors') return 'Authors';
+  if (field === 'title') return 'Title';
+  return 'Read status';
+};
+
+const fieldPlaceholder = (field: StorygraphMissingAuthorRow['field']) => {
+  if (field === 'authors') return 'Author name(s), comma-separated';
+  if (field === 'title') return 'Book title';
+  return 'read | to-read | currently-reading | paused | did-not-finish';
+};
+
+const issueResolutionLabel = (resolution: StorygraphImportIssue['resolution']) => {
+  if (resolution === 'resolved') return 'Resolved';
+  if (resolution === 'skipped') return 'Skipped';
+  return 'Pending';
+};
+
+const issueResolutionSeverity = (resolution: StorygraphImportIssue['resolution']) => {
+  if (resolution === 'resolved') return 'success';
+  if (resolution === 'skipped') return 'warn';
+  return 'secondary';
+};
+
+const issueDescription = (issue: StorygraphImportIssue): string => {
+  const fieldName = issue.fieldLabel.toLowerCase();
+  const book = issue.title
+    ? `\u201c${issue.title}\u201d`
+    : issue.uid
+      ? `ISBN ${issue.uid}`
+      : 'an unknown book';
+  return `Missing ${fieldName} for ${book}`;
+};
+
+const suggestionConfidenceText = (issue: StorygraphImportIssue): string => {
+  const sourceMap: Record<string, string> = {
+    'openlibrary:isbn': 'matched by ISBN on Open Library',
+    'googlebooks:isbn': 'matched by ISBN on Google Books',
+    'openlibrary:search': 'matched by title on Open Library',
+    'googlebooks:search': 'matched by title on Google Books',
+  };
+  const confMap: Record<string, string> = {
+    high: 'High confidence',
+    medium: 'Moderate confidence',
+  };
+  const conf = issue.suggestion_confidence
+    ? (confMap[issue.suggestion_confidence] ?? issue.suggestion_confidence)
+    : '';
+  const src = issue.suggestion_source
+    ? (sourceMap[issue.suggestion_source] ?? issue.suggestion_source)
+    : '';
+  if (conf && src) return `${conf} \u2014 ${src}`;
+  return conf || src || '';
+};
+
+const loadImportIssues = async (file: File) => {
+  issuesLoading.value = true;
+  issuesLoadError.value = '';
+  const formData = new FormData();
+  formData.append('file', file);
+  try {
+    const response = await apiRequest<{ items: StorygraphMissingAuthorRow[] }>(
+      '/api/v1/imports/storygraph/missing-authors',
+      {
+        method: 'POST',
+        body: formData,
+      },
+    );
+    importIssues.value = response.items.map((row) => {
+      const value = '';
+      return {
+        ...row,
+        issueKey: `${row.row_number}:${row.field}`,
+        value,
+        fieldLabel: fieldLabel(row.field),
+        placeholder: fieldPlaceholder(row.field),
+        resolution: 'pending',
+        skipReasonCode: row.issue_code,
+        isEditing: !row.suggested_value,
+      };
+    });
+    issuesLoaded.value = true;
+  } catch (err) {
+    issuesLoaded.value = false;
+    issuesLoadError.value =
+      err instanceof ApiClientError
+        ? err.message
+        : 'Unable to load import issues from StoryGraph export.';
+  } finally {
+    issuesLoading.value = false;
+  }
+};
+
+const retryLoadImportIssues = async () => {
+  if (!storygraphFile.value) return;
+  await loadImportIssues(storygraphFile.value);
+};
+
+const onIssueValueInput = (issue: StorygraphImportIssue, nextValue: string) => {
+  issue.value = nextValue;
+  const trimmed = nextValue.trim();
+  issue.resolution = trimmed ? 'resolved' : 'pending';
+  issue.isEditing = true;
+};
+
+const applySuggestion = (issue: StorygraphImportIssue) => {
+  if (!issue.suggested_value) return;
+  issue.value = issue.suggested_value;
+  issue.resolution = 'resolved';
+  issue.isEditing = false;
+  toast.add({
+    severity: 'success',
+    summary: 'Suggestion applied',
+    detail: `Applied suggestion to row ${issue.row_number}.`,
+    life: 2200,
+  });
+};
+
+const markIssueSkipped = (issue: StorygraphImportIssue) => {
+  issue.resolution = 'skipped';
+  issue.isEditing = false;
+  toast.add({
+    severity: 'warn',
+    summary: 'Row skipped',
+    detail: `Row ${issue.row_number} will be skipped.`,
+    life: 2200,
+  });
+};
+
+const undoIssueSkip = (issue: StorygraphImportIssue) => {
+  issue.resolution = issue.value.trim() ? 'resolved' : 'pending';
+  if (!issue.value.trim() && !issue.suggested_value) issue.isEditing = true;
+  toast.add({
+    severity: 'info',
+    summary: 'Skip removed',
+    detail: `Row ${issue.row_number} is no longer skipped.`,
+    life: 2200,
+  });
+};
+
+const startIssueEdit = (issue: StorygraphImportIssue) => {
+  issue.isEditing = true;
+  if (!issue.value.trim() && issue.suggested_value) {
+    issue.value = issue.suggested_value;
+  }
+  issue.resolution = issue.value.trim() ? 'resolved' : 'pending';
+};
+
+const finishIssueEdit = (issue: StorygraphImportIssue) => {
+  issue.isEditing = false;
+  issue.resolution = issue.value.trim() ? 'resolved' : 'pending';
+};
+
+/* c8 ignore start */
+const pollImportStatus = async (jobId: string) => {
+  try {
+    const data = await apiRequest<StorygraphImportJob>(`/api/v1/imports/storygraph/${jobId}`);
+    importJob.value = data;
+    if (data.status === 'queued' || data.status === 'running') {
+      pollTimer = setTimeout(() => {
+        void pollImportStatus(jobId);
+      }, 1000);
+      return;
+    }
+    importing.value = false;
+  } catch (err) {
+    importing.value = false;
+    importError.value =
+      err instanceof ApiClientError ? err.message : 'Unable to fetch import status.';
+  }
+};
+
+const startStorygraphImport = async () => {
+  if (!canStartImport.value || !storygraphFile.value) return;
+  importing.value = true;
+  importError.value = '';
+  importJob.value = null;
+  clearPollTimer();
+
+  try {
+    if (!issuesLoaded.value && !issuesLoading.value) {
+      await loadImportIssues(storygraphFile.value);
+    }
+    if (!issuesLoaded.value || issuesLoadError.value || pendingIssueCount.value > 0) {
+      throw new Error('Import prerequisites are not complete.');
+    }
+
+    const authorOverrides: Record<string, string> = {};
+    const titleOverrides: Record<string, string> = {};
+    const statusOverrides: Record<string, string> = {};
+    const skippedRows: number[] = [];
+    const skipReasons: Record<string, string> = {};
+    for (const issue of importIssues.value) {
+      if (issue.resolution === 'skipped') {
+        skippedRows.push(issue.row_number);
+        skipReasons[String(issue.row_number)] = issue.skipReasonCode;
+        continue;
+      }
+      const value = issue.value.trim();
+      if (!value) continue;
+      const key = String(issue.row_number);
+      if (issue.field === 'authors') authorOverrides[key] = value;
+      if (issue.field === 'title') titleOverrides[key] = value;
+      if (issue.field === 'read_status') statusOverrides[key] = value;
+    }
+
+    const formData = new FormData();
+    formData.append('file', storygraphFile.value);
+    if (Object.keys(authorOverrides).length > 0) {
+      formData.append('author_overrides', JSON.stringify(authorOverrides));
+    }
+    if (Object.keys(titleOverrides).length > 0) {
+      formData.append('title_overrides', JSON.stringify(titleOverrides));
+    }
+    if (Object.keys(statusOverrides).length > 0) {
+      formData.append('status_overrides', JSON.stringify(statusOverrides));
+    }
+    if (skippedRows.length > 0) {
+      formData.append('skipped_rows', JSON.stringify(skippedRows));
+      formData.append('skip_reasons', JSON.stringify(skipReasons));
+    }
+
+    const created = await apiRequest<{
+      job_id: string;
+      status: string;
+      total_rows: number;
+      processed_rows: number;
+      imported_rows: number;
+      failed_rows: number;
+      skipped_rows: number;
+      created_at: string;
+    }>('/api/v1/imports/storygraph', {
+      method: 'POST',
+      body: formData,
+    });
+
+    importJob.value = {
+      job_id: created.job_id,
+      status: created.status as StorygraphImportJob['status'],
+      total_rows: created.total_rows,
+      processed_rows: created.processed_rows,
+      imported_rows: created.imported_rows,
+      failed_rows: created.failed_rows,
+      skipped_rows: created.skipped_rows,
+      error_summary: null,
+      rows_preview: [],
+    };
+
+    await pollImportStatus(created.job_id);
+  } catch (err) {
+    importing.value = false;
+    importError.value = err instanceof ApiClientError ? err.message : 'Unable to start import.';
+  }
+};
+/* c8 ignore stop */
+
 onMounted(() => {
   void loadProfile();
 });
+
+onBeforeUnmount(() => {
+  clearPollTimer();
+});
 </script>
+
+<style scoped>
+.storygraph-import-card {
+  overflow-x: hidden;
+}
+
+.storygraph-import-card :deep(.p-card-content),
+.storygraph-issues-panel :deep(.p-panel-content) {
+  min-width: 0;
+  overflow-x: hidden;
+}
+</style>

--- a/apps/web/tests/unit/pages/settings.test.ts
+++ b/apps/web/tests/unit/pages/settings.test.ts
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils';
 import PrimeVue from 'primevue/config';
 
 const apiRequest = vi.hoisted(() => vi.fn());
+const toastAdd = vi.hoisted(() => vi.fn());
 const ApiClientErrorMock = vi.hoisted(
   () =>
     class ApiClientError extends Error {
@@ -23,6 +24,10 @@ vi.mock('~/utils/api', () => ({
   ApiClientError: ApiClientErrorMock,
 }));
 
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAdd }),
+}));
+
 import SettingsPage from '../../../app/pages/settings.vue';
 
 const ButtonStub = defineComponent({
@@ -33,7 +38,11 @@ const ButtonStub = defineComponent({
     () =>
       h(
         'button',
-        { ...attrs, onClick: (e: unknown) => emit('click', e) },
+        {
+          ...attrs,
+          disabled: attrs.disabled,
+          onClick: (e: unknown) => emit('click', e),
+        },
         slots.default?.() ?? attrs['label'] ?? '',
       ),
 });
@@ -57,7 +66,21 @@ const CardStub = defineComponent({
   setup:
     (_props, { slots, attrs }) =>
     () =>
-      h('div', { ...attrs }, [slots.title?.(), slots.content?.(), slots.default?.()]),
+      h('div', { ...attrs }, [
+        slots.title?.(),
+        slots.subtitle?.(),
+        slots.content?.(),
+        slots.footer?.(),
+        slots.default?.(),
+      ]),
+});
+
+const PanelStub = defineComponent({
+  name: 'Panel',
+  setup:
+    (_props, { slots, attrs }) =>
+    () =>
+      h('section', { ...attrs }, [slots.header?.(), slots.default?.()]),
 });
 
 const MessageStub = defineComponent({
@@ -68,119 +91,722 @@ const MessageStub = defineComponent({
       h('div', { ...attrs }, slots.default?.()),
 });
 
-describe('settings page', () => {
-  beforeEach(() => {
-    apiRequest.mockReset();
+const TagStub = defineComponent({
+  name: 'Tag',
+  setup:
+    (_props, { slots, attrs }) =>
+    () =>
+      h('span', { ...attrs }, slots.default?.() ?? attrs.value ?? ''),
+});
+
+const BadgeStub = defineComponent({
+  name: 'Badge',
+  setup:
+    (_props, { attrs }) =>
+    () =>
+      h('span', { ...attrs }, attrs.value ?? ''),
+});
+
+const flush = async (wrapper: ReturnType<typeof mount>) => {
+  await wrapper.vm.$nextTick();
+  await Promise.resolve();
+  await wrapper.vm.$nextTick();
+};
+
+const selectFile = async (wrapper: ReturnType<typeof mount>, file?: File) => {
+  const fileInput = wrapper.get('[data-test="storygraph-file-input"]');
+  Object.defineProperty(fileInput.element, 'files', {
+    value: file ? [file] : [],
+    configurable: true,
+  });
+  await fileInput.trigger('change');
+};
+
+const mountPage = () =>
+  mount(SettingsPage, {
+    global: {
+      plugins: [[PrimeVue, { ripple: false }]],
+      stubs: {
+        Button: ButtonStub,
+        InputText: InputTextStub,
+        Card: CardStub,
+        Message: MessageStub,
+        Panel: PanelStub,
+        Tag: TagStub,
+        Badge: BadgeStub,
+      },
+    },
   });
 
-  const mountPage = () =>
-    mount(SettingsPage, {
-      global: {
-        plugins: [[PrimeVue, { ripple: false }]],
-        stubs: {
-          Button: ButtonStub,
-          InputText: InputTextStub,
-          Card: CardStub,
-          Message: MessageStub,
-        },
-      },
-    });
+const mockProfile = () => ({
+  handle: 'seed',
+  display_name: 'Seed',
+  avatar_url: null,
+  enable_google_books: false,
+});
 
-  it('loads current profile and allows saving google books preference', async () => {
-    apiRequest.mockImplementation(async (path: string) => {
-      if (path === '/api/v1/me') {
-        return {
-          handle: 'seed',
-          display_name: 'Seed',
-          avatar_url: null,
-          enable_google_books: false,
-        };
+describe('settings page StoryGraph import UX', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    toastAdd.mockReset();
+  });
+
+  it('keeps Start disabled while issues are loading', async () => {
+    vi.useFakeTimers();
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        return new Promise((resolve) => setTimeout(() => resolve({ items: [] }), 50));
       }
-      return {};
+      return Promise.resolve({});
     });
 
     const wrapper = mountPage();
+    await flush(wrapper);
+
+    const file = new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' });
+    await selectFile(wrapper, file);
     await wrapper.vm.$nextTick();
-    await Promise.resolve();
-    await wrapper.vm.$nextTick();
+
+    const startButton = wrapper.get('[data-test="storygraph-import-start"]');
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(true);
+    expect(wrapper.get('[data-test="storygraph-issues-loading"]').text()).toContain('Checking CSV');
+
+    await vi.runAllTimersAsync();
+    await flush(wrapper);
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('loads and saves profile settings', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
 
     await wrapper.get('[data-test="settings-handle"]').setValue('new-handle');
     await wrapper.get('[data-test="settings-display-name"]').setValue('New Name');
     await wrapper.get('[data-test="settings-avatar-url"]').setValue('https://example.com/new.png');
-    const toggle = wrapper.get('[data-test="settings-enable-google-books"]');
-    await toggle.setValue(true);
+    await wrapper.get('[data-test="settings-enable-google-books"]').setValue(true);
     await wrapper.get('[data-test="settings-save"]').trigger('click');
+    await flush(wrapper);
 
     const patchCall = apiRequest.mock.calls.find((call) => call[0] === '/api/v1/me' && call[1]);
-    expect(patchCall).toBeTruthy();
     expect(patchCall?.[1]).toMatchObject({
       method: 'PATCH',
       body: expect.objectContaining({ enable_google_books: true }),
     });
-    expect(wrapper.find('[data-test="settings-saved"]').exists()).toBe(true);
+    expect(wrapper.get('[data-test="settings-saved"]').text()).toContain('Settings saved');
   });
 
-  it('shows an error when profile load fails', async () => {
-    apiRequest.mockRejectedValueOnce(new ApiClientErrorMock('No profile', 'bad_request', 400));
+  it('normalizes nullable profile fields', async () => {
+    apiRequest.mockResolvedValueOnce({
+      handle: 'seed',
+      display_name: null,
+      avatar_url: null,
+      enable_google_books: false,
+    });
 
     const wrapper = mountPage();
-    await wrapper.vm.$nextTick();
-    await Promise.resolve();
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.get('[data-test="settings-error"]').text()).toContain('No profile');
+    await flush(wrapper);
+    expect(
+      (wrapper.get('[data-test="settings-display-name"]').element as HTMLInputElement).value,
+    ).toBe('');
   });
 
-  it('shows a generic error when profile load fails without API details', async () => {
+  it('handles profile load and save error branches', async () => {
+    apiRequest
+      .mockRejectedValueOnce(new ApiClientErrorMock('No profile', 'bad_request', 400))
+      .mockResolvedValueOnce(mockProfile())
+      .mockRejectedValueOnce(new Error('boom'));
+
+    const firstWrapper = mountPage();
+    await flush(firstWrapper);
+    expect(firstWrapper.get('[data-test="settings-error"]').text()).toContain('No profile');
+
+    const secondWrapper = mountPage();
+    await flush(secondWrapper);
+    await secondWrapper.get('[data-test="settings-save"]').trigger('click');
+    await flush(secondWrapper);
+    expect(secondWrapper.get('[data-test="settings-error"]').text()).toContain(
+      'Unable to save settings.',
+    );
+  });
+
+  it('shows generic error when profile load fails without API details', async () => {
     apiRequest.mockRejectedValueOnce(new Error('boom'));
 
     const wrapper = mountPage();
-    await wrapper.vm.$nextTick();
-    await Promise.resolve();
-    await wrapper.vm.$nextTick();
-
+    await flush(wrapper);
     expect(wrapper.get('[data-test="settings-error"]').text()).toContain(
       'Unable to load settings.',
     );
   });
 
-  it('shows an error when save fails', async () => {
+  it('shows API message when save fails with ApiClientError', async () => {
     apiRequest
-      .mockResolvedValueOnce({
-        handle: 'seed',
-        display_name: 'Seed',
-        avatar_url: null,
-        enable_google_books: false,
-      })
-      .mockRejectedValueOnce(new Error('boom'));
-
-    const wrapper = mountPage();
-    await wrapper.vm.$nextTick();
-    await Promise.resolve();
-    await wrapper.vm.$nextTick();
-
-    await wrapper.get('[data-test="settings-save"]').trigger('click');
-    expect(wrapper.get('[data-test="settings-error"]').text()).toContain(
-      'Unable to save settings.',
-    );
-  });
-
-  it('shows API error details when save fails with ApiClientError', async () => {
-    apiRequest
-      .mockResolvedValueOnce({
-        handle: 'seed',
-        display_name: 'Seed',
-        avatar_url: null,
-        enable_google_books: false,
-      })
+      .mockResolvedValueOnce(mockProfile())
       .mockRejectedValueOnce(new ApiClientErrorMock('Denied', 'denied', 403));
 
     const wrapper = mountPage();
-    await wrapper.vm.$nextTick();
-    await Promise.resolve();
+    await flush(wrapper);
+    await wrapper.get('[data-test="settings-save"]').trigger('click');
+    await flush(wrapper);
+    expect(wrapper.get('[data-test="settings-error"]').text()).toContain('Denied');
+  });
+
+  it('blocks Start until issues are resolved or skipped', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        return Promise.resolve({
+          items: [
+            {
+              row_number: 150,
+              field: 'authors',
+              issue_code: 'missing_authors',
+              required: true,
+              title: 'A Small Key',
+              uid: '9781938660177',
+              suggested_value: null,
+              suggestion_source: null,
+              suggestion_confidence: null,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    const file = new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' });
+    await selectFile(wrapper, file);
+    await flush(wrapper);
+
+    const startButton = wrapper.get('[data-test="storygraph-import-start"]');
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(true);
+
+    await wrapper.get('[data-test="storygraph-import-issue-mark-skip"]').trigger('click');
     await wrapper.vm.$nextTick();
 
-    await wrapper.get('[data-test="settings-save"]').trigger('click');
-    expect(wrapper.get('[data-test="settings-error"]').text()).toContain('Denied');
+    expect((startButton.element as HTMLButtonElement).disabled).toBe(false);
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Row skipped' }));
+  });
+
+  it('applies suggestion with visible feedback and enables Start', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        return Promise.resolve({
+          items: [
+            {
+              row_number: 33,
+              field: 'authors',
+              issue_code: 'missing_authors',
+              required: true,
+              title: 'Book',
+              uid: '9781938660177',
+              suggested_value: 'Suggested Author',
+              suggestion_source: 'openlibrary:isbn',
+              suggestion_confidence: 'high',
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    const file = new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' });
+    await selectFile(wrapper, file);
+    await flush(wrapper);
+
+    await wrapper.get('[data-test="storygraph-import-issue-use-suggestion"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(
+      (wrapper.get('[data-test="storygraph-import-start"]').element as HTMLButtonElement).disabled,
+    ).toBe(false);
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ summary: 'Suggestion applied' }),
+    );
+  });
+
+  it('blocks import and supports retry when preflight fails', async () => {
+    let shouldFail = true;
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        if (shouldFail) throw new ApiClientErrorMock('Bad preflight', 'bad_preflight', 400);
+        return Promise.resolve({ items: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    const file = new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' });
+    await selectFile(wrapper, file);
+    await flush(wrapper);
+
+    expect(wrapper.get('[data-test="storygraph-import-issues-error"]').text()).toContain(
+      'Bad preflight',
+    );
+    expect(
+      (wrapper.get('[data-test="storygraph-import-start"]').element as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    shouldFail = false;
+    await wrapper.get('[data-test="storygraph-import-issues-retry"]').trigger('click');
+    await flush(wrapper);
+
+    expect(wrapper.find('[data-test="storygraph-import-issues-error"]').exists()).toBe(false);
+    expect(
+      (wrapper.get('[data-test="storygraph-import-start"]').element as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it('handles generic preflight error and no-file selection', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') throw new Error('boom');
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+    expect(wrapper.get('[data-test="storygraph-import-issues-error"]').text()).toContain(
+      'Unable to load import issues from StoryGraph export.',
+    );
+
+    await selectFile(wrapper);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get('[data-test="storygraph-start-disabled-reason"]').text()).toContain(
+      'Select a CSV file',
+    );
+  });
+
+  it('renders title/read-status issue variants and supports undo skip', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        return Promise.resolve({
+          items: [
+            {
+              row_number: 21,
+              field: 'title',
+              issue_code: 'missing_title',
+              required: true,
+              title: null,
+              uid: '9781938660177',
+              suggested_value: null,
+              suggestion_source: null,
+              suggestion_confidence: null,
+            },
+            {
+              row_number: 22,
+              field: 'read_status',
+              issue_code: 'missing_read_status',
+              required: true,
+              title: 'Read Status Missing',
+              uid: null,
+              suggested_value: null,
+              suggestion_source: null,
+              suggestion_confidence: null,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+
+    const panelText = wrapper.get('[data-test="storygraph-import-issues"]').text();
+    expect(panelText).toContain('Missing title');
+    expect(panelText).toContain('Missing read status');
+
+    const issueInputs = wrapper.findAll('[data-test="storygraph-import-issue-input"]');
+    expect((issueInputs[1]?.element as HTMLInputElement).placeholder).toContain(
+      'currently-reading',
+    );
+
+    const skipButtons = wrapper.findAll('[data-test="storygraph-import-issue-mark-skip"]');
+    await skipButtons[0]?.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get('[data-test="storygraph-import-issue-undo-skip"]').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Skip removed' }));
+  });
+
+  it('allows modify + done flow without auto-accepting suggestion', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        return Promise.resolve({
+          items: [
+            {
+              row_number: 40,
+              field: 'authors',
+              issue_code: 'missing_authors',
+              required: true,
+              title: 'Book',
+              uid: '9781938660177',
+              suggested_value: 'Suggested Author',
+              suggestion_source: 'openlibrary:isbn',
+              suggestion_confidence: 'high',
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+
+    expect(
+      (wrapper.get('[data-test="storygraph-import-start"]').element as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    await wrapper.get('[data-test="storygraph-import-issue-modify"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const issueInput = wrapper.get('[data-test="storygraph-import-issue-input"]');
+    expect((issueInput.element as HTMLInputElement).value).toBe('Suggested Author');
+    await issueInput.setValue('Manual Author');
+    await wrapper.get('[data-test="storygraph-import-issue-done"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(
+      (wrapper.get('[data-test="storygraph-import-start"]').element as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it('clears import state from clear button and unmounts safely', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors')
+        return Promise.resolve({ items: [] });
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+
+    await wrapper.get('[data-test="storygraph-file-clear"]').trigger('click');
+    await flush(wrapper);
+    expect(wrapper.get('[data-test="storygraph-start-disabled-reason"]').text()).toContain(
+      'Select a CSV file',
+    );
+
+    wrapper.unmount();
+  });
+
+  it('covers retry/suggestion guard paths and resolved undo branch', async () => {
+    apiRequest.mockResolvedValue(mockProfile());
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    const setupState = (wrapper.vm as any).$?.setupState;
+    expect(setupState).toBeTruthy();
+
+    const beforeCalls = apiRequest.mock.calls.length;
+    await setupState.retryLoadImportIssues();
+    expect(apiRequest.mock.calls.length).toBe(beforeCalls);
+
+    const noSuggestionIssue = {
+      row_number: 7,
+      suggested_value: null,
+      value: '',
+      resolution: 'pending',
+      skipReasonCode: 'missing_authors',
+    };
+    setupState.applySuggestion(noSuggestionIssue);
+    expect(toastAdd).not.toHaveBeenCalledWith(
+      expect.objectContaining({ summary: 'Suggestion applied' }),
+    );
+
+    const resolvedUndoIssue = {
+      row_number: 8,
+      suggested_value: null,
+      value: 'Author Name',
+      resolution: 'skipped',
+      skipReasonCode: 'missing_authors',
+    };
+    setupState.undoIssueSkip(resolvedUndoIssue);
+    expect(resolvedUndoIssue.resolution).toBe('resolved');
+
+    const editIssue = {
+      row_number: 9,
+      suggested_value: 'Suggested',
+      value: 'Manual',
+      resolution: 'pending',
+      isEditing: false,
+      skipReasonCode: 'missing_authors',
+    };
+    setupState.startIssueEdit(editIssue);
+    expect(editIssue.value).toBe('Manual');
+    expect(editIssue.resolution).toBe('resolved');
+    editIssue.value = '';
+    setupState.finishIssueEdit(editIssue);
+    expect(editIssue.resolution).toBe('pending');
+
+    setupState.storygraphFile = new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' });
+    setupState.issuesLoading = false;
+    setupState.issuesLoadError = '';
+    setupState.issuesLoaded = false;
+    expect(setupState.startDisabledReason).toContain('Issue check has not completed');
+
+    const pendingInputIssue = {
+      row_number: 10,
+      suggested_value: null,
+      value: '',
+      resolution: 'resolved',
+      isEditing: false,
+      skipReasonCode: 'missing_authors',
+    };
+    setupState.onIssueValueInput(pendingInputIssue, '   ');
+    expect(pendingInputIssue.resolution).toBe('pending');
+  });
+
+  it('covers picker click and label/confidence fallbacks', async () => {
+    apiRequest.mockResolvedValue(mockProfile());
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    const setupState = (wrapper.vm as any).$?.setupState;
+    expect(setupState).toBeTruthy();
+
+    let clicked = 0;
+    setupState.storygraphFileInput = { click: () => clicked++ };
+    setupState.openStorygraphPicker();
+    expect(clicked).toBe(1);
+
+    expect(setupState.issueResolutionLabel('pending')).toBe('Pending');
+    expect(setupState.issueResolutionSeverity('pending')).toBe('secondary');
+
+    const noSuggestion = {
+      suggestion_confidence: null,
+      suggestion_source: null,
+    };
+    expect(setupState.suggestionConfidenceText(noSuggestion)).toBe('');
+  });
+
+  it('shows import start API errors', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors')
+        return Promise.resolve({ items: [] });
+      if (path === '/api/v1/imports/storygraph') {
+        throw new ApiClientErrorMock('Bad CSV', 'bad_csv', 400);
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+
+    await wrapper.get('[data-test="storygraph-import-start"]').trigger('click');
+    await flush(wrapper);
+    expect(wrapper.get('[data-test="storygraph-import-error"]').text()).toContain('Bad CSV');
+  });
+
+  it('renders job error summary and failed/skipped preview rows', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors')
+        return Promise.resolve({ items: [] });
+      if (path === '/api/v1/imports/storygraph') {
+        return Promise.resolve({
+          job_id: 'job-preview',
+          status: 'queued',
+          total_rows: 0,
+          processed_rows: 0,
+          imported_rows: 0,
+          failed_rows: 0,
+          skipped_rows: 0,
+          created_at: '2026-02-14T00:00:00Z',
+        });
+      }
+      if (path === '/api/v1/imports/storygraph/job-preview') {
+        return Promise.resolve({
+          job_id: 'job-preview',
+          status: 'completed',
+          total_rows: 2,
+          processed_rows: 2,
+          imported_rows: 1,
+          failed_rows: 1,
+          skipped_rows: 0,
+          error_summary: 'authors missing (1 rows)',
+          rows_preview: [{ row_number: 150, result: 'failed', message: 'authors missing' }],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+
+    await wrapper.get('[data-test="storygraph-import-start"]').trigger('click');
+    await flush(wrapper);
+    expect(wrapper.get('[data-test="storygraph-import-error-summary"]').text()).toContain(
+      'authors missing',
+    );
+    expect(wrapper.get('[data-test="storygraph-import-preview"]').text()).toContain('Row 150');
+  });
+
+  it('clears polling timer when unmounting during running import', async () => {
+    vi.useFakeTimers();
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors')
+        return Promise.resolve({ items: [] });
+      if (path === '/api/v1/imports/storygraph') {
+        return Promise.resolve({
+          job_id: 'job-running',
+          status: 'queued',
+          total_rows: 0,
+          processed_rows: 0,
+          imported_rows: 0,
+          failed_rows: 0,
+          skipped_rows: 0,
+          created_at: '2026-02-14T00:00:00Z',
+        });
+      }
+      if (path === '/api/v1/imports/storygraph/job-running') {
+        return Promise.resolve({
+          job_id: 'job-running',
+          status: 'running',
+          total_rows: 2,
+          processed_rows: 1,
+          imported_rows: 1,
+          failed_rows: 0,
+          skipped_rows: 0,
+          error_summary: null,
+          rows_preview: [],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+    await selectFile(wrapper, new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' }));
+    await flush(wrapper);
+
+    await wrapper.get('[data-test="storygraph-import-start"]').trigger('click');
+    await flush(wrapper);
+    await vi.runOnlyPendingTimersAsync();
+    wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  it('submits overrides and skipped rows in a single import request', async () => {
+    apiRequest.mockImplementation((path: string) => {
+      if (path === '/api/v1/me') return Promise.resolve(mockProfile());
+      if (path === '/api/v1/imports/storygraph/missing-authors') {
+        return Promise.resolve({
+          items: [
+            {
+              row_number: 10,
+              field: 'authors',
+              issue_code: 'missing_authors',
+              required: true,
+              title: 'Book A',
+              uid: null,
+              suggested_value: null,
+              suggestion_source: null,
+              suggestion_confidence: null,
+            },
+            {
+              row_number: 11,
+              field: 'title',
+              issue_code: 'missing_title',
+              required: true,
+              title: null,
+              uid: '9781938660177',
+              suggested_value: null,
+              suggestion_source: null,
+              suggestion_confidence: null,
+            },
+          ],
+        });
+      }
+      if (path === '/api/v1/imports/storygraph') {
+        return Promise.resolve({
+          job_id: 'job-1',
+          status: 'queued',
+          total_rows: 0,
+          processed_rows: 0,
+          imported_rows: 0,
+          failed_rows: 0,
+          skipped_rows: 0,
+          created_at: '2026-02-14T00:00:00Z',
+        });
+      }
+      if (path === '/api/v1/imports/storygraph/job-1') {
+        return Promise.resolve({
+          job_id: 'job-1',
+          status: 'completed',
+          total_rows: 2,
+          processed_rows: 2,
+          imported_rows: 1,
+          failed_rows: 0,
+          skipped_rows: 1,
+          error_summary: null,
+          rows_preview: [],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const wrapper = mountPage();
+    await flush(wrapper);
+
+    const file = new File(['a,b\n'], 'storygraph.csv', { type: 'text/csv' });
+    await selectFile(wrapper, file);
+    await flush(wrapper);
+
+    const issueInputs = wrapper.findAll('[data-test="storygraph-import-issue-input"]');
+    await issueInputs[0]?.setValue('Author Added');
+    const skipButtons = wrapper.findAll('[data-test="storygraph-import-issue-mark-skip"]');
+    await skipButtons[1]?.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get('[data-test="storygraph-import-start"]').trigger('click');
+    await flush(wrapper);
+
+    const importCall = apiRequest.mock.calls.find(
+      (call) => call[0] === '/api/v1/imports/storygraph',
+    );
+    const body = importCall?.[1]?.body as FormData;
+    expect(body.get('author_overrides')).toBe('{"10":"Author Added"}');
+    expect(body.get('skipped_rows')).toBe('[11]');
+    expect(body.get('skip_reasons')).toBe('{"11":"missing_title"}');
+    expect(wrapper.get('[data-test="storygraph-import-status"]').text()).toContain('completed');
   });
 });

--- a/docs/issue-roadmap.md
+++ b/docs/issue-roadmap.md
@@ -47,6 +47,7 @@ This is a suggested order of execution based on dependencies and risk.
 - #22 Implement notes CRUD endpoints
 - #23 Implement highlights CRUD with visibility controls
 - #24 Implement review endpoints with public listing
+- #132 Import from The StoryGraph exports
 
 ## 5) Web UI
 

--- a/docs/storygraph-import.md
+++ b/docs/storygraph-import.md
@@ -1,0 +1,80 @@
+# StoryGraph import
+
+Chapterverse supports importing a user-owned StoryGraph CSV export through `POST /api/v1/imports/storygraph`.
+
+## Supported columns
+
+The importer currently requires these columns from the StoryGraph CSV header:
+
+- `Title`
+- `Authors`
+- `ISBN/UID`
+- `Read Status`
+- `Date Added`
+- `Last Date Read`
+- `Dates Read`
+- `Read Count`
+- `Star Rating`
+- `Review`
+- `Tags`
+
+## Mapping rules
+
+### Status mapping
+
+- `read` -> `completed`
+- `to-read` -> `to_read`
+- `currently-reading` -> `reading`
+- `paused` -> `reading`
+- `did-not-finish` -> `abandoned`
+
+### Ratings
+
+- StoryGraph `Star Rating` is mapped to `library_items.rating` (0-10) using `round(stars * 2)`.
+- If a review is imported, review rating is stored on a 1-5 scale via `round(stars)`.
+
+### Tags
+
+- StoryGraph tags are split by comma, trimmed, de-duplicated (case-insensitive), and written to `library_items.tags`.
+
+### Reviews
+
+- Non-empty StoryGraph `Review` creates or updates a work review for the user.
+- Imported review visibility defaults to `private`.
+
+### Reading sessions
+
+One reading session can be created per row when at least one date is available:
+
+1. `Dates Read` range (`YYYY/MM/DD-YYYY/MM/DD`) if present
+2. `Last Date Read`
+3. `Date Added`
+
+The session note stores a deterministic marker (`storygraph:{row_hash}`) to prevent duplicates on re-import.
+
+## Work resolution strategy
+
+1. If `ISBN/UID` looks like ISBN10/ISBN13, try existing local editions first.
+2. If not found locally, query Open Library by ISBN and import that work.
+3. If unresolved (or non-ISBN UID), create/get a manual work keyed by deterministic identity hash (`title|authors|uid`).
+
+## Async job flow
+
+- `POST /api/v1/imports/storygraph` creates a queued job.
+- Background processing moves status through `queued -> running -> completed|failed`.
+- Use `GET /api/v1/imports/storygraph/{job_id}` for progress and preview rows.
+- Use `GET /api/v1/imports/storygraph/{job_id}/rows` for paginated row-level details.
+
+## Idempotency
+
+- Re-import is duplicate-safe per user.
+- Existing library items are upserted (`status`, `rating`, `tags`) instead of duplicated.
+- Review upserts key off user + library item.
+- Reading session dedupe uses deterministic marker.
+- Row records are de-duplicated per job using row identity hash.
+
+## Troubleshooting
+
+- `400 file must be a .csv export`: upload a CSV file.
+- `400 file is empty`: exported file has no content.
+- `failed` job with `error_summary`: malformed header/data or provider lookup failures; inspect preview rows and `/rows` endpoint for details.

--- a/supabase/migrations/20260214170000_add_storygraph_import_jobs.sql
+++ b/supabase/migrations/20260214170000_add_storygraph_import_jobs.sql
@@ -1,0 +1,76 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'storygraph_import_job_status') THEN
+    CREATE TYPE storygraph_import_job_status AS ENUM ('queued', 'running', 'completed', 'failed');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'storygraph_import_row_result') THEN
+    CREATE TYPE storygraph_import_row_result AS ENUM ('imported', 'failed', 'skipped');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.storygraph_import_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  filename varchar(255) NOT NULL,
+  status storygraph_import_job_status NOT NULL,
+  total_rows integer NOT NULL DEFAULT 0,
+  processed_rows integer NOT NULL DEFAULT 0,
+  imported_rows integer NOT NULL DEFAULT 0,
+  failed_rows integer NOT NULL DEFAULT 0,
+  skipped_rows integer NOT NULL DEFAULT 0,
+  error_summary text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_storygraph_import_jobs_user_created
+  ON public.storygraph_import_jobs (user_id, created_at);
+CREATE INDEX IF NOT EXISTS ix_storygraph_import_jobs_status
+  ON public.storygraph_import_jobs (status);
+
+CREATE TABLE IF NOT EXISTS public.storygraph_import_job_rows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL REFERENCES public.storygraph_import_jobs(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  row_number integer NOT NULL,
+  identity_hash varchar(64) NOT NULL,
+  title varchar(512),
+  uid varchar(255),
+  result storygraph_import_row_result NOT NULL,
+  message text NOT NULL,
+  work_id uuid,
+  library_item_id uuid,
+  review_id uuid,
+  session_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_storygraph_import_job_rows_job_identity UNIQUE (job_id, identity_hash)
+);
+
+CREATE INDEX IF NOT EXISTS ix_storygraph_import_job_rows_job_row
+  ON public.storygraph_import_job_rows (job_id, row_number);
+CREATE INDEX IF NOT EXISTS ix_storygraph_import_job_rows_job_result
+  ON public.storygraph_import_job_rows (job_id, result);
+
+ALTER TABLE public.storygraph_import_jobs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS storygraph_import_jobs_owner ON public.storygraph_import_jobs;
+CREATE POLICY storygraph_import_jobs_owner
+  ON public.storygraph_import_jobs
+  FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+ALTER TABLE public.storygraph_import_job_rows ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS storygraph_import_job_rows_owner ON public.storygraph_import_job_rows;
+CREATE POLICY storygraph_import_job_rows_owner
+  ON public.storygraph_import_job_rows
+  FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- implement full StoryGraph CSV import pipeline with async jobs, row outcomes, and idempotent upsert behavior
- add settings-page import workflow with issue resolution UX, progress polling, and actionable errors
- harden metadata/cover enrichment matching with Open Library + Google fallback strategies and author/title normalization
- improve enrich-metadata UX by prioritizing cover row and auto-applying "Pick all provider" actions

## Backend
- add import job models/tables, migrations, and policies
- add StoryGraph parser + import services + routers for job creation/status/rows/issues
- add unresolved-field handling and explicit skipped-row semantics
- improve enrichment candidate discovery:
  - resilient Open Library work-key resolution via ISBN + title/author variants
  - Google fallback candidate ranking for sparse/missing ISBN mappings
  - metadata enrichment now always attempts Google as a best-effort provider

## Web
- add StoryGraph import section on settings with guided workflow and issue resolution controls
- add row-level issue actions (suggestion, skip/resolve) and clear progress summaries
- adjust enrichment dialog UX:
  - `work.cover_url` row rendered first
  - "Pick all Open Library" / "Pick all Google Books" now immediately apply selections

## Docs
- add StoryGraph import docs with mapping rules and limitations
- update roadmap notes

## Validation
- `make quality` passes locally

Closes #132
