### PR TITLE
Library: replace load-more with true pagination + full-dataset sorting

### DIFF
--- a/apps/api/alembic/versions/0014_library_pagination_indexes.py
+++ b/apps/api/alembic/versions/0014_library_pagination_indexes.py
@@ -1,0 +1,79 @@
+"""Add indexes for library pagination and sorting.
+
+Revision ID: 0014_library_pagination_indexes
+Revises: 0013_storygraph_import_jobs
+Create Date: 2026-02-15
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0014_library_pagination_indexes"
+down_revision = "0013_storygraph_import_jobs"
+branch_labels = None
+depends_on = None
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(
+        index.get("name") == index_name
+        for index in inspector.get_indexes(table_name, schema="public")
+    )
+
+
+def upgrade() -> None:
+    if not _has_index("library_items", "ix_library_items_user_created_at_id"):
+        op.create_index(
+            "ix_library_items_user_created_at_id",
+            "library_items",
+            ["user_id", "created_at", "id"],
+            schema="public",
+        )
+    if not _has_index("library_items", "ix_library_items_user_rating_id"):
+        op.create_index(
+            "ix_library_items_user_rating_id",
+            "library_items",
+            ["user_id", "rating", "id"],
+            schema="public",
+        )
+    if not _has_index("library_items", "ix_library_items_user_status_created_at"):
+        op.create_index(
+            "ix_library_items_user_status_created_at",
+            "library_items",
+            ["user_id", "status", "created_at"],
+            schema="public",
+        )
+    if not _has_index("library_items", "ix_library_items_user_visibility_created_at"):
+        op.create_index(
+            "ix_library_items_user_visibility_created_at",
+            "library_items",
+            ["user_id", "visibility", "created_at"],
+            schema="public",
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_library_items_user_visibility_created_at",
+        table_name="library_items",
+        schema="public",
+    )
+    op.drop_index(
+        "ix_library_items_user_status_created_at",
+        table_name="library_items",
+        schema="public",
+    )
+    op.drop_index(
+        "ix_library_items_user_rating_id",
+        table_name="library_items",
+        schema="public",
+    )
+    op.drop_index(
+        "ix_library_items_user_created_at_id",
+        table_name="library_items",
+        schema="public",
+    )

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -80,6 +80,25 @@ class LibraryItem(Base):
         sa.Index("ix_library_items_status", "status"),
         sa.Index("ix_library_items_visibility", "visibility"),
         sa.Index("ix_library_items_tags", "tags", postgresql_using="gin"),
+        sa.Index(
+            "ix_library_items_user_created_at_id",
+            "user_id",
+            "created_at",
+            "id",
+        ),
+        sa.Index("ix_library_items_user_rating_id", "user_id", "rating", "id"),
+        sa.Index(
+            "ix_library_items_user_status_created_at",
+            "user_id",
+            "status",
+            "created_at",
+        ),
+        sa.Index(
+            "ix_library_items_user_visibility_created_at",
+            "user_id",
+            "visibility",
+            "created_at",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/apps/api/app/routers/library.py
+++ b/apps/api/app/routers/library.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -50,8 +50,23 @@ router = APIRouter(
 def list_items(
     auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
-    limit: Annotated[int, Query(ge=1, le=100)] = 20,
-    cursor: str | None = None,
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 25,
+    sort: Annotated[
+        Literal[
+            "newest",
+            "oldest",
+            "title_asc",
+            "title_desc",
+            "author_asc",
+            "author_desc",
+            "status_asc",
+            "status_desc",
+            "rating_asc",
+            "rating_desc",
+        ],
+        Query(),
+    ] = "newest",
     status: str | None = None,
     tag: str | None = None,
     visibility: str | None = None,
@@ -60,8 +75,9 @@ def list_items(
         result = list_library_items(
             session,
             user_id=auth.user_id,
-            limit=limit,
-            cursor=cursor,
+            page=page,
+            page_size=page_size,
+            sort=sort,
             status=status,
             tag=tag,
             visibility=visibility,

--- a/supabase/migrations/20260215120000_add_library_pagination_indexes.sql
+++ b/supabase/migrations/20260215120000_add_library_pagination_indexes.sql
@@ -1,0 +1,11 @@
+create index if not exists ix_library_items_user_created_at_id
+  on public.library_items (user_id, created_at, id);
+
+create index if not exists ix_library_items_user_rating_id
+  on public.library_items (user_id, rating, id);
+
+create index if not exists ix_library_items_user_status_created_at
+  on public.library_items (user_id, status, created_at);
+
+create index if not exists ix_library_items_user_visibility_created_at
+  on public.library_items (user_id, visibility, created_at);


### PR DESCRIPTION
## Summary
Implements issue #139 by replacing library load-more with true page-based pagination and moving sorting/filtering to server-side full-dataset queries.

### Backend
- Switches `GET /api/v1/library/items` to `page`, `page_size`, and `sort` query params.
- Removes cursor-based list contract usage for this endpoint.
- Adds response pagination metadata:
  - `page`, `page_size`, `total_count`, `total_pages`, `from`, `to`, `has_prev`, `has_next`
- Implements deterministic server-side sort modes over full dataset:
  - `newest`, `oldest`, `title_asc`, `title_desc`, `author_asc`, `author_desc`, `status_asc`, `status_desc`, `rating_asc`, `rating_desc`
- Uses SQL tie-breakers for stable ordering across page boundaries.
- Applies tag filtering as case-insensitive partial match.
- Adds supporting DB indexes and mirrored migrations (Alembic + Supabase).

### Frontend
- Removes load-more UX and adds paginator-based navigation.
- Sends pagination/sort/filter params to API (`page`, `page_size`, `sort`, `status`, `visibility`, `tag`).
- Adds visible pagination-area total summary (`X-Y of Z books`).
- Resets to page 1 on sort/filter changes.
- Debounces tag filter fetches (300ms).
- Handles delete edge case by stepping back a page when current page becomes empty.

### Tests
- Updates API router tests for new list contract and query validation.
- Expands user library service tests for pagination metadata, sort paths, and filtering.
- Updates high-coverage web unit tests for paginator flow and new query payloads.
- Updates Cypress library spec response contract and request assertions.

Closes #139.

## Validation
- `make quality`
