### PR TITLE
Fix tablet topbar overlap and align clear input with PrimeVue

### DIFF
--- a/apps/web/app/components/shell/AppTopBarBookSearch.vue
+++ b/apps/web/app/components/shell/AppTopBarBookSearch.vue
@@ -1,31 +1,33 @@
 <template>
   <div>
-    <!-- Desktop: centered popover search -->
+    <!-- Large screens: centered popover search -->
     <div
       v-show="!mobileOpen"
-      class="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 md:block"
+      class="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 lg:block"
       data-test="topbar-book-search-desktop"
     >
       <div class="flex w-[min(760px,92vw)] items-center gap-2 lg:w-[min(760px,52vw)]">
-        <div ref="anchorEl" class="relative flex flex-1 items-center">
-          <InputText
-            v-model="query"
-            placeholder="Find a book"
-            class="w-full pr-10"
-            data-test="topbar-search-input"
-            @focus="onFocus"
-          />
-          <Button
-            v-if="query.trim().length"
-            icon="pi pi-times"
-            variant="text"
-            severity="secondary"
-            size="small"
-            class="absolute right-1 top-1/2 -translate-y-1/2"
-            aria-label="Clear search"
-            data-test="topbar-search-clear"
-            @click="clear"
-          />
+        <div ref="anchorEl" class="flex flex-1">
+          <InputGroup class="w-full">
+            <InputText
+              v-model="query"
+              placeholder="Find a book"
+              class="w-full"
+              data-test="topbar-search-input"
+              @focus="onFocus"
+            />
+            <InputGroupAddon v-if="query.trim().length">
+              <Button
+                icon="pi pi-times"
+                variant="text"
+                severity="secondary"
+                size="small"
+                aria-label="Clear search"
+                data-test="topbar-search-clear"
+                @click="clear"
+              />
+            </InputGroupAddon>
+          </InputGroup>
         </div>
 
         <SelectButton
@@ -175,9 +177,9 @@
       </Popover>
     </div>
 
-    <!-- Mobile: button that opens a dialog -->
+    <!-- Mobile and tablet: button that opens a dialog -->
     <Button
-      class="md:hidden"
+      class="lg:hidden"
       icon="pi pi-search"
       variant="text"
       severity="secondary"
@@ -198,25 +200,25 @@
     >
       <div class="flex flex-col gap-3">
         <div class="flex flex-col gap-2">
-          <div class="relative flex items-center">
+          <InputGroup>
             <InputText
               v-model="query"
               placeholder="Find a book"
-              class="w-full pr-10"
+              class="w-full"
               data-test="topbar-search-input-mobile"
             />
-            <Button
-              v-if="query.trim().length"
-              icon="pi pi-times"
-              variant="text"
-              severity="secondary"
-              size="small"
-              class="absolute right-1 top-1/2 -translate-y-1/2"
-              aria-label="Clear search"
-              data-test="topbar-search-clear-mobile"
-              @click="clear"
-            />
-          </div>
+            <InputGroupAddon v-if="query.trim().length">
+              <Button
+                icon="pi pi-times"
+                variant="text"
+                severity="secondary"
+                size="small"
+                aria-label="Clear search"
+                data-test="topbar-search-clear-mobile"
+                @click="clear"
+              />
+            </InputGroupAddon>
+          </InputGroup>
 
           <SelectButton
             v-model="scope"
@@ -366,6 +368,8 @@ import Button from 'primevue/button';
 import Card from 'primevue/card';
 import Dialog from 'primevue/dialog';
 import Fieldset from 'primevue/fieldset';
+import InputGroup from 'primevue/inputgroup';
+import InputGroupAddon from 'primevue/inputgroupaddon';
 import InputText from 'primevue/inputtext';
 import Message from 'primevue/message';
 import Popover from 'primevue/popover';

--- a/apps/web/tests/unit/components/app-topbar-book-search.test.ts
+++ b/apps/web/tests/unit/components/app-topbar-book-search.test.ts
@@ -69,6 +69,22 @@ const InputTextStub = defineComponent({
   },
 });
 
+const InputGroupStub = defineComponent({
+  name: 'InputGroup',
+  setup:
+    (_props, { slots, attrs }) =>
+    () =>
+      h('div', { ...attrs }, slots.default?.()),
+});
+
+const InputGroupAddonStub = defineComponent({
+  name: 'InputGroupAddon',
+  setup:
+    (_props, { slots, attrs }) =>
+    () =>
+      h('div', { ...attrs }, slots.default?.()),
+});
+
 const SelectButtonStub = defineComponent({
   name: 'SelectButton',
   props: ['modelValue', 'options', 'optionLabel', 'optionValue'],
@@ -181,6 +197,8 @@ describe('AppTopBarBookSearch', () => {
         plugins: [[PrimeVue, { ripple: false }]],
         stubs: {
           Button: ButtonStub,
+          InputGroup: InputGroupStub,
+          InputGroupAddon: InputGroupAddonStub,
           InputText: InputTextStub,
           SelectButton: SelectButtonStub,
           Popover: PopoverStub,
@@ -533,6 +551,18 @@ describe('AppTopBarBookSearch', () => {
     await wrapper.get('[data-test="topbar-search-mobile-open"]').trigger('click');
     await wrapper.get('[data-test="topbar-search-mobile-close"]').trigger('click');
     await wrapper.get('[data-test="dialog-update-visible-false"]').trigger('click');
+  });
+
+  it('uses lg breakpoints so tablet follows the dialog search path', () => {
+    const wrapper = mountSearch();
+
+    const desktopWrapper = wrapper.get('[data-test="topbar-book-search-desktop"]');
+    expect(desktopWrapper.classes()).toContain('lg:block');
+    expect(desktopWrapper.classes()).not.toContain('md:block');
+
+    const dialogTrigger = wrapper.get('[data-test="topbar-search-mobile-open"]');
+    expect(dialogTrigger.classes()).toContain('lg:hidden');
+    expect(dialogTrigger.classes()).not.toContain('md:hidden');
   });
 
   it('mobile controls render and the mobile clear button clears the shared query', async () => {


### PR DESCRIPTION
## Summary
- fix tablet topbar collisions by shifting inline search to `lg` and using dialog search for `md` widths
- replace custom overlaid clear "X" controls with PrimeVue `InputGroup` + `InputGroupAddon` clear actions
- keep existing search behavior and selectors while aligning the input UX with PrimeVue component patterns
- add/adjust unit coverage for responsive breakpoint contracts and InputGroup stubbing

## Testing
- make quality

## Issue
- Closes #142
