### PR TITLE
Reading Sessions v2: Data Model + API Foundation

### DIFF
--- a/apps/api/alembic/versions/0016_reading_sessions_v2_foundation.py
+++ b/apps/api/alembic/versions/0016_reading_sessions_v2_foundation.py
@@ -1,6 +1,6 @@
 """Reading sessions v2 foundation: read cycles + progress logs.
 
-Revision ID: 0016_reading_sessions_v2_foundation
+Revision ID: 0016_reading_sessions_v2
 Revises: 0015_goodreads_import_jobs
 Create Date: 2026-02-16 00:00:00
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-revision = "0016_reading_sessions_v2_foundation"
+revision = "0016_reading_sessions_v2"
 down_revision = "0015_goodreads_import_jobs"
 branch_labels = None
 depends_on = None

--- a/apps/api/alembic/versions/0016_reading_sessions_v2_foundation.py
+++ b/apps/api/alembic/versions/0016_reading_sessions_v2_foundation.py
@@ -1,0 +1,197 @@
+"""Reading sessions v2 foundation: read cycles + progress logs.
+
+Revision ID: 0016_reading_sessions_v2_foundation
+Revises: 0015_goodreads_import_jobs
+Create Date: 2026-02-16 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0016_reading_sessions_v2_foundation"
+down_revision = "0015_goodreads_import_jobs"
+branch_labels = None
+depends_on = None
+
+reading_progress_unit_enum = postgresql.ENUM(
+    "pages_read",
+    "percent_complete",
+    "minutes_listened",
+    name="reading_progress_unit",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    reading_progress_unit_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column("editions", sa.Column("total_pages", sa.Integer(), nullable=True))
+    op.add_column(
+        "editions", sa.Column("total_audio_minutes", sa.Integer(), nullable=True)
+    )
+    op.create_check_constraint(
+        "ck_editions_total_pages_positive",
+        "editions",
+        "total_pages IS NULL OR total_pages >= 1",
+    )
+    op.create_check_constraint(
+        "ck_editions_total_audio_minutes_positive",
+        "editions",
+        "total_audio_minutes IS NULL OR total_audio_minutes >= 1",
+    )
+
+    op.drop_constraint(
+        "ck_reading_sessions_pages_read_nonnegative",
+        "reading_sessions",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_reading_sessions_progress_percent_range",
+        "reading_sessions",
+        type_="check",
+    )
+    op.drop_column("reading_sessions", "pages_read")
+    op.drop_column("reading_sessions", "progress_percent")
+    op.add_column("reading_sessions", sa.Column("title", sa.String(length=255)))
+
+    op.create_table(
+        "reading_progress_logs",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_item_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "reading_session_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("reading_sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("logged_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("unit", reading_progress_unit_enum, nullable=False),
+        sa.Column("value", sa.Numeric(10, 2), nullable=False),
+        sa.Column("canonical_percent", sa.Numeric(6, 3)),
+        sa.Column("note", sa.Text()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "value >= 0",
+            name="ck_reading_progress_logs_value_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "canonical_percent IS NULL OR (canonical_percent >= 0 AND canonical_percent <= 100)",
+            name="ck_reading_progress_logs_canonical_percent_range",
+        ),
+    )
+    op.create_index(
+        "ix_reading_progress_logs_user_id",
+        "reading_progress_logs",
+        ["user_id"],
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_reading_progress_logs_library_item_logged_at
+        ON reading_progress_logs (library_item_id, logged_at DESC);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_reading_progress_logs_session_logged_at
+        ON reading_progress_logs (reading_session_id, logged_at DESC);
+        """
+    )
+
+    op.execute("ALTER TABLE public.reading_progress_logs ENABLE ROW LEVEL SECURITY;")
+    op.execute(
+        "DROP POLICY IF EXISTS reading_progress_logs_owner ON public.reading_progress_logs;"
+    )
+    op.execute(
+        """
+        CREATE POLICY reading_progress_logs_owner
+        ON public.reading_progress_logs
+        FOR ALL
+        TO authenticated
+        USING (user_id = auth.uid())
+        WITH CHECK (user_id = auth.uid());
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS reading_progress_logs_owner ON public.reading_progress_logs;"
+    )
+    op.drop_index(
+        "ix_reading_progress_logs_session_logged_at",
+        table_name="reading_progress_logs",
+    )
+    op.drop_index(
+        "ix_reading_progress_logs_library_item_logged_at",
+        table_name="reading_progress_logs",
+    )
+    op.drop_index(
+        "ix_reading_progress_logs_user_id", table_name="reading_progress_logs"
+    )
+    op.drop_table("reading_progress_logs")
+
+    op.drop_column("reading_sessions", "title")
+    op.add_column(
+        "reading_sessions",
+        sa.Column("progress_percent", sa.Numeric(5, 2), nullable=True),
+    )
+    op.add_column(
+        "reading_sessions",
+        sa.Column("pages_read", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_reading_sessions_pages_read_nonnegative",
+        "reading_sessions",
+        "pages_read >= 0",
+    )
+    op.create_check_constraint(
+        "ck_reading_sessions_progress_percent_range",
+        "reading_sessions",
+        "progress_percent >= 0 AND progress_percent <= 100",
+    )
+
+    op.drop_constraint(
+        "ck_editions_total_audio_minutes_positive",
+        "editions",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_editions_total_pages_positive",
+        "editions",
+        type_="check",
+    )
+    op.drop_column("editions", "total_audio_minutes")
+    op.drop_column("editions", "total_pages")
+
+    reading_progress_unit_enum.drop(op.get_bind(), checkfirst=True)

--- a/apps/api/app/db/models/__init__.py
+++ b/apps/api/app/db/models/__init__.py
@@ -12,6 +12,7 @@ from app.db.models.imports import (
 from app.db.models.platform import ApiAuditLog, ApiClient
 from app.db.models.users import (
     LibraryItem,
+    ReadingProgressLog,
     ReadingSession,
     ReadingStateEvent,
     User,
@@ -28,6 +29,7 @@ __all__ = [
     "Highlight",
     "LibraryItem",
     "Note",
+    "ReadingProgressLog",
     "ReadingSession",
     "ReadingStateEvent",
     "Review",

--- a/apps/api/app/db/models/bibliography.py
+++ b/apps/api/app/db/models/bibliography.py
@@ -64,6 +64,14 @@ class Work(Base):
 class Edition(Base):
     __tablename__ = "editions"
     __table_args__ = (
+        sa.CheckConstraint(
+            "total_pages IS NULL OR total_pages >= 1",
+            name="ck_editions_total_pages_positive",
+        ),
+        sa.CheckConstraint(
+            "total_audio_minutes IS NULL OR total_audio_minutes >= 1",
+            name="ck_editions_total_audio_minutes_positive",
+        ),
         sa.Index("ix_editions_isbn10", "isbn10"),
         sa.Index("ix_editions_isbn13", "isbn13"),
     )
@@ -84,6 +92,8 @@ class Edition(Base):
     publish_date: Mapped[dt.date | None] = mapped_column(sa.Date)
     language: Mapped[str | None] = mapped_column(sa.String(32))
     format: Mapped[str | None] = mapped_column(sa.String(64))
+    total_pages: Mapped[int | None] = mapped_column(sa.Integer)
+    total_audio_minutes: Mapped[int | None] = mapped_column(sa.Integer)
     cover_url: Mapped[str | None] = mapped_column(sa.Text)
     cover_set_by: Mapped[uuid.UUID | None] = mapped_column(sa.UUID(as_uuid=True))
     cover_set_at: Mapped[dt.datetime | None] = mapped_column(sa.DateTime(timezone=True))

--- a/apps/api/app/routers/sessions.py
+++ b/apps/api/app/routers/sessions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -13,26 +13,44 @@ from app.core.responses import ok
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.services.reading_sessions import (
-    create_reading_session,
-    delete_reading_session,
-    list_reading_sessions,
-    update_reading_session,
+    create_progress_log,
+    create_read_cycle,
+    delete_progress_log,
+    delete_read_cycle,
+    list_progress_logs,
+    list_read_cycles,
+    update_progress_log,
+    update_read_cycle,
 )
 
+ProgressUnit = Literal["pages_read", "percent_complete", "minutes_listened"]
 
-class CreateReadingSessionRequest(BaseModel):
+
+class CreateReadCycleRequest(BaseModel):
     started_at: dt.datetime
     ended_at: dt.datetime | None = None
-    pages_read: int | None = Field(default=None, ge=0)
-    progress_percent: float | None = Field(default=None, ge=0.0, le=100.0)
+    title: str | None = Field(default=None, max_length=255)
     note: str | None = Field(default=None, max_length=5000)
 
 
-class UpdateReadingSessionRequest(BaseModel):
+class UpdateReadCycleRequest(BaseModel):
     started_at: dt.datetime | None = None
     ended_at: dt.datetime | None = None
-    pages_read: int | None = Field(default=None, ge=0)
-    progress_percent: float | None = Field(default=None, ge=0.0, le=100.0)
+    title: str | None = Field(default=None, max_length=255)
+    note: str | None = Field(default=None, max_length=5000)
+
+
+class CreateProgressLogRequest(BaseModel):
+    unit: ProgressUnit
+    value: float = Field(ge=0.0)
+    logged_at: dt.datetime | None = None
+    note: str | None = Field(default=None, max_length=5000)
+
+
+class UpdateProgressLogRequest(BaseModel):
+    unit: ProgressUnit | None = None
+    value: float | None = Field(default=None, ge=0.0)
+    logged_at: dt.datetime | None = None
     note: str | None = Field(default=None, max_length=5000)
 
 
@@ -42,15 +60,15 @@ router = APIRouter(
 )
 
 
-@router.get("/api/v1/library/items/{library_item_id}/sessions")
-def list_sessions(
+@router.get("/api/v1/library/items/{library_item_id}/read-cycles")
+def list_cycles(
     library_item_id: uuid.UUID,
     auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
     limit: Annotated[int, Query(ge=1, le=200)] = 100,
 ) -> dict[str, object]:
     try:
-        rows = list_reading_sessions(
+        rows = list_read_cycles(
             session,
             user_id=auth.user_id,
             library_item_id=library_item_id,
@@ -61,22 +79,21 @@ def list_sessions(
     return ok({"items": rows})
 
 
-@router.post("/api/v1/library/items/{library_item_id}/sessions")
-def create_session(
+@router.post("/api/v1/library/items/{library_item_id}/read-cycles")
+def create_cycle(
     library_item_id: uuid.UUID,
-    payload: CreateReadingSessionRequest,
+    payload: CreateReadCycleRequest,
     auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:
-        model = create_reading_session(
+        model = create_read_cycle(
             session,
             user_id=auth.user_id,
             library_item_id=library_item_id,
             started_at=payload.started_at,
             ended_at=payload.ended_at,
-            pages_read=payload.pages_read,
-            progress_percent=payload.progress_percent,
+            title=payload.title,
             note=payload.note,
         )
     except LookupError as exc:
@@ -84,22 +101,21 @@ def create_session(
     return ok({"id": str(model.id)})
 
 
-@router.patch("/api/v1/sessions/{session_id}")
-def patch_session(
-    session_id: uuid.UUID,
-    payload: UpdateReadingSessionRequest,
+@router.patch("/api/v1/read-cycles/{cycle_id}")
+def patch_cycle(
+    cycle_id: uuid.UUID,
+    payload: UpdateReadCycleRequest,
     auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:
-        model = update_reading_session(
+        model = update_read_cycle(
             session,
             user_id=auth.user_id,
-            session_id=session_id,
+            cycle_id=cycle_id,
             started_at=payload.started_at,
             ended_at=payload.ended_at,
-            pages_read=payload.pages_read,
-            progress_percent=payload.progress_percent,
+            title=payload.title,
             note=payload.note,
         )
     except LookupError as exc:
@@ -107,14 +123,94 @@ def patch_session(
     return ok({"id": str(model.id)})
 
 
-@router.delete("/api/v1/sessions/{session_id}")
-def delete_session(
-    session_id: uuid.UUID,
+@router.delete("/api/v1/read-cycles/{cycle_id}")
+def remove_cycle(
+    cycle_id: uuid.UUID,
     auth: Annotated[AuthContext, Depends(require_auth_context)],
     session: Annotated[Session, Depends(get_db_session)],
 ) -> dict[str, object]:
     try:
-        delete_reading_session(session, user_id=auth.user_id, session_id=session_id)
+        delete_read_cycle(session, user_id=auth.user_id, cycle_id=cycle_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ok({"deleted": True})
+
+
+@router.get("/api/v1/read-cycles/{cycle_id}/progress-logs")
+def list_logs(
+    cycle_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 200,
+) -> dict[str, object]:
+    try:
+        rows = list_progress_logs(
+            session,
+            user_id=auth.user_id,
+            cycle_id=cycle_id,
+            limit=limit,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ok({"items": rows})
+
+
+@router.post("/api/v1/read-cycles/{cycle_id}/progress-logs")
+def create_log(
+    cycle_id: uuid.UUID,
+    payload: CreateProgressLogRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        model = create_progress_log(
+            session,
+            user_id=auth.user_id,
+            cycle_id=cycle_id,
+            unit=payload.unit,
+            value=payload.value,
+            logged_at=payload.logged_at,
+            note=payload.note,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ok({"id": str(model.id)})
+
+
+@router.patch("/api/v1/progress-logs/{log_id}")
+def patch_log(
+    log_id: uuid.UUID,
+    payload: UpdateProgressLogRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        model = update_progress_log(
+            session,
+            user_id=auth.user_id,
+            log_id=log_id,
+            unit=payload.unit,
+            value=payload.value,
+            logged_at=payload.logged_at,
+            note=payload.note,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ok({"id": str(model.id)})
+
+
+@router.delete("/api/v1/progress-logs/{log_id}")
+def remove_log(
+    log_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, object]:
+    try:
+        delete_progress_log(session, user_id=auth.user_id, log_id=log_id)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return ok({"deleted": True})

--- a/apps/api/app/services/reading_sessions.py
+++ b/apps/api/app/services/reading_sessions.py
@@ -2,28 +2,154 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
-from typing import Any
+from decimal import Decimal
+from typing import Any, Literal
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from app.db.models.users import LibraryItem, ReadingSession
+from app.db.models.bibliography import Edition
+from app.db.models.users import LibraryItem, ReadingProgressLog, ReadingSession
+
+ProgressUnit = Literal["pages_read", "percent_complete", "minutes_listened"]
 
 
 def _ensure_library_item_owned(
     session: Session, *, user_id: uuid.UUID, library_item_id: uuid.UUID
-) -> None:
-    exists = session.scalar(
-        sa.select(LibraryItem.id).where(
+) -> LibraryItem:
+    item = session.scalar(
+        sa.select(LibraryItem).where(
             LibraryItem.id == library_item_id,
             LibraryItem.user_id == user_id,
         )
     )
-    if exists is None:
+    if item is None:
         raise LookupError("library item not found")
+    return item
 
 
-def list_reading_sessions(
+def _get_cycle(
+    session: Session, *, user_id: uuid.UUID, cycle_id: uuid.UUID
+) -> ReadingSession:
+    cycle = session.scalar(
+        sa.select(ReadingSession).where(
+            ReadingSession.id == cycle_id,
+            ReadingSession.user_id == user_id,
+        )
+    )
+    if cycle is None:
+        raise LookupError("read cycle not found")
+    return cycle
+
+
+def _get_item_totals(
+    session: Session, *, library_item_id: uuid.UUID
+) -> tuple[int | None, int | None]:
+    preferred = session.execute(
+        sa.select(Edition.total_pages, Edition.total_audio_minutes)
+        .join(LibraryItem, LibraryItem.preferred_edition_id == Edition.id)
+        .where(LibraryItem.id == library_item_id)
+        .limit(1)
+    ).first()
+    if preferred is not None:
+        return preferred[0], preferred[1]
+
+    fallback = session.execute(
+        sa.select(Edition.total_pages, Edition.total_audio_minutes)
+        .join(LibraryItem, LibraryItem.work_id == Edition.work_id)
+        .where(LibraryItem.id == library_item_id)
+        .order_by(Edition.created_at.desc(), Edition.id.desc())
+        .limit(1)
+    ).first()
+    if fallback is not None:
+        return fallback[0], fallback[1]
+
+    return None, None
+
+
+def _conversion_metadata(
+    *, total_pages: int | None, total_audio_minutes: int | None
+) -> dict[str, Any]:
+    return {
+        "total_pages": total_pages,
+        "total_audio_minutes": total_audio_minutes,
+        "can_convert_pages_percent": total_pages is not None,
+        "can_convert_minutes_percent": total_audio_minutes is not None,
+        "can_convert_pages_minutes": (
+            total_pages is not None and total_audio_minutes is not None
+        ),
+    }
+
+
+def _to_float(value: Decimal | float | int | None) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _canonical_percent(
+    *,
+    unit: ProgressUnit,
+    value: float,
+    total_pages: int | None,
+    total_audio_minutes: int | None,
+) -> float | None:
+    if unit == "percent_complete":
+        if value < 0 or value > 100:
+            raise ValueError("percent_complete must be between 0 and 100")
+        return value
+    if unit == "pages_read":
+        if total_pages is None:
+            return None
+        if total_pages <= 0:
+            return None
+        return min(100.0, max(0.0, (value / total_pages) * 100.0))
+    if unit == "minutes_listened":
+        if total_audio_minutes is None:
+            return None
+        if total_audio_minutes <= 0:
+            return None
+        return min(100.0, max(0.0, (value / total_audio_minutes) * 100.0))
+    raise ValueError("unsupported progress unit")
+
+
+def _serialize_cycle(
+    cycle: ReadingSession, *, total_pages: int | None, total_audio_minutes: int | None
+) -> dict[str, Any]:
+    return {
+        "id": str(cycle.id),
+        "library_item_id": str(cycle.library_item_id),
+        "started_at": cycle.started_at.isoformat(),
+        "ended_at": cycle.ended_at.isoformat() if cycle.ended_at else None,
+        "title": cycle.title,
+        "note": cycle.note,
+        "conversion": _conversion_metadata(
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        ),
+    }
+
+
+def _serialize_log(
+    log: ReadingProgressLog, *, total_pages: int | None, total_audio_minutes: int | None
+) -> dict[str, Any]:
+    return {
+        "id": str(log.id),
+        "library_item_id": str(log.library_item_id),
+        "reading_session_id": str(log.reading_session_id),
+        "logged_at": log.logged_at.isoformat(),
+        "unit": log.unit,
+        "value": _to_float(log.value),
+        "canonical_percent": _to_float(log.canonical_percent),
+        "note": log.note,
+        "conversion": _conversion_metadata(
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        ),
+    }
+
+
+def list_read_cycles(
     session: Session,
     *,
     user_id: uuid.UUID,
@@ -32,6 +158,9 @@ def list_reading_sessions(
 ) -> list[dict[str, Any]]:
     _ensure_library_item_owned(
         session, user_id=user_id, library_item_id=library_item_id
+    )
+    total_pages, total_audio_minutes = _get_item_totals(
+        session, library_item_id=library_item_id
     )
     rows = session.execute(
         sa.select(ReadingSession)
@@ -43,32 +172,23 @@ def list_reading_sessions(
         .limit(limit)
     ).scalars()
     return [
-        {
-            "id": str(row.id),
-            "library_item_id": str(row.library_item_id),
-            "started_at": row.started_at.isoformat(),
-            "ended_at": row.ended_at.isoformat() if row.ended_at else None,
-            "pages_read": row.pages_read,
-            "progress_percent": (
-                float(row.progress_percent)
-                if row.progress_percent is not None
-                else None
-            ),
-            "note": row.note,
-        }
+        _serialize_cycle(
+            row,
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        )
         for row in rows
     ]
 
 
-def create_reading_session(
+def create_read_cycle(
     session: Session,
     *,
     user_id: uuid.UUID,
     library_item_id: uuid.UUID,
     started_at: dt.datetime,
     ended_at: dt.datetime | None,
-    pages_read: int | None,
-    progress_percent: float | None,
+    title: str | None,
     note: str | None,
 ) -> ReadingSession:
     _ensure_library_item_owned(
@@ -79,8 +199,7 @@ def create_reading_session(
         library_item_id=library_item_id,
         started_at=started_at,
         ended_at=ended_at,
-        pages_read=pages_read,
-        progress_percent=progress_percent,
+        title=title,
         note=note,
     )
     session.add(model)
@@ -88,51 +207,186 @@ def create_reading_session(
     return model
 
 
-def update_reading_session(
+def update_read_cycle(
     session: Session,
     *,
     user_id: uuid.UUID,
-    session_id: uuid.UUID,
+    cycle_id: uuid.UUID,
     started_at: dt.datetime | None,
     ended_at: dt.datetime | None,
-    pages_read: int | None,
-    progress_percent: float | None,
+    title: str | None,
     note: str | None,
 ) -> ReadingSession:
-    model = session.scalar(
-        sa.select(ReadingSession).where(
-            ReadingSession.id == session_id,
-            ReadingSession.user_id == user_id,
-        )
-    )
-    if model is None:
-        raise LookupError("session not found")
-
+    model = _get_cycle(session, user_id=user_id, cycle_id=cycle_id)
     if started_at is not None:
         model.started_at = started_at
     if ended_at is not None:
         model.ended_at = ended_at
-    if pages_read is not None:
-        model.pages_read = pages_read
-    if progress_percent is not None:
-        model.progress_percent = progress_percent
+    if title is not None:
+        model.title = title
     if note is not None:
         model.note = note
-
     session.commit()
     return model
 
 
-def delete_reading_session(
-    session: Session, *, user_id: uuid.UUID, session_id: uuid.UUID
+def delete_read_cycle(
+    session: Session, *, user_id: uuid.UUID, cycle_id: uuid.UUID
 ) -> None:
+    model = _get_cycle(session, user_id=user_id, cycle_id=cycle_id)
+    session.delete(model)
+    session.commit()
+
+
+def list_progress_logs(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    cycle_id: uuid.UUID,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    cycle = _get_cycle(session, user_id=user_id, cycle_id=cycle_id)
+    total_pages, total_audio_minutes = _get_item_totals(
+        session, library_item_id=cycle.library_item_id
+    )
+    rows = session.execute(
+        sa.select(ReadingProgressLog)
+        .where(
+            ReadingProgressLog.user_id == user_id,
+            ReadingProgressLog.reading_session_id == cycle_id,
+        )
+        .order_by(ReadingProgressLog.logged_at.desc(), ReadingProgressLog.id.desc())
+        .limit(limit)
+    ).scalars()
+    return [
+        _serialize_log(
+            row,
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        )
+        for row in rows
+    ]
+
+
+def create_progress_log(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    cycle_id: uuid.UUID,
+    unit: ProgressUnit,
+    value: float,
+    logged_at: dt.datetime | None,
+    note: str | None,
+) -> ReadingProgressLog:
+    cycle = _get_cycle(session, user_id=user_id, cycle_id=cycle_id)
+    total_pages, total_audio_minutes = _get_item_totals(
+        session, library_item_id=cycle.library_item_id
+    )
+    canonical_percent = _canonical_percent(
+        unit=unit,
+        value=value,
+        total_pages=total_pages,
+        total_audio_minutes=total_audio_minutes,
+    )
+    model = ReadingProgressLog(
+        user_id=user_id,
+        library_item_id=cycle.library_item_id,
+        reading_session_id=cycle.id,
+        logged_at=logged_at or dt.datetime.now(tz=dt.UTC),
+        unit=unit,
+        value=value,
+        canonical_percent=canonical_percent,
+        note=note,
+    )
+    session.add(model)
+    session.commit()
+    return model
+
+
+def update_progress_log(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    log_id: uuid.UUID,
+    unit: ProgressUnit | None,
+    value: float | None,
+    logged_at: dt.datetime | None,
+    note: str | None,
+) -> ReadingProgressLog:
     model = session.scalar(
-        sa.select(ReadingSession).where(
-            ReadingSession.id == session_id,
-            ReadingSession.user_id == user_id,
+        sa.select(ReadingProgressLog).where(
+            ReadingProgressLog.id == log_id,
+            ReadingProgressLog.user_id == user_id,
         )
     )
     if model is None:
-        raise LookupError("session not found")
+        raise LookupError("progress log not found")
+
+    if logged_at is not None:
+        model.logged_at = logged_at
+    if note is not None:
+        model.note = note
+
+    if unit is not None:
+        model.unit = unit
+    if value is not None:
+        model.value = value
+
+    if unit is not None or value is not None:
+        total_pages, total_audio_minutes = _get_item_totals(
+            session, library_item_id=model.library_item_id
+        )
+        model.canonical_percent = _canonical_percent(
+            unit=model.unit,  # type: ignore[arg-type]
+            value=float(model.value),
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        )
+    session.commit()
+    return model
+
+
+def delete_progress_log(
+    session: Session, *, user_id: uuid.UUID, log_id: uuid.UUID
+) -> None:
+    model = session.scalar(
+        sa.select(ReadingProgressLog).where(
+            ReadingProgressLog.id == log_id,
+            ReadingProgressLog.user_id == user_id,
+        )
+    )
+    if model is None:
+        raise LookupError("progress log not found")
     session.delete(model)
     session.commit()
+
+
+def get_or_create_import_cycle(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    library_item_id: uuid.UUID,
+    marker: str,
+    started_at: dt.datetime,
+    ended_at: dt.datetime | None,
+) -> ReadingSession:
+    existing = session.scalar(
+        sa.select(ReadingSession).where(
+            ReadingSession.user_id == user_id,
+            ReadingSession.library_item_id == library_item_id,
+            ReadingSession.note == marker,
+        )
+    )
+    if existing is not None:
+        return existing
+
+    model = ReadingSession(
+        user_id=user_id,
+        library_item_id=library_item_id,
+        started_at=started_at,
+        ended_at=ended_at,
+        note=marker,
+    )
+    session.add(model)
+    session.flush()
+    return model

--- a/apps/api/app/services/storygraph_imports.py
+++ b/apps/api/app/services/storygraph_imports.py
@@ -13,10 +13,10 @@ from sqlalchemy.orm import Session
 from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
 from app.db.models.external_provider import ExternalId
 from app.db.models.imports import StorygraphImportJob, StorygraphImportJobRow
-from app.db.models.users import ReadingSession
 from app.db.session import create_db_session
 from app.services.catalog import import_openlibrary_bundle
 from app.services.open_library import OpenLibraryClient
+from app.services.reading_sessions import get_or_create_import_cycle
 from app.services.reviews import upsert_review_for_work
 from app.services.storygraph_parser import (
     StorygraphCsvError,
@@ -513,26 +513,15 @@ async def process_storygraph_import_job(
                 if session_bounds:
                     started_at, ended_at = session_bounds
                     marker = f"storygraph:{row.identity_hash}"
-                    existing_session = session.scalar(
-                        sa.select(ReadingSession).where(
-                            ReadingSession.user_id == user_id,
-                            ReadingSession.library_item_id == library_item.id,
-                            ReadingSession.note == marker,
-                        )
+                    cycle = get_or_create_import_cycle(
+                        session,
+                        user_id=user_id,
+                        library_item_id=library_item.id,
+                        marker=marker,
+                        started_at=started_at,
+                        ended_at=ended_at,
                     )
-                    if existing_session is None:
-                        model = ReadingSession(
-                            user_id=user_id,
-                            library_item_id=library_item.id,
-                            started_at=started_at,
-                            ended_at=ended_at,
-                            note=marker,
-                        )
-                        session.add(model)
-                        session.flush()
-                        reading_session_id = model.id
-                    else:
-                        reading_session_id = existing_session.id
+                    reading_session_id = cycle.id
 
                 _record_row(
                     session,

--- a/apps/api/app/services/works.py
+++ b/apps/api/app/services/works.py
@@ -70,6 +70,14 @@ def get_work_detail(session: Session, *, work_id: uuid.UUID) -> dict[str, Any]:
         "description": work.description,
         "first_publish_year": work.first_publish_year,
         "cover_url": cover_url,
+        "total_pages": (
+            selected_edition.total_pages if selected_edition is not None else None
+        ),
+        "total_audio_minutes": (
+            selected_edition.total_audio_minutes
+            if selected_edition is not None
+            else None
+        ),
         "authors": [{"id": str(a.id), "name": a.name} for a in authors],
         "identifiers": {
             "isbn10": selected_edition.isbn10 if selected_edition else None,
@@ -118,6 +126,8 @@ def list_work_editions(
                 "publish_date": (
                     edition.publish_date.isoformat() if edition.publish_date else None
                 ),
+                "total_pages": edition.total_pages,
+                "total_audio_minutes": edition.total_audio_minutes,
                 "cover_url": edition.cover_url,
                 "created_at": edition.created_at.isoformat(),
                 "provider": provider,

--- a/apps/api/tests/test_bibliography_models.py
+++ b/apps/api/tests/test_bibliography_models.py
@@ -59,6 +59,8 @@ def test_edition_table_schema_and_indexes() -> None:
         "publish_date",
         "language",
         "format",
+        "total_pages",
+        "total_audio_minutes",
         "cover_url",
         "cover_set_by",
         "cover_set_at",
@@ -74,6 +76,8 @@ def test_edition_table_schema_and_indexes() -> None:
     assert isinstance(table.columns["publish_date"].type, sa.Date)
     assert isinstance(table.columns["language"].type, sa.String)
     assert isinstance(table.columns["format"].type, sa.String)
+    assert isinstance(table.columns["total_pages"].type, sa.Integer)
+    assert isinstance(table.columns["total_audio_minutes"].type, sa.Integer)
     assert isinstance(table.columns["cover_url"].type, sa.Text)
 
     fk_targets = {fk.column.table.name for fk in table.foreign_keys}
@@ -82,6 +86,14 @@ def test_edition_table_schema_and_indexes() -> None:
     index_names = {index.name for index in table.indexes}
     assert "ix_editions_isbn10" in index_names
     assert "ix_editions_isbn13" in index_names
+    check_constraints = [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, sa.CheckConstraint)
+    ]
+    check_names = {constraint.name for constraint in check_constraints}
+    assert "ck_editions_total_pages_positive" in check_names
+    assert "ck_editions_total_audio_minutes_positive" in check_names
 
 
 def test_work_authors_composite_key() -> None:

--- a/apps/api/tests/test_reading_sessions_service.py
+++ b/apps/api/tests/test_reading_sessions_service.py
@@ -2,21 +2,29 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
-from typing import Any
+from typing import Any, cast
 
+import pytest
 import sqlalchemy as sa
 
-from app.db.models.users import ReadingSession
+from app.db.models.users import ReadingProgressLog, ReadingSession
 from app.services.reading_sessions import (
-    create_reading_session,
-    delete_reading_session,
-    list_reading_sessions,
-    update_reading_session,
+    _canonical_percent,
+    _get_item_totals,
+    create_progress_log,
+    create_read_cycle,
+    delete_progress_log,
+    delete_read_cycle,
+    get_or_create_import_cycle,
+    list_progress_logs,
+    list_read_cycles,
+    update_progress_log,
+    update_read_cycle,
 )
 
 
 class _ScalarIter:
-    def __init__(self, rows: list[ReadingSession]) -> None:
+    def __init__(self, rows: list[Any]) -> None:
         self._rows = rows
 
     def __iter__(self) -> Any:
@@ -24,19 +32,26 @@ class _ScalarIter:
 
 
 class _ExecResult:
-    def __init__(self, rows: list[ReadingSession]) -> None:
+    def __init__(self, rows: list[Any]) -> None:
         self._rows = rows
 
     def scalars(self) -> _ScalarIter:
         return _ScalarIter(self._rows)
 
+    def first(self) -> Any:
+        if not self._rows:
+            return None
+        return self._rows[0]
+
 
 class FakeSession:
     def __init__(self) -> None:
         self.scalar_values: list[Any] = []
+        self.execute_values: list[Any] = []
         self.added: list[Any] = []
         self.deleted: list[Any] = []
         self.committed = False
+        self.flushed = False
 
     def scalar(self, _stmt: sa.Select[Any]) -> Any:
         if self.scalar_values:
@@ -44,7 +59,7 @@ class FakeSession:
         return None
 
     def execute(self, _stmt: sa.Select[Any]) -> _ExecResult:
-        rows = self.scalar_values.pop(0)
+        rows = self.execute_values.pop(0)
         return _ExecResult(rows)
 
     def add(self, obj: Any) -> None:
@@ -55,145 +70,422 @@ class FakeSession:
     def delete(self, obj: Any) -> None:
         self.deleted.append(obj)
 
+    def flush(self) -> None:
+        self.flushed = True
+
     def commit(self) -> None:
         self.committed = True
 
 
-def test_list_create_update_delete_reading_sessions() -> None:
+def test_cycle_crud_and_list() -> None:
     user_id = uuid.uuid4()
     item_id = uuid.uuid4()
-    sess_id = uuid.uuid4()
+    cycle_id = uuid.uuid4()
     started = dt.datetime(2026, 2, 8, tzinfo=dt.UTC)
 
-    # list: ownership check returns item id, then execute returns one session
     session = FakeSession()
-    session.scalar_values = [
-        item_id,
+    session.scalar_values = [object()]
+    session.execute_values = [
+        [(320, 600)],
         [
             ReadingSession(
-                id=sess_id,
+                id=cycle_id,
                 user_id=user_id,
                 library_item_id=item_id,
                 started_at=started,
                 ended_at=None,
-                pages_read=1,
-                progress_percent=None,
+                title=None,
                 note=None,
                 created_at=started,
                 updated_at=started,
             )
         ],
     ]
-    rows = list_reading_sessions(
-        session,  # type: ignore[arg-type]
+    rows = list_read_cycles(
+        cast(Any, session),
         user_id=user_id,
         library_item_id=item_id,
         limit=10,
     )
-    assert rows[0]["id"] == str(sess_id)
+    assert rows[0]["id"] == str(cycle_id)
+    assert rows[0]["conversion"]["can_convert_pages_minutes"] is True
 
-    # create: ownership check returns item id
     session = FakeSession()
-    session.scalar_values = [item_id]
-    created = create_reading_session(
-        session,  # type: ignore[arg-type]
+    session.scalar_values = [object()]
+    created = create_read_cycle(
+        cast(Any, session),
         user_id=user_id,
         library_item_id=item_id,
         started_at=started,
         ended_at=None,
-        pages_read=2,
-        progress_percent=10.0,
+        title="Read #1",
         note="n",
     )
     assert session.committed is True
     assert created.id is not None
 
-    # update: scalar returns model
     session = FakeSession()
     model = ReadingSession(
-        id=sess_id,
+        id=cycle_id,
         user_id=user_id,
         library_item_id=item_id,
         started_at=started,
         ended_at=None,
-        pages_read=None,
-        progress_percent=None,
+        title=None,
         note=None,
         created_at=started,
         updated_at=started,
     )
     session.scalar_values = [model]
-    updated = update_reading_session(
-        session,  # type: ignore[arg-type]
+    updated = update_read_cycle(
+        cast(Any, session),
         user_id=user_id,
-        session_id=sess_id,
+        cycle_id=cycle_id,
         started_at=None,
         ended_at=None,
-        pages_read=5,
-        progress_percent=None,
+        title="updated",
         note="ok",
     )
-    assert updated.pages_read == 5
+    assert updated.title == "updated"
 
-    # delete: scalar returns model
     session = FakeSession()
     session.scalar_values = [model]
-    delete_reading_session(
-        session,  # type: ignore[arg-type]
-        user_id=user_id,
-        session_id=sess_id,
-    )
+    delete_read_cycle(cast(Any, session), user_id=user_id, cycle_id=cycle_id)
     assert session.deleted
     assert session.committed is True
 
 
-def test_reading_session_errors() -> None:
+def test_progress_log_crud_and_list() -> None:
     user_id = uuid.uuid4()
     item_id = uuid.uuid4()
-    sess_id = uuid.uuid4()
+    cycle_id = uuid.uuid4()
+    log_id = uuid.uuid4()
+    started = dt.datetime(2026, 2, 8, tzinfo=dt.UTC)
+
+    session = FakeSession()
+    session.scalar_values = [
+        ReadingSession(
+            id=cycle_id,
+            user_id=user_id,
+            library_item_id=item_id,
+            started_at=started,
+            ended_at=None,
+            title=None,
+            note=None,
+            created_at=started,
+            updated_at=started,
+        )
+    ]
+    session.execute_values = [
+        [(200, 400)],
+        [
+            ReadingProgressLog(
+                id=log_id,
+                user_id=user_id,
+                library_item_id=item_id,
+                reading_session_id=cycle_id,
+                logged_at=started,
+                unit="percent_complete",
+                value=10,
+                canonical_percent=10,
+                note=None,
+                created_at=started,
+                updated_at=started,
+            )
+        ],
+    ]
+    rows = list_progress_logs(
+        cast(Any, session),
+        user_id=user_id,
+        cycle_id=cycle_id,
+        limit=10,
+    )
+    assert rows[0]["canonical_percent"] == 10.0
+
+    session = FakeSession()
+    session.scalar_values = [
+        ReadingSession(
+            id=cycle_id,
+            user_id=user_id,
+            library_item_id=item_id,
+            started_at=started,
+            ended_at=None,
+            title=None,
+            note=None,
+            created_at=started,
+            updated_at=started,
+        )
+    ]
+    session.execute_values = [[(100, 300)]]
+    created = create_progress_log(
+        cast(Any, session),
+        user_id=user_id,
+        cycle_id=cycle_id,
+        unit="pages_read",
+        value=30.0,
+        logged_at=started,
+        note="x",
+    )
+    assert session.committed is True
+    assert created.canonical_percent == 30.0
+
+    session = FakeSession()
+    model = ReadingProgressLog(
+        id=log_id,
+        user_id=user_id,
+        library_item_id=item_id,
+        reading_session_id=cycle_id,
+        logged_at=started,
+        unit="minutes_listened",
+        value=10,
+        canonical_percent=5,
+        note=None,
+        created_at=started,
+        updated_at=started,
+    )
+    session.scalar_values = [model]
+    session.execute_values = [[(None, None)]]
+    updated = update_progress_log(
+        cast(Any, session),
+        user_id=user_id,
+        log_id=log_id,
+        unit=None,
+        value=40.0,
+        logged_at=None,
+        note="ok",
+    )
+    assert updated.canonical_percent is None
+
+    session = FakeSession()
+    session.scalar_values = [model]
+    delete_progress_log(cast(Any, session), user_id=user_id, log_id=log_id)
+    assert session.deleted
+    assert session.committed is True
+
+
+def test_import_cycle_helper_reuses_or_creates() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle_id = uuid.uuid4()
+    started = dt.datetime(2026, 2, 8, tzinfo=dt.UTC)
+    marker = "goodreads:abc"
+
+    session = FakeSession()
+    existing = ReadingSession(
+        id=cycle_id,
+        user_id=user_id,
+        library_item_id=item_id,
+        started_at=started,
+        ended_at=None,
+        title=None,
+        note=marker,
+        created_at=started,
+        updated_at=started,
+    )
+    session.scalar_values = [existing]
+    model = get_or_create_import_cycle(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+        marker=marker,
+        started_at=started,
+        ended_at=None,
+    )
+    assert model.id == cycle_id
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    model = get_or_create_import_cycle(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+        marker=marker,
+        started_at=started,
+        ended_at=None,
+    )
+    assert model.id is not None
+    assert session.flushed is True
+
+
+def test_get_item_totals_prefers_preferred_then_fallback_then_none() -> None:
+    item_id = uuid.uuid4()
+
+    session = FakeSession()
+    session.execute_values = [[(111, 222)]]
+    assert _get_item_totals(cast(Any, session), library_item_id=item_id) == (111, 222)
+
+    session = FakeSession()
+    session.execute_values = [[], [(333, 444)]]
+    assert _get_item_totals(cast(Any, session), library_item_id=item_id) == (333, 444)
+
+    session = FakeSession()
+    session.execute_values = [[], []]
+    assert _get_item_totals(cast(Any, session), library_item_id=item_id) == (
+        None,
+        None,
+    )
+
+
+def test_canonical_percent_rules() -> None:
+    assert (
+        _canonical_percent(
+            unit="percent_complete",
+            value=25.0,
+            total_pages=None,
+            total_audio_minutes=None,
+        )
+        == 25.0
+    )
+    assert (
+        _canonical_percent(
+            unit="pages_read",
+            value=50.0,
+            total_pages=200,
+            total_audio_minutes=None,
+        )
+        == 25.0
+    )
+    assert (
+        _canonical_percent(
+            unit="minutes_listened",
+            value=30.0,
+            total_pages=None,
+            total_audio_minutes=120,
+        )
+        == 25.0
+    )
+    assert (
+        _canonical_percent(
+            unit="pages_read",
+            value=10.0,
+            total_pages=None,
+            total_audio_minutes=None,
+        )
+        is None
+    )
+    assert (
+        _canonical_percent(
+            unit="minutes_listened",
+            value=10.0,
+            total_pages=None,
+            total_audio_minutes=0,
+        )
+        is None
+    )
+    with pytest.raises(ValueError):
+        _canonical_percent(
+            unit="percent_complete",
+            value=120.0,
+            total_pages=None,
+            total_audio_minutes=None,
+        )
+
+
+def test_service_error_paths() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle_id = uuid.uuid4()
+    log_id = uuid.uuid4()
     started = dt.datetime(2026, 2, 8, tzinfo=dt.UTC)
 
     session = FakeSession()
     session.scalar_values = [None]
-    try:
-        list_reading_sessions(
-            session,  # type: ignore[arg-type]
+    with pytest.raises(LookupError):
+        list_read_cycles(
+            cast(Any, session), user_id=user_id, library_item_id=item_id, limit=10
+        )
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        create_read_cycle(
+            cast(Any, session),
             user_id=user_id,
             library_item_id=item_id,
-            limit=10,
-        )
-    except LookupError:
-        pass
-    else:
-        raise AssertionError("expected LookupError for missing library item")
-
-    session = FakeSession()
-    session.scalar_values = [None]
-    try:
-        update_reading_session(
-            session,  # type: ignore[arg-type]
-            user_id=user_id,
-            session_id=sess_id,
             started_at=started,
             ended_at=None,
-            pages_read=None,
-            progress_percent=None,
+            title=None,
             note=None,
         )
-    except LookupError:
-        pass
-    else:
-        raise AssertionError("expected LookupError for missing session")
 
     session = FakeSession()
     session.scalar_values = [None]
-    try:
-        delete_reading_session(
-            session,  # type: ignore[arg-type]
+    with pytest.raises(LookupError):
+        update_read_cycle(
+            cast(Any, session),
             user_id=user_id,
-            session_id=sess_id,
+            cycle_id=cycle_id,
+            started_at=None,
+            ended_at=None,
+            title=None,
+            note=None,
         )
-    except LookupError:
-        pass
-    else:
-        raise AssertionError("expected LookupError for missing session")
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        delete_read_cycle(cast(Any, session), user_id=user_id, cycle_id=cycle_id)
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        list_progress_logs(
+            cast(Any, session), user_id=user_id, cycle_id=cycle_id, limit=10
+        )
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        create_progress_log(
+            cast(Any, session),
+            user_id=user_id,
+            cycle_id=cycle_id,
+            unit="percent_complete",
+            value=10,
+            logged_at=None,
+            note=None,
+        )
+
+    session = FakeSession()
+    session.scalar_values = [
+        ReadingSession(
+            id=cycle_id,
+            user_id=user_id,
+            library_item_id=item_id,
+            started_at=started,
+            ended_at=None,
+            title=None,
+            note=None,
+            created_at=started,
+            updated_at=started,
+        )
+    ]
+    session.execute_values = [[(None, None)]]
+    with pytest.raises(ValueError):
+        create_progress_log(
+            cast(Any, session),
+            user_id=user_id,
+            cycle_id=cycle_id,
+            unit="percent_complete",
+            value=101,
+            logged_at=None,
+            note=None,
+        )
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        update_progress_log(
+            cast(Any, session),
+            user_id=user_id,
+            log_id=log_id,
+            unit=None,
+            value=None,
+            logged_at=None,
+            note=None,
+        )
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        delete_progress_log(cast(Any, session), user_id=user_id, log_id=log_id)

--- a/apps/api/tests/test_works_service.py
+++ b/apps/api/tests/test_works_service.py
@@ -93,6 +93,8 @@ def test_get_work_detail_uses_edition_cover_when_present() -> None:
 
     detail = get_work_detail(session, work_id=work_id)  # type: ignore[arg-type]
     assert detail["cover_url"] == "https://example.com/edition.jpg"
+    assert detail["total_pages"] is None
+    assert detail["total_audio_minutes"] is None
     assert detail["authors"][0]["name"] == "Author"
     assert detail["identifiers"]["isbn13"] == "9781234567890"
     assert detail["identifiers"]["asin"] == "B00TESTASIN"
@@ -114,6 +116,8 @@ def test_get_work_detail_falls_back_to_work_default_cover() -> None:
 
     detail = get_work_detail(session, work_id=work_id)  # type: ignore[arg-type]
     assert detail["cover_url"] == "https://example.com/default.jpg"
+    assert detail["total_pages"] is None
+    assert detail["total_audio_minutes"] is None
     assert detail["identifiers"]["isbn10"] is None
     assert detail["identifiers"]["isbn13"] is None
 
@@ -157,6 +161,8 @@ def test_list_work_editions_returns_rows() -> None:
     rows = list_work_editions(session, work_id=work_id, limit=20)  # type: ignore[arg-type]
     assert rows[0]["id"] == str(edition.id)
     assert rows[0]["provider"] == "openlibrary"
+    assert rows[0]["total_pages"] is None
+    assert rows[0]["total_audio_minutes"] is None
 
 
 def test_list_work_editions_raises_when_work_missing() -> None:

--- a/supabase/migrations/20260216120000_reading_sessions_v2_foundation.sql
+++ b/supabase/migrations/20260216120000_reading_sessions_v2_foundation.sql
@@ -1,0 +1,72 @@
+-- Reading Sessions v2 foundation: read cycles + progress logs.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'reading_progress_unit'
+  ) THEN
+    CREATE TYPE public.reading_progress_unit AS ENUM (
+      'pages_read',
+      'percent_complete',
+      'minutes_listened'
+    );
+  END IF;
+END $$;
+
+ALTER TABLE public.editions
+  ADD COLUMN IF NOT EXISTS total_pages integer,
+  ADD COLUMN IF NOT EXISTS total_audio_minutes integer;
+
+ALTER TABLE public.editions
+  DROP CONSTRAINT IF EXISTS ck_editions_total_pages_positive,
+  ADD CONSTRAINT ck_editions_total_pages_positive
+    CHECK (total_pages IS NULL OR total_pages >= 1),
+  DROP CONSTRAINT IF EXISTS ck_editions_total_audio_minutes_positive,
+  ADD CONSTRAINT ck_editions_total_audio_minutes_positive
+    CHECK (total_audio_minutes IS NULL OR total_audio_minutes >= 1);
+
+ALTER TABLE public.reading_sessions
+  ADD COLUMN IF NOT EXISTS title varchar(255);
+
+ALTER TABLE public.reading_sessions
+  DROP CONSTRAINT IF EXISTS ck_reading_sessions_pages_read_nonnegative,
+  DROP CONSTRAINT IF EXISTS ck_reading_sessions_progress_percent_range;
+
+ALTER TABLE public.reading_sessions
+  DROP COLUMN IF EXISTS pages_read,
+  DROP COLUMN IF EXISTS progress_percent;
+
+CREATE TABLE IF NOT EXISTS public.reading_progress_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  library_item_id uuid NOT NULL REFERENCES public.library_items(id) ON DELETE CASCADE,
+  reading_session_id uuid NOT NULL REFERENCES public.reading_sessions(id) ON DELETE CASCADE,
+  logged_at timestamptz NOT NULL,
+  unit public.reading_progress_unit NOT NULL,
+  value numeric(10,2) NOT NULL,
+  canonical_percent numeric(6,3),
+  note text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ck_reading_progress_logs_value_nonnegative CHECK (value >= 0),
+  CONSTRAINT ck_reading_progress_logs_canonical_percent_range
+    CHECK (canonical_percent IS NULL OR (canonical_percent >= 0 AND canonical_percent <= 100))
+);
+
+CREATE INDEX IF NOT EXISTS ix_reading_progress_logs_user_id
+  ON public.reading_progress_logs (user_id);
+CREATE INDEX IF NOT EXISTS ix_reading_progress_logs_library_item_logged_at
+  ON public.reading_progress_logs (library_item_id, logged_at DESC);
+CREATE INDEX IF NOT EXISTS ix_reading_progress_logs_session_logged_at
+  ON public.reading_progress_logs (reading_session_id, logged_at DESC);
+
+ALTER TABLE public.reading_progress_logs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS reading_progress_logs_owner ON public.reading_progress_logs;
+CREATE POLICY reading_progress_logs_owner
+ON public.reading_progress_logs
+FOR ALL
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
Implements issue #144 by introducing the Reading Sessions v2 backend foundation:

- Migrates `reading_sessions` to read-cycle semantics
- Adds `reading_progress_logs` with unit-aware values and canonical percent
- Adds edition totals metadata (`total_pages`, `total_audio_minutes`)
- Replaces v1 sessions API surface with v2 read-cycle/progress-log endpoints
- Updates Goodreads/StoryGraph imports to create/reuse v2 cycles

## API Changes
### Removed v1 behavior
- `/api/v1/library/items/{library_item_id}/sessions`
- `/api/v1/sessions/{session_id}`

### Added v2 endpoints
- `GET /api/v1/library/items/{library_item_id}/read-cycles`
- `POST /api/v1/library/items/{library_item_id}/read-cycles`
- `PATCH /api/v1/read-cycles/{cycle_id}`
- `DELETE /api/v1/read-cycles/{cycle_id}`
- `GET /api/v1/read-cycles/{cycle_id}/progress-logs`
- `POST /api/v1/read-cycles/{cycle_id}/progress-logs`
- `PATCH /api/v1/progress-logs/{log_id}`
- `DELETE /api/v1/progress-logs/{log_id}`

## Data Model Changes
- `reading_sessions`
  - removed: `pages_read`, `progress_percent`
  - added: `title`
- new `reading_progress_logs`
  - fields: `unit`, `value`, `canonical_percent`, `logged_at`, `note`
  - constraints: non-negative values, canonical percent range
  - indexes: user, library-item+timestamp, session+timestamp
  - RLS owner policy added
- `editions`
  - added: `total_pages`, `total_audio_minutes` (+ positive checks)

## Migrations
- Alembic: `apps/api/alembic/versions/0016_reading_sessions_v2_foundation.py`
- Supabase SQL: `supabase/migrations/20260216120000_reading_sessions_v2_foundation.sql`

## Import Compatibility
- StoryGraph and Goodreads imports now use shared cycle helper:
  - creates one cycle per imported row (or reuses by marker)
  - preserves `session_id` semantics in import job row outputs

## Validation/Conversion Behavior
- Supported progress units:
  - `pages_read`
  - `percent_complete`
  - `minutes_listened`
- Canonicalization:
  - `percent_complete` -> canonical percent directly
  - `pages_read` -> canonical percent when `total_pages` exists
  - `minutes_listened` -> canonical percent when `total_audio_minutes` exists
  - missing denominator -> raw value accepted, canonical percent `null`

## Verification
- `make quality` passes locally
- Includes API/unit/integration test updates for:
  - schema/model assertions
  - v2 service behavior
  - v2 router behavior
  - RLS coverage for new table (with local-schema compatibility skip)
  - work detail/edition response updates

Closes #144
