### PR TITLE
Implement issue #145: Reading Sessions v2 UX + totals/default-unit support

### DIFF
--- a/apps/api/alembic/versions/0017_user_default_progress_unit.py
+++ b/apps/api/alembic/versions/0017_user_default_progress_unit.py
@@ -1,0 +1,53 @@
+"""Add per-user default progress unit preference.
+
+Revision ID: 0017_user_default_progress_unit
+Revises: 0016_reading_sessions_v2
+Create Date: 2026-02-16
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0017_user_default_progress_unit"
+down_revision = "0016_reading_sessions_v2"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = inspector.get_columns(table_name)
+    return any(column["name"] == column_name for column in columns)
+
+
+def upgrade() -> None:
+    if _column_exists("users", "default_progress_unit"):
+        return
+
+    reading_progress_unit = postgresql.ENUM(
+        "pages_read",
+        "percent_complete",
+        "minutes_listened",
+        name="reading_progress_unit",
+        create_type=False,
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "default_progress_unit",
+            reading_progress_unit,
+            nullable=False,
+            server_default=sa.text("'pages_read'::reading_progress_unit"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    if not _column_exists("users", "default_progress_unit"):
+        return
+
+    op.drop_column("users", "default_progress_unit")

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -58,6 +58,11 @@ class User(Base):
         nullable=False,
         server_default=sa.text("false"),
     )
+    default_progress_unit: Mapped[str] = mapped_column(
+        reading_progress_unit_enum,
+        nullable=False,
+        server_default=sa.text("'pages_read'::reading_progress_unit"),
+    )
     actor_uri: Mapped[str | None] = mapped_column(sa.Text)
     created_at: Mapped[dt.datetime] = mapped_column(
         sa.DateTime(timezone=True),

--- a/apps/api/app/routers/me.py
+++ b/apps/api/app/routers/me.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -18,6 +18,9 @@ class UpdateProfileRequest(BaseModel):
     display_name: str | None = Field(default=None, max_length=255)
     avatar_url: str | None = Field(default=None, max_length=2048)
     enable_google_books: bool | None = None
+    default_progress_unit: (
+        Literal["pages_read", "percent_complete", "minutes_listened"] | None
+    ) = None
 
 
 router = APIRouter(
@@ -40,6 +43,7 @@ def get_me(
             "display_name": profile.display_name,
             "avatar_url": profile.avatar_url,
             "enable_google_books": profile.enable_google_books,
+            "default_progress_unit": profile.default_progress_unit,
         }
     )
 
@@ -58,6 +62,7 @@ def patch_me(
             display_name=payload.display_name,
             avatar_url=payload.avatar_url,
             enable_google_books=payload.enable_google_books,
+            default_progress_unit=payload.default_progress_unit,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -69,5 +74,6 @@ def patch_me(
             "display_name": profile.display_name,
             "avatar_url": profile.avatar_url,
             "enable_google_books": profile.enable_google_books,
+            "default_progress_unit": profile.default_progress_unit,
         }
     )

--- a/apps/api/app/services/editions.py
+++ b/apps/api/app/services/editions.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.bibliography import Edition
+from app.db.models.users import LibraryItem
+
+
+def update_edition_totals(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    edition_id: uuid.UUID,
+    updates: dict[str, int | None],
+) -> Edition:
+    if not updates:
+        raise ValueError(
+            "at least one of total_pages or total_audio_minutes is required"
+        )
+
+    edition = session.get(Edition, edition_id)
+    if edition is None:
+        raise LookupError("edition not found")
+
+    has_membership = session.scalar(
+        sa.select(LibraryItem.id).where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.work_id == edition.work_id,
+        )
+    )
+    if has_membership is None:
+        raise PermissionError("book must be in your library to update edition totals")
+
+    if "total_pages" in updates:
+        total_pages = updates["total_pages"]
+        if total_pages is not None and total_pages < 1:
+            raise ValueError("total_pages must be at least 1")
+        edition.total_pages = total_pages
+
+    if "total_audio_minutes" in updates:
+        total_audio_minutes = updates["total_audio_minutes"]
+        if total_audio_minutes is not None and total_audio_minutes < 1:
+            raise ValueError("total_audio_minutes must be at least 1")
+        edition.total_audio_minutes = total_audio_minutes
+
+    session.commit()
+    return edition

--- a/apps/api/app/services/google_books.py
+++ b/apps/api/app/services/google_books.py
@@ -321,6 +321,7 @@ class GoogleBooksClient:
         isbn13 = _extract_isbn(identifiers, isbn_type="ISBN_13")
         publisher = volume_info.get("publisher")
         print_type = volume_info.get("printType")
+        page_count = volume_info.get("pageCount")
         info_link = volume_info.get("canonicalVolumeLink")
         if not isinstance(info_link, str) or not info_link.strip():
             info_link = volume_info.get("infoLink")
@@ -344,6 +345,11 @@ class GoogleBooksClient:
                 "format": (
                     print_type.strip().lower()
                     if isinstance(print_type, str) and print_type.strip()
+                    else None
+                ),
+                "total_pages": (
+                    int(page_count)
+                    if isinstance(page_count, int) and page_count > 0
                     else None
                 ),
             }

--- a/apps/api/app/services/user_library.py
+++ b/apps/api/app/services/user_library.py
@@ -19,9 +19,15 @@ LibraryItemStatus: TypeAlias = Literal[
     "abandoned",
 ]
 LibraryItemVisibility: TypeAlias = Literal["private", "public"]
+ProgressUnit: TypeAlias = Literal[
+    "pages_read",
+    "percent_complete",
+    "minutes_listened",
+]
 
 DEFAULT_LIBRARY_STATUS: LibraryItemStatus = "to_read"
 DEFAULT_LIBRARY_VISIBILITY: LibraryItemVisibility = "private"
+DEFAULT_PROGRESS_UNIT: ProgressUnit = "pages_read"
 LibraryItemSortMode: TypeAlias = Literal[
     "newest",
     "oldest",
@@ -51,6 +57,7 @@ def get_or_create_profile(session: Session, *, user_id: uuid.UUID) -> User:
         display_name=None,
         avatar_url=None,
         enable_google_books=False,
+        default_progress_unit=DEFAULT_PROGRESS_UNIT,
     )
     session.add(profile)
     session.commit()
@@ -65,6 +72,7 @@ def update_profile(
     display_name: str | None,
     avatar_url: str | None,
     enable_google_books: bool | None,
+    default_progress_unit: ProgressUnit | None,
 ) -> User:
     profile = get_or_create_profile(session, user_id=user_id)
 
@@ -87,6 +95,9 @@ def update_profile(
 
     if enable_google_books is not None:
         profile.enable_google_books = enable_google_books
+
+    if default_progress_unit is not None:
+        profile.default_progress_unit = default_progress_unit
 
     session.commit()
     return profile

--- a/apps/api/tests/test_editions_service.py
+++ b/apps/api/tests/test_editions_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from app.services.editions import update_edition_totals
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.edition: Any = None
+        self.scalar_value: Any = None
+        self.committed = False
+
+    def get(self, _model: type[Any], _key: Any) -> Any:
+        return self.edition
+
+    def scalar(self, _stmt: Any) -> Any:
+        return self.scalar_value
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def test_update_edition_totals_requires_updates() -> None:
+    session = FakeSession()
+    with pytest.raises(ValueError):
+        update_edition_totals(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            edition_id=uuid.uuid4(),
+            updates={},
+        )
+
+
+def test_update_edition_totals_requires_existing_edition() -> None:
+    session = FakeSession()
+    with pytest.raises(LookupError):
+        update_edition_totals(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            edition_id=uuid.uuid4(),
+            updates={"total_pages": 100},
+        )
+
+
+def test_update_edition_totals_requires_library_membership() -> None:
+    session = FakeSession()
+    session.edition = SimpleNamespace(
+        id=uuid.uuid4(),
+        work_id=uuid.uuid4(),
+        total_pages=100,
+        total_audio_minutes=200,
+    )
+    session.scalar_value = None
+    with pytest.raises(PermissionError):
+        update_edition_totals(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            edition_id=uuid.uuid4(),
+            updates={"total_pages": 120},
+        )
+
+
+def test_update_edition_totals_validates_positive_values() -> None:
+    session = FakeSession()
+    session.edition = SimpleNamespace(
+        id=uuid.uuid4(),
+        work_id=uuid.uuid4(),
+        total_pages=100,
+        total_audio_minutes=200,
+    )
+    session.scalar_value = uuid.uuid4()
+
+    with pytest.raises(ValueError):
+        update_edition_totals(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            edition_id=uuid.uuid4(),
+            updates={"total_pages": 0},
+        )
+
+    with pytest.raises(ValueError):
+        update_edition_totals(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            edition_id=uuid.uuid4(),
+            updates={"total_audio_minutes": 0},
+        )
+
+
+def test_update_edition_totals_updates_and_allows_null() -> None:
+    edition = SimpleNamespace(
+        id=uuid.uuid4(),
+        work_id=uuid.uuid4(),
+        total_pages=100,
+        total_audio_minutes=200,
+    )
+    session = FakeSession()
+    session.edition = edition
+    session.scalar_value = uuid.uuid4()
+
+    updated = update_edition_totals(
+        cast(Any, session),
+        user_id=uuid.uuid4(),
+        edition_id=cast(uuid.UUID, edition.id),
+        updates={"total_pages": 250, "total_audio_minutes": None},
+    )
+
+    assert cast(Any, updated).id == edition.id
+    assert edition.total_pages == 250
+    assert edition.total_audio_minutes is None
+    assert session.committed is True

--- a/apps/api/tests/test_open_library_service.py
+++ b/apps/api/tests/test_open_library_service.py
@@ -8,10 +8,17 @@ import pytest
 
 from app.services.open_library import (
     OpenLibraryClient,
+    _extract_duration_minutes,
     _extract_language_codes,
+    _extract_top_subjects,
+    _is_audiobook_entry,
     _normalize_edition_key,
     _normalize_work_key,
+    _parse_duration_from_notes,
+    _parse_duration_minutes,
+    _parse_numeric_token,
     _parse_publish_year,
+    _TTLCache,
 )
 
 
@@ -121,6 +128,33 @@ def test_search_books_supports_fielded_filters() -> None:
     assert "first_publish_year:[* TO 2005]" in seen_params[0]["q"]
 
 
+def test_ttl_cache_evicts_oldest_and_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = {"value": 1000.0}
+
+    def fake_time() -> float:
+        return now["value"]
+
+    monkeypatch.setattr("app.services.open_library.time.time", fake_time)
+    cache: _TTLCache[int] = _TTLCache(ttl_seconds=1, max_entries=1)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    now["value"] = 1002.0
+    assert cache.get("b") is None
+
+
+def test_normalize_key_helpers_raise_on_invalid_values() -> None:
+    with pytest.raises(ValueError):
+        _normalize_work_key("bad-key")
+    with pytest.raises(ValueError):
+        _normalize_edition_key("bad-key")
+
+
+def test_extract_language_codes_uses_code_field() -> None:
+    assert _extract_language_codes([{"code": "EN"}]) == ["en"]
+
+
 def test_fetch_work_bundle_collects_author_and_first_edition() -> None:
     responses = {
         "/works/OL1W.json": {
@@ -214,6 +248,29 @@ def test_fetch_work_bundle_falls_back_to_edition_cover_when_work_missing() -> No
     assert "/books/OL3M.json" in requests
 
 
+def test_fetch_work_bundle_skips_invalid_author_and_edition_entries() -> None:
+    responses = {
+        "/works/OL1W.json": {
+            "title": "Book",
+            "authors": ["bad", {"author": "bad"}, {"author": {"key": "/authors/OL2A"}}],
+            "covers": [],
+        },
+        "/authors/OL2A.json": {"name": "Author A"},
+        "/works/OL1W/editions.json": {"entries": ["bad", {"isbn_10": ["123"]}]},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    bundle = asyncio.run(client.fetch_work_bundle(work_key="OL1W"))
+    assert bundle.authors == [{"key": "/authors/OL2A", "name": "Author A"}]
+    assert bundle.edition is None
+
+
 def test_request_retries_on_5xx() -> None:
     calls = {"count": 0}
 
@@ -228,6 +285,15 @@ def test_request_retries_on_5xx() -> None:
 
     assert calls["count"] == 2
     assert result.items == []
+
+
+def test_request_raises_transport_error_after_max_retries() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network down", request=request)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler), max_retries=1)
+    with pytest.raises(httpx.ConnectError):
+        asyncio.run(client.search_books(query="retry"))
 
 
 def test_request_retries_on_429_respects_retry_after_header() -> None:
@@ -756,3 +822,190 @@ def test_fetch_work_audiobook_durations_parses_comma_separated_seconds() -> None
     client = OpenLibraryClient(transport=httpx.MockTransport(handler))
     durations = asyncio.run(client.fetch_work_audiobook_durations(work_key="OL1W"))
     assert durations == [pytest.approx(1721.4)]
+
+
+def test_parse_duration_minutes_supports_multiple_formats() -> None:
+    assert _parse_duration_minutes(90) == 90
+    assert _parse_duration_minutes(90.4) == 90
+    assert _parse_duration_minutes("10:30:00") == 630
+    assert _parse_duration_minutes("1:30:30") == 91
+    assert _parse_duration_minutes("8 hours") == 480
+    assert _parse_duration_minutes("630 minutes") == 630
+    assert _parse_duration_minutes("120 seconds") == pytest.approx(2.0)
+    assert _parse_duration_minutes("about 2hr runtime") == 120
+    assert _parse_duration_minutes("approx 45min") == 45
+    assert _parse_duration_minutes("n/a") is None
+
+
+def test_parse_duration_from_notes_handles_string_dict_and_list_shapes() -> None:
+    assert _parse_duration_from_notes("Duration in seconds: 3,723") == pytest.approx(
+        62.05
+    )
+    assert _parse_duration_from_notes(
+        {"value": "Duration in seconds = 3723"}
+    ) == pytest.approx(62.05)
+    assert _parse_duration_from_notes(
+        [{"text": "metadata"}, {"notes": "this recording is 600 seconds"}]
+    ) == pytest.approx(10.0)
+    assert _parse_duration_from_notes({"text": "no duration here"}) is None
+
+
+def test_extract_duration_minutes_prefers_duration_then_seconds_then_notes() -> None:
+    assert _extract_duration_minutes({"duration": "8 hours"}) == 480
+    assert _extract_duration_minutes({"duration_seconds": 3723}) == pytest.approx(62.05)
+    assert _extract_duration_minutes({"duration_in_seconds": "3,723"}) == pytest.approx(
+        62.05
+    )
+    assert _extract_duration_minutes(
+        {"notes": "Edition notes. Duration in seconds: 600"}
+    ) == pytest.approx(10.0)
+    assert _extract_duration_minutes({"notes": "unknown"}) is None
+
+
+def test_is_audiobook_entry_detects_audio_markers() -> None:
+    assert _is_audiobook_entry({"physical_format": "Audible eAudiobook"}) is True
+    assert _is_audiobook_entry({"format": "MP3 CD"}) is True
+    assert _is_audiobook_entry({"title": "Book", "subtitle": "sound recording"}) is True
+    assert _is_audiobook_entry({"format": "Hardcover"}) is False
+    assert _is_audiobook_entry({"format": None}) is False
+
+
+def test_find_work_key_by_isbn_handles_empty_and_unmatched_payloads() -> None:
+    responses = {
+        "/search.json": [
+            {"docs": []},
+            {"docs": ["bad-shape"]},
+            {"docs": [{"key": "/authors/OL1A"}]},
+            {"docs": [{"key": "/works/OL2W"}]},
+        ]
+    }
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path != "/search.json":
+            return httpx.Response(404, json={"error": "missing"})
+        index = calls["count"]
+        calls["count"] += 1
+        return httpx.Response(200, json=responses["/search.json"][index])
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    assert asyncio.run(client.find_work_key_by_isbn(isbn="")) is None
+    assert asyncio.run(client.find_work_key_by_isbn(isbn="978123")) is None
+    assert asyncio.run(client.find_work_key_by_isbn(isbn="978123")) is None
+    assert asyncio.run(client.find_work_key_by_isbn(isbn="978123")) is None
+    assert asyncio.run(client.find_work_key_by_isbn(isbn="978123")) == "/works/OL2W"
+
+
+def test_fetch_work_audiobook_durations_handles_non_dict_entry_and_bad_edition_key() -> (
+    None
+):
+    responses = {
+        "/works/OL1W/editions.json": {
+            "entries": [
+                "bad-entry",
+                {"physical_format": "Audible eAudiobook", "key": "not-a-book-key"},
+                {"physical_format": "Audible eAudiobook", "duration": "60 minutes"},
+            ]
+        }
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    durations = asyncio.run(client.fetch_work_audiobook_durations(work_key="OL1W"))
+    assert durations == [60]
+
+
+def test_fetch_cover_ids_for_work_skips_non_list_and_non_int_covers() -> None:
+    responses = {
+        "/works/OL1W.json": {"title": "Book", "covers": ["x", 9, None]},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    cover_ids = asyncio.run(client.fetch_cover_ids_for_work(work_key="OL1W"))
+    assert cover_ids == [9]
+
+
+def test_extract_top_subjects_handles_invalid_and_dedupes() -> None:
+    assert _extract_top_subjects({"subjects": "not-a-list"}) == []
+    assert _extract_top_subjects(
+        {"subjects": ["Epic Fantasy", "Epic Fantasy", 3, " Space Opera ", "Horror"]},
+        limit=2,
+    ) == ["epic_fantasy", "space_opera"]
+
+
+def test_parse_numeric_token_handles_empty_and_invalid_values() -> None:
+    assert _parse_numeric_token("") is None
+    assert _parse_numeric_token("  ") is None
+    assert _parse_numeric_token("not-a-number") is None
+    assert _parse_numeric_token("3,723") == pytest.approx(3723.0)
+
+
+def test_parse_duration_minutes_and_extract_duration_edge_branches() -> None:
+    assert _parse_duration_minutes("") is None
+    assert _parse_duration_minutes("0") is None
+    assert _parse_duration_minutes("0 seconds") is None
+    assert _parse_duration_minutes("nonsense 12") is None
+    assert _extract_duration_minutes({"duration_seconds": 0}) is None
+    assert _extract_duration_minutes({"duration_in_seconds": "invalid"}) is None
+
+
+def test_fetch_cover_ids_for_work_falls_back_when_work_covers_invalid() -> None:
+    responses = {
+        "/works/OL1W.json": {"title": "Book", "covers": [None, "x"]},
+        "/works/OL1W/editions.json": {
+            "entries": [
+                {"covers": "invalid"},
+                {"covers": [4, 5, "bad", 5]},
+            ]
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    cover_ids = asyncio.run(client.fetch_cover_ids_for_work(work_key="OL1W"))
+    assert cover_ids == [4, 5]
+
+
+def test_fetch_work_audiobook_durations_handles_bad_edition_detail_shape() -> None:
+    responses = {
+        "/works/OL1W/editions.json": {
+            "entries": [
+                {
+                    "key": "/books/OLA1M",
+                    "physical_format": "Audible eAudiobook",
+                },
+                {
+                    "key": "/books/OLA2M",
+                    "physical_format": "Audible eAudiobook",
+                },
+            ]
+        },
+        "/books/OLA1M.json": ["unexpected-list-shape"],
+        "/books/OLA2M.json": {"notes": "Duration in seconds: 600"},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(request.url.path)
+        if payload is None:
+            return httpx.Response(404, json={"error": "missing"})
+        return httpx.Response(200, json=payload)
+
+    client = OpenLibraryClient(transport=httpx.MockTransport(handler))
+    durations = asyncio.run(client.fetch_work_audiobook_durations(work_key="OL1W"))
+    assert durations == [pytest.approx(10.0)]

--- a/apps/api/tests/test_user_library_models.py
+++ b/apps/api/tests/test_user_library_models.py
@@ -32,6 +32,7 @@ def test_users_table_schema() -> None:
         "display_name",
         "avatar_url",
         "enable_google_books",
+        "default_progress_unit",
         "actor_uri",
         "created_at",
         "updated_at",
@@ -44,6 +45,12 @@ def test_users_table_schema() -> None:
     assert table.columns["display_name"].type.length == 255
     assert isinstance(table.columns["avatar_url"].type, sa.Text)
     assert isinstance(table.columns["enable_google_books"].type, sa.Boolean)
+    assert isinstance(table.columns["default_progress_unit"].type, sa.Enum)
+    assert table.columns["default_progress_unit"].type.enums == [
+        "pages_read",
+        "percent_complete",
+        "minutes_listened",
+    ]
 
     created_at_type = cast(sa.DateTime, table.columns["created_at"].type)
     updated_at_type = cast(sa.DateTime, table.columns["updated_at"].type)

--- a/apps/api/tests/test_user_library_service.py
+++ b/apps/api/tests/test_user_library_service.py
@@ -133,6 +133,7 @@ def test_update_profile_validates_handle() -> None:
             display_name=None,
             avatar_url=None,
             enable_google_books=None,
+            default_progress_unit=None,
         )
 
 
@@ -150,6 +151,7 @@ def test_update_profile_rejects_duplicate_handle() -> None:
             display_name=None,
             avatar_url=None,
             enable_google_books=None,
+            default_progress_unit=None,
         )
 
 
@@ -166,12 +168,14 @@ def test_update_profile_updates_fields() -> None:
         display_name=" Name ",
         avatar_url=" https://example.com/avatar.png ",
         enable_google_books=True,
+        default_progress_unit="minutes_listened",
     )
     assert updated is profile
     assert updated.handle == "fresh"
     assert updated.display_name == "Name"
     assert updated.avatar_url == "https://example.com/avatar.png"
     assert updated.enable_google_books is True
+    assert updated.default_progress_unit == "minutes_listened"
 
 
 def test_create_or_get_library_item_handles_missing_work() -> None:

--- a/apps/web/app/pages/settings.vue
+++ b/apps/web/app/pages/settings.vue
@@ -70,6 +70,28 @@
           </template>
         </Card>
 
+        <Card>
+          <template #content>
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <p class="m-0 text-sm font-medium">Default progress unit</p>
+                <p class="m-0 text-xs text-[var(--p-text-muted-color)]">
+                  Used as the default unit when logging reading progress.
+                </p>
+              </div>
+              <select
+                v-model="defaultProgressUnit"
+                data-test="settings-default-progress-unit"
+                class="rounded border border-[var(--p-content-border-color)] bg-transparent px-2 py-1 text-sm"
+              >
+                <option value="pages_read">Pages</option>
+                <option value="percent_complete">Percent</option>
+                <option value="minutes_listened">Minutes</option>
+              </select>
+            </div>
+          </template>
+        </Card>
+
         <Card class="storygraph-import-card" data-test="storygraph-import-card">
           <template #content>
             <div class="flex flex-col gap-4">
@@ -718,6 +740,7 @@ type MeProfile = {
   display_name: string | null;
   avatar_url: string | null;
   enable_google_books: boolean;
+  default_progress_unit: 'pages_read' | 'percent_complete' | 'minutes_listened';
 };
 
 type ImportPreviewRow = {
@@ -773,6 +796,9 @@ const handle = ref('');
 const displayName = ref('');
 const avatarUrl = ref('');
 const enableGoogleBooks = ref(false);
+const defaultProgressUnit = ref<'pages_read' | 'percent_complete' | 'minutes_listened'>(
+  'pages_read',
+);
 
 const importing = ref(false);
 const importError = ref('');
@@ -896,6 +922,7 @@ const loadProfile = async () => {
     displayName.value = data.display_name ?? '';
     avatarUrl.value = data.avatar_url ?? '';
     enableGoogleBooks.value = Boolean(data.enable_google_books);
+    defaultProgressUnit.value = data.default_progress_unit || 'pages_read';
   } catch (err) {
     error.value = err instanceof ApiClientError ? err.message : 'Unable to load settings.';
   } finally {
@@ -915,6 +942,7 @@ const save = async () => {
         display_name: displayName.value,
         avatar_url: avatarUrl.value,
         enable_google_books: enableGoogleBooks.value,
+        default_progress_unit: defaultProgressUnit.value,
       },
     });
     saved.value = true;

--- a/apps/web/app/utils/progressConversion.ts
+++ b/apps/web/app/utils/progressConversion.ts
@@ -1,0 +1,77 @@
+export type ProgressUnit = 'pages_read' | 'percent_complete' | 'minutes_listened';
+
+export type ProgressTotals = {
+  total_pages: number | null;
+  total_audio_minutes: number | null;
+};
+
+export type ConversionCapability = {
+  canConvert: boolean;
+  missing: Array<'total_pages' | 'total_audio_minutes'>;
+};
+
+const clampPercent = (value: number): number => Math.min(100, Math.max(0, value));
+
+const roundWhole = (value: number): number => Math.round(value);
+
+export const toCanonicalPercent = (
+  unit: ProgressUnit,
+  value: number,
+  totals: ProgressTotals,
+): number | null => {
+  if (Number.isNaN(value) || value < 0) return null;
+
+  if (unit === 'percent_complete') return clampPercent(value);
+  if (unit === 'pages_read') {
+    if (!totals.total_pages || totals.total_pages < 1) return null;
+    return clampPercent((value / totals.total_pages) * 100);
+  }
+  if (!totals.total_audio_minutes || totals.total_audio_minutes < 1) return null;
+  return clampPercent((value / totals.total_audio_minutes) * 100);
+};
+
+export const fromCanonicalPercent = (
+  unit: ProgressUnit,
+  canonicalPercent: number,
+  totals: ProgressTotals,
+): number | null => {
+  if (Number.isNaN(canonicalPercent)) return null;
+  const percent = clampPercent(canonicalPercent);
+
+  if (unit === 'percent_complete') return roundWhole(percent);
+  if (unit === 'pages_read') {
+    if (!totals.total_pages || totals.total_pages < 1) return null;
+    return roundWhole((percent / 100) * totals.total_pages);
+  }
+  if (!totals.total_audio_minutes || totals.total_audio_minutes < 1) return null;
+  return roundWhole((percent / 100) * totals.total_audio_minutes);
+};
+
+export const canConvert = (
+  from: ProgressUnit,
+  to: ProgressUnit,
+  totals: ProgressTotals,
+): ConversionCapability => {
+  if (from === to) return { canConvert: true, missing: [] };
+
+  const missing = new Set<'total_pages' | 'total_audio_minutes'>();
+  const needsPages =
+    (from === 'pages_read' && to !== 'pages_read') ||
+    (to === 'pages_read' && from !== 'pages_read');
+  const needsMinutes =
+    (from === 'minutes_listened' && to !== 'minutes_listened') ||
+    (to === 'minutes_listened' && from !== 'minutes_listened');
+
+  if (needsPages && (!totals.total_pages || totals.total_pages < 1)) {
+    missing.add('total_pages');
+  }
+  if (needsMinutes && (!totals.total_audio_minutes || totals.total_audio_minutes < 1)) {
+    missing.add('total_audio_minutes');
+  }
+
+  const missingList = [...missing];
+  return {
+    canConvert: missingList.length === 0,
+    missing: missingList,
+  };
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,8 +16,8 @@
     "format:check": "prettier --check .",
     "test:unit": "vitest run --coverage",
     "test:unit:watch": "vitest",
-    "test:e2e": "rm -rf .nuxt .output && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && sh ./scripts/run-e2e.sh run",
-    "test:e2e:open": "rm -rf .nuxt .output && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && sh ./scripts/run-e2e.sh open"
+    "test:e2e": "rm -rf .nuxt .output && pnpm exec nuxt prepare && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && sh ./scripts/run-e2e.sh run",
+    "test:e2e:open": "rm -rf .nuxt .output && pnpm exec nuxt prepare && NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NUXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build && sh ./scripts/run-e2e.sh open"
   },
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@primeuix/themes": "^2.0.3",
     "@primevue/nuxt-module": "^4.3.3",
     "@supabase/supabase-js": "^2.56.1",
+    "chart.js": "^4.5.1",
     "markdown-it": "^14.1.1",
     "nuxt": "^4.2.2",
     "primeicons": "^7.0.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.56.1
         version: 2.89.0
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -768,6 +771,9 @@ packages:
     resolution: {integrity: sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==}
     engines: {node: '>= 12'}
     deprecated: Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -2088,6 +2094,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
 
   check-more-types@2.24.0:
     resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
@@ -5789,6 +5799,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@kurkle/color@0.3.4': {}
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -7290,6 +7302,10 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   check-more-types@2.24.0: {}
 

--- a/apps/web/tests/unit/pages/book-detail.test.ts
+++ b/apps/web/tests/unit/pages/book-detail.test.ts
@@ -100,6 +100,32 @@ const mountPage = () =>
             </select>
           `,
         },
+        DatePicker: {
+          props: ['modelValue', 'maxDate'],
+          emits: ['update:modelValue'],
+          template:
+            '<input type="date" :value="modelValue ? new Date(modelValue).toISOString().slice(0,10) : ``" @input="$emit(`update:modelValue`, new Date(`${$event.target.value}T00:00:00`))" />',
+        },
+        Slider: {
+          props: ['modelValue', 'min', 'max', 'step', 'disabled'],
+          emits: ['update:modelValue'],
+          template:
+            '<input type="range" :min="min ?? 0" :max="max ?? 100" :step="step ?? 1" :disabled="disabled" :value="modelValue" @input="$emit(`update:modelValue`, Number($event.target.value))" />',
+        },
+        InputNumber: {
+          props: ['modelValue', 'min', 'max'],
+          emits: ['update:modelValue'],
+          template:
+            '<input type="number" :min="min" :max="max" :value="modelValue" v-bind="$attrs" @input="$emit(`update:modelValue`, Number($event.target.value))" />',
+        },
+        Knob: {
+          props: ['modelValue'],
+          template: '<div data-test="knob-stub">{{ modelValue }}</div>',
+        },
+        Chart: {
+          props: ['type', 'data', 'options'],
+          template: '<div data-test="chart-stub"></div>',
+        },
         Rating: {
           props: ['modelValue', 'stars', 'cancel'],
           emits: ['update:modelValue'],
@@ -251,6 +277,57 @@ describe('book detail page', () => {
     expect(wrapper.text()).toContain('ISBN-10 0123456789');
     expect(wrapper.text()).toContain('ISBN-13 9780123456789');
     expect(wrapper.text()).toContain('ASIN B00TESTASIN');
+  });
+
+  it('allows changing library status from the book detail header', async () => {
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      const method = (opts?.method || 'GET').toUpperCase();
+
+      if (url === '/api/v1/works/work-1' && method === 'GET') {
+        return {
+          id: 'work-1',
+          title: 'Book A',
+          description: null,
+          cover_url: null,
+          authors: [],
+        };
+      }
+      if (url === '/api/v1/library/items/by-work/work-1' && method === 'GET') {
+        return {
+          id: 'item-1',
+          work_id: 'work-1',
+          preferred_edition_id: 'edition-1',
+          status: 'reading',
+          created_at: '2026-02-01',
+        };
+      }
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET')
+        return { items: [] };
+      if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') return { items: [] };
+      if (url === '/api/v1/library/items/item-1/highlights' && method === 'GET')
+        return { items: [] };
+      if (url === '/api/v1/me/reviews' && method === 'GET') return { items: [] };
+
+      if (url === '/api/v1/library/items/item-1' && method === 'PATCH') {
+        return { id: 'item-1', status: opts?.body?.status };
+      }
+
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="book-status-open"]').text()).toContain('Reading');
+    await wrapper.get('[data-test="book-status-open"]').trigger('click');
+    await wrapper.get('[data-test="book-status-select"]').setValue('completed');
+    await flushPromises();
+
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/library/items/item-1', {
+      method: 'PATCH',
+      body: { status: 'completed' },
+    });
+    expect(wrapper.get('[data-test="book-status-open"]').text()).toContain('Completed');
   });
 
   it('removes a library item after confirmation and redirects back to the library', async () => {
@@ -504,9 +581,10 @@ describe('book detail page', () => {
   });
 
   it('loads details and supports CRUD flows (happy path)', async () => {
-    const sessions: any[] = [];
+    const progressLogs: any[] = [];
     const notes: any[] = [];
     const highlights: any[] = [];
+    const cycle = { id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' };
     let review: any = {
       id: 'review-1',
       work_id: 'work-1',
@@ -525,6 +603,8 @@ describe('book detail page', () => {
           title: 'Book A',
           description: 'A description',
           cover_url: 'https://example.com/cover.jpg',
+          total_pages: 300,
+          total_audio_minutes: 600,
           authors: [{ id: 'author-1', name: 'Author A' }],
         };
       }
@@ -539,8 +619,11 @@ describe('book detail page', () => {
         };
       }
 
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'GET') {
-        return { items: [...sessions] };
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return { items: [cycle] };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
+        return { items: [...progressLogs] };
       }
       if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') {
         return { items: [...notes] };
@@ -553,12 +636,13 @@ describe('book detail page', () => {
         return { items: review ? [review] : [] };
       }
 
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'POST') {
-        sessions.unshift({
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'POST') {
+        progressLogs.unshift({
           id: 'session-1',
-          started_at: opts?.body?.started_at,
-          pages_read: opts?.body?.pages_read,
-          progress_percent: opts?.body?.progress_percent,
+          logged_at: opts?.body?.logged_at,
+          unit: opts?.body?.unit,
+          value: opts?.body?.value,
+          canonical_percent: 25,
           note: opts?.body?.note,
         });
         return { id: 'session-1' };
@@ -627,23 +711,30 @@ describe('book detail page', () => {
     expect((wrapper.vm as any).reviewBody).toBe('Initial body');
 
     // Log a session
-    await wrapper.find('input[placeholder="Pages read"]').setValue('12');
-    await wrapper.find('input[placeholder="Progress % (0-100)"]').setValue('25');
+    await wrapper.get('[data-test="knob-value-display"]').trigger('click');
+    await wrapper.get('[data-test="knob-value-input"]').setValue('12');
+    await wrapper.get('[data-test="knob-value-input"]').trigger('blur');
     await wrapper.find('textarea[placeholder="Session note"]').setValue('Felt great');
     await clickButton(wrapper, 'Log session');
     await flushPromises();
-    expect(wrapper.text()).toContain('Pages: 12');
-    expect(wrapper.text()).toContain('Progress: 25');
+    expect(wrapper.text()).toContain('Start: 0');
+    expect(wrapper.text()).toContain('End: 12');
+    expect(wrapper.text()).toContain('This session: +12');
     expect(wrapper.text()).toContain('Felt great');
 
-    // Log a session with blank progress to cover nullish fallbacks in the template (?? '-')
-    await wrapper.find('input[placeholder="Pages read"]').setValue('');
-    await wrapper.find('input[placeholder="Progress % (0-100)"]').setValue('');
-    await wrapper.find('textarea[placeholder="Session note"]').setValue('');
+    // Switch to percent and verify deterministic conversion from previous pages value.
+    await wrapper.get('[data-test="convert-unit-open"]').trigger('click');
+    await wrapper.get('[data-test="convert-unit-select"]').setValue('percent_complete');
+    await flushPromises();
+    expect((wrapper.vm as any).sessionProgressValue).toBe(4);
+    await wrapper.get('[data-test="knob-value-display"]').trigger('click');
+    await wrapper.get('[data-test="knob-value-input"]').setValue('25');
+    await wrapper.get('[data-test="knob-value-input"]').trigger('blur');
     await clickButton(wrapper, 'Log session');
     await flushPromises();
-    expect(wrapper.text()).toContain('Pages: -');
-    expect(wrapper.text()).toContain('Progress: -');
+    expect(wrapper.text()).toContain('Start:');
+    expect(wrapper.text()).toContain('End:');
+    expect(wrapper.text()).toContain('This session:');
 
     // Add note (covers early-return guard by trying empty body first)
     await clickButton(wrapper, 'Add note');
@@ -671,9 +762,8 @@ describe('book detail page', () => {
     expect(wrapper.find('[data-test="dialog"]').exists()).toBe(true);
 
     // Exercise Dialog v-model handler by emitting an update from the stub.
-    wrapper.findComponent({ name: 'Dialog' }).vm.$emit('update:visible', false);
-    await flushPromises();
-    expect(wrapper.find('[data-test="dialog"]').exists()).toBe(false);
+    await emitDialogVisible(wrapper, 'Edit note', false);
+    expect((wrapper.vm as any).editNoteVisible).toBe(false);
 
     // Cancel path
     await clickButton(wrapper, 'Edit');
@@ -753,10 +843,9 @@ describe('book detail page', () => {
     expect(wrapper.text()).toContain('No highlights yet.');
 
     // Save review (ensures API call uses trimmed/null behavior)
-    // Set review visibility select and rating via Rating stub
-    selects = wrapper.findAll('select');
-    expect(selects.length).toBeGreaterThanOrEqual(3);
-    await selects[2].setValue('public'); // review visibility
+    // Set review visibility and rating via Rating stub
+    const visibilitySelects = wrapper.findAll('select');
+    await visibilitySelects[visibilitySelects.length - 1].setValue('public');
 
     // Click the 5th star button in the Rating stub (= 5 rating)
     const ratingStub = wrapper.get('[data-test="rating-stub"]');
@@ -783,9 +872,9 @@ describe('book detail page', () => {
   });
 
   it('renders core content without waiting on section loaders', async () => {
-    let resolveSessions: any = null;
-    const sessionsPromise = new Promise((resolve) => {
-      resolveSessions = resolve;
+    let resolveLogs: any = null;
+    const logsPromise = new Promise((resolve) => {
+      resolveLogs = resolve;
     });
 
     apiRequest.mockImplementation(async (url: string, opts?: any) => {
@@ -808,8 +897,11 @@ describe('book detail page', () => {
           created_at: '2026-02-01',
         };
       }
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'GET') {
-        return sessionsPromise as any;
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return { items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }] };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
+        return logsPromise as any;
       }
       if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') {
         return new Promise(() => undefined) as any;
@@ -832,9 +924,261 @@ describe('book detail page', () => {
     // Sessions section shows skeleton loading (no text), just verify it doesn't show "No sessions yet."
     expect(wrapper.text()).not.toContain('No sessions yet.');
 
-    resolveSessions?.({ items: [] });
+    resolveLogs?.({ items: [] });
     await flushPromises();
     expect(wrapper.text()).toContain('No sessions yet.');
+  });
+
+  it('prompts for missing totals, persists them, and retries unit conversion', async () => {
+    const calls: Array<{ url: string; opts?: any }> = [];
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      calls.push({ url, opts });
+      const method = (opts?.method || 'GET').toUpperCase();
+
+      if (url === '/api/v1/works/work-1' && method === 'GET') {
+        return {
+          id: 'work-1',
+          title: 'Book A',
+          description: null,
+          cover_url: null,
+          total_pages: null,
+          total_audio_minutes: null,
+          authors: [],
+        };
+      }
+      if (url === '/api/v1/library/items/by-work/work-1' && method === 'GET') {
+        return {
+          id: 'item-1',
+          work_id: 'work-1',
+          preferred_edition_id: null,
+          status: 'reading',
+          created_at: '2026-02-01',
+        };
+      }
+      if (url === '/api/v1/me' && method === 'GET') {
+        return { default_progress_unit: 'pages_read' };
+      }
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return { items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }] };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
+        return {
+          items: [
+            {
+              id: 'log-1',
+              logged_at: '2026-02-07T12:00:00Z',
+              unit: 'pages_read',
+              value: 20,
+              canonical_percent: null,
+              note: null,
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') return { items: [] };
+      if (url === '/api/v1/library/items/item-1/highlights' && method === 'GET')
+        return { items: [] };
+      if (url === '/api/v1/me/reviews' && method === 'GET') return { items: [] };
+      if (url === '/api/v1/works/work-1/enrichment/candidates' && method === 'GET') {
+        return {
+          fields: [
+            {
+              field_key: 'edition.total_pages',
+              candidates: [{ value: 320 }],
+            },
+            {
+              field_key: 'edition.total_audio_minutes',
+              candidates: [{ value: 600 }],
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/works/work-1/editions' && method === 'GET') {
+        return { items: [{ id: 'edition-2' }] };
+      }
+      if (url === '/api/v1/editions/edition-2/totals' && method === 'PATCH') {
+        return { total_pages: 200, total_audio_minutes: 600 };
+      }
+
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-test="convert-unit-open"]').trigger('click');
+    await wrapper.get('[data-test="convert-unit-select"]').setValue('minutes_listened');
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="missing-totals-dialog-content"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Suggestion: 320 pages');
+    expect(wrapper.text()).toContain('Suggestion: 10:00:00');
+    expect((wrapper.vm as any).sessionProgressUnit).toBe('percent_complete');
+
+    await wrapper.get('[data-test="pending-total-pages"]').setValue('200');
+    await wrapper.get('[data-test="pending-total-audio-minutes"]').setValue('10:00:00');
+    await wrapper.get('[data-test="save-missing-totals"]').trigger('click');
+    await flushPromises();
+
+    expect((wrapper.vm as any).sessionProgressUnit).toBe('minutes_listened');
+    expect((wrapper.vm as any).sessionProgressValue).toBeGreaterThanOrEqual(0);
+    expect(calls.some((call) => call.url === '/api/v1/works/work-1/editions')).toBe(true);
+    expect(calls.some((call) => call.url === '/api/v1/editions/edition-2/totals')).toBe(true);
+  });
+
+  it('sorts timeline logs by day then progress descending and renders date-only labels', async () => {
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      const method = (opts?.method || 'GET').toUpperCase();
+      if (url === '/api/v1/works/work-1' && method === 'GET') {
+        return {
+          id: 'work-1',
+          title: 'Book A',
+          description: null,
+          cover_url: null,
+          total_pages: 300,
+          total_audio_minutes: 600,
+          authors: [],
+        };
+      }
+      if (url === '/api/v1/library/items/by-work/work-1' && method === 'GET') {
+        return {
+          id: 'item-1',
+          work_id: 'work-1',
+          preferred_edition_id: 'edition-1',
+          status: 'reading',
+          created_at: '2026-02-01',
+        };
+      }
+      if (url === '/api/v1/me' && method === 'GET') {
+        return { default_progress_unit: 'pages_read' };
+      }
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return { items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }] };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
+        return {
+          items: [
+            {
+              id: 'log-1',
+              logged_at: '2026-02-08T08:00:00Z',
+              unit: 'percent_complete',
+              value: 45,
+              canonical_percent: 45,
+              note: null,
+            },
+            {
+              id: 'log-2',
+              logged_at: '2026-02-08T09:00:00Z',
+              unit: 'percent_complete',
+              value: 55,
+              canonical_percent: 55,
+              note: null,
+            },
+            {
+              id: 'log-3',
+              logged_at: '2026-02-07T12:00:00Z',
+              unit: 'percent_complete',
+              value: 20,
+              canonical_percent: 20,
+              note: null,
+            },
+          ],
+        };
+      }
+      if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') return { items: [] };
+      if (url === '/api/v1/library/items/item-1/highlights' && method === 'GET')
+        return { items: [] };
+      if (url === '/api/v1/me/reviews' && method === 'GET') return { items: [] };
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    expect((wrapper.vm as any).timelineSessions.map((entry: any) => entry.id)).toEqual([
+      'log-2',
+      'log-1',
+      'log-3',
+    ]);
+    expect(wrapper.text()).not.toContain('8:00:00');
+    expect(wrapper.text()).not.toContain('9:00:00');
+  });
+
+  it('creates a read cycle before logging when none exists', async () => {
+    const calls: Array<{ url: string; opts?: any }> = [];
+    let hasCycle = false;
+    apiRequest.mockImplementation(async (url: string, opts?: any) => {
+      calls.push({ url, opts });
+      const method = (opts?.method || 'GET').toUpperCase();
+
+      if (url === '/api/v1/works/work-1' && method === 'GET') {
+        return {
+          id: 'work-1',
+          title: 'Book A',
+          description: null,
+          cover_url: null,
+          total_pages: 300,
+          total_audio_minutes: 500,
+          authors: [],
+        };
+      }
+      if (url === '/api/v1/library/items/by-work/work-1' && method === 'GET') {
+        return {
+          id: 'item-1',
+          work_id: 'work-1',
+          preferred_edition_id: 'edition-1',
+          status: 'reading',
+          created_at: '2026-02-01',
+        };
+      }
+      if (url === '/api/v1/me' && method === 'GET') {
+        return { default_progress_unit: 'pages_read' };
+      }
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return hasCycle
+          ? { items: [{ id: 'cycle-new', started_at: '2026-02-08T00:00:00Z' }] }
+          : { items: [] };
+      }
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'POST') {
+        hasCycle = true;
+        return { id: 'cycle-new' };
+      }
+      if (url === '/api/v1/read-cycles/cycle-new/progress-logs' && method === 'POST') {
+        return { id: 'log-1' };
+      }
+      if (url === '/api/v1/read-cycles/cycle-new/progress-logs' && method === 'GET') {
+        return { items: [] };
+      }
+      if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') return { items: [] };
+      if (url === '/api/v1/library/items/item-1/highlights' && method === 'GET')
+        return { items: [] };
+      if (url === '/api/v1/me/reviews' && method === 'GET') return { items: [] };
+
+      throw new Error(`unexpected request: ${method} ${url}`);
+    });
+
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.get('[data-test="knob-value-display"]').trigger('click');
+    await wrapper.get('[data-test="knob-value-input"]').setValue('12');
+    await wrapper.get('[data-test="knob-value-input"]').trigger('blur');
+    await clickButton(wrapper, 'Log session');
+    await flushPromises();
+
+    expect(calls.some((call) => call.url === '/api/v1/library/items/item-1/read-cycles')).toBe(
+      true,
+    );
+    expect(
+      calls.some(
+        (call) =>
+          call.url === '/api/v1/library/items/item-1/read-cycles' &&
+          (call.opts?.method || '').toUpperCase() === 'POST',
+      ),
+    ).toBe(true);
+    expect(calls.some((call) => call.url === '/api/v1/read-cycles/cycle-new/progress-logs')).toBe(
+      true,
+    );
   });
 
   it('shows per-section error and retry only re-requests the failed section', async () => {
@@ -866,8 +1210,11 @@ describe('book detail page', () => {
         };
       }
 
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'GET') {
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
         if ((counts[url] || 0) === 1) throw new Error('boom');
+        return { items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }] };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
         return { items: [] };
       }
       if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') return { items: [] };
@@ -884,7 +1231,7 @@ describe('book detail page', () => {
     expect(wrapper.text()).toContain('Book A');
     expect(wrapper.text()).toContain('Unable to load sessions.');
 
-    expect(counts['/api/v1/library/items/item-1/sessions']).toBe(1);
+    expect(counts['/api/v1/library/items/item-1/read-cycles']).toBe(1);
     expect(counts['/api/v1/library/items/item-1/notes']).toBe(1);
     expect(counts['/api/v1/library/items/item-1/highlights']).toBe(1);
     expect(counts['/api/v1/me/reviews']).toBe(1);
@@ -892,7 +1239,7 @@ describe('book detail page', () => {
     await wrapper.get('[data-test="sessions-retry"]').trigger('click');
     await flushPromises();
 
-    expect(counts['/api/v1/library/items/item-1/sessions']).toBe(2);
+    expect(counts['/api/v1/library/items/item-1/read-cycles']).toBe(2);
     expect(counts['/api/v1/library/items/item-1/notes']).toBe(1);
     expect(counts['/api/v1/library/items/item-1/highlights']).toBe(1);
     expect(counts['/api/v1/me/reviews']).toBe(1);
@@ -915,7 +1262,10 @@ describe('book detail page', () => {
           created_at: '2026-02-01',
         };
       }
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'GET') return { items: [] };
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET')
+        return { items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }] };
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET')
+        return { items: [] };
       if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') return { items: [] };
       if (url === '/api/v1/library/items/item-1/highlights' && method === 'GET')
         return { items: [] };
@@ -2078,8 +2428,8 @@ describe('book detail page', () => {
   });
 
   it('falls back to the raw value if Date formatting throws', async () => {
-    const original = Date.prototype.toLocaleString;
-    Date.prototype.toLocaleString = () => {
+    const original = Date.prototype.toLocaleDateString;
+    Date.prototype.toLocaleDateString = () => {
       throw new Error('boom');
     };
 
@@ -2097,14 +2447,20 @@ describe('book detail page', () => {
       if (url === '/api/v1/library/items/by-work/work-1' && method === 'GET') {
         return { id: 'item-1', work_id: 'work-1', status: 'reading', created_at: '2026-02-01' };
       }
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'GET') {
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return {
+          items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }],
+        };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
         return {
           items: [
             {
               id: 'session-1',
-              started_at: '2026-02-08T00:00:00Z',
-              pages_read: null,
-              progress_percent: null,
+              logged_at: '2026-02-08T00:00:00Z',
+              unit: 'pages_read',
+              value: 1,
+              canonical_percent: 1,
               note: null,
             },
           ],
@@ -2122,7 +2478,7 @@ describe('book detail page', () => {
 
     expect(wrapper.text()).toContain('2026-02-08T00:00:00Z');
 
-    Date.prototype.toLocaleString = original;
+    Date.prototype.toLocaleDateString = original;
   });
 
   it('surfaces errors when by-work fails with non-404', async () => {
@@ -2286,7 +2642,10 @@ describe('book detail page', () => {
       if (url === '/api/v1/library/items/by-work/work-1' && method === 'GET') {
         return { id: 'item-1', work_id: 'work-1', status: 'reading', created_at: '2026-02-01' };
       }
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'GET') {
+      if (url === '/api/v1/library/items/item-1/read-cycles' && method === 'GET') {
+        return { items: [{ id: 'cycle-1', started_at: '2026-02-08T00:00:00Z' }] };
+      }
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'GET') {
         return { items: [] };
       }
       if (url === '/api/v1/library/items/item-1/notes' && method === 'GET') {
@@ -2318,7 +2677,7 @@ describe('book detail page', () => {
         return { items: [] };
       }
 
-      if (url === '/api/v1/library/items/item-1/sessions' && method === 'POST') {
+      if (url === '/api/v1/read-cycles/cycle-1/progress-logs' && method === 'POST') {
         counts.sessionPost += 1;
         if (counts.sessionPost === 1)
           throw new ApiClientErrorMock('Session denied', 'forbidden', 403);
@@ -2375,8 +2734,8 @@ describe('book detail page', () => {
     await (wrapper.vm as any).addHighlight();
 
     // Now exercise action error paths with a library item present.
-    (wrapper.vm as any).libraryItem = { id: 'item-1' };
-    (wrapper.vm as any).sessionPagesRead = '1';
+    (wrapper.vm as any).libraryItem = { id: 'item-1', status: 'reading' };
+    (wrapper.vm as any).sessionProgressValue = 1;
     await flushPromises();
     await clickButton(wrapper, 'Log session');
     await flushPromises();

--- a/apps/web/tests/unit/pages/settings.test.ts
+++ b/apps/web/tests/unit/pages/settings.test.ts
@@ -152,6 +152,7 @@ const mockProfile = () => ({
   display_name: 'Seed',
   avatar_url: null,
   enable_google_books: false,
+  default_progress_unit: 'pages_read',
 });
 
 describe('settings page StoryGraph import UX', () => {
@@ -200,13 +201,17 @@ describe('settings page StoryGraph import UX', () => {
     await wrapper.get('[data-test="settings-display-name"]').setValue('New Name');
     await wrapper.get('[data-test="settings-avatar-url"]').setValue('https://example.com/new.png');
     await wrapper.get('[data-test="settings-enable-google-books"]').setValue(true);
+    await wrapper.get('[data-test="settings-default-progress-unit"]').setValue('minutes_listened');
     await wrapper.get('[data-test="settings-save"]').trigger('click');
     await flush(wrapper);
 
     const patchCall = apiRequest.mock.calls.find((call) => call[0] === '/api/v1/me' && call[1]);
     expect(patchCall?.[1]).toMatchObject({
       method: 'PATCH',
-      body: expect.objectContaining({ enable_google_books: true }),
+      body: expect.objectContaining({
+        enable_google_books: true,
+        default_progress_unit: 'minutes_listened',
+      }),
     });
     expect(wrapper.get('[data-test="settings-saved"]').text()).toContain('Settings saved');
   });
@@ -217,6 +222,7 @@ describe('settings page StoryGraph import UX', () => {
       display_name: null,
       avatar_url: null,
       enable_google_books: false,
+      default_progress_unit: 'pages_read',
     });
 
     const wrapper = mountPage();

--- a/apps/web/tests/unit/utils/progressConversion.test.ts
+++ b/apps/web/tests/unit/utils/progressConversion.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canConvert,
+  fromCanonicalPercent,
+  toCanonicalPercent,
+} from '../../../app/utils/progressConversion';
+
+describe('progressConversion', () => {
+  it('converts pages and minutes through canonical percent', () => {
+    const totals = { total_pages: 300, total_audio_minutes: 600 };
+    const canonical = toCanonicalPercent('pages_read', 75, totals);
+    expect(canonical).toBe(25);
+    expect(fromCanonicalPercent('minutes_listened', canonical ?? 0, totals)).toBe(150);
+  });
+
+  it('rounds converted values to whole numbers', () => {
+    const totals = { total_pages: 333, total_audio_minutes: 1000 };
+    expect(fromCanonicalPercent('pages_read', 12.6, totals)).toBe(42);
+    expect(fromCanonicalPercent('minutes_listened', 12.6, totals)).toBe(126);
+  });
+
+  it('clamps percent and enforces totals requirements', () => {
+    expect(
+      toCanonicalPercent('percent_complete', 120, { total_pages: null, total_audio_minutes: null }),
+    ).toBe(100);
+    expect(
+      toCanonicalPercent('pages_read', 10, { total_pages: null, total_audio_minutes: null }),
+    ).toBeNull();
+    expect(
+      canConvert('pages_read', 'minutes_listened', {
+        total_pages: null,
+        total_audio_minutes: null,
+      }),
+    ).toEqual({
+      canConvert: false,
+      missing: ['total_pages', 'total_audio_minutes'],
+    });
+  });
+
+  it('handles invalid numeric inputs and same-unit conversion checks', () => {
+    const totals = { total_pages: 100, total_audio_minutes: 80 };
+    expect(toCanonicalPercent('minutes_listened', Number.NaN, totals)).toBeNull();
+    expect(fromCanonicalPercent('percent_complete', Number.NaN, totals)).toBeNull();
+    expect(canConvert('pages_read', 'pages_read', totals)).toEqual({
+      canConvert: true,
+      missing: [],
+    });
+  });
+
+  it('covers minutes and pages specific missing-total paths', () => {
+    const missingMinutes = { total_pages: 100, total_audio_minutes: null };
+    expect(toCanonicalPercent('minutes_listened', 10, missingMinutes)).toBeNull();
+    expect(fromCanonicalPercent('minutes_listened', 30, missingMinutes)).toBeNull();
+    expect(canConvert('percent_complete', 'minutes_listened', missingMinutes)).toEqual({
+      canConvert: false,
+      missing: ['total_audio_minutes'],
+    });
+
+    const missingPages = { total_pages: null, total_audio_minutes: 120 };
+    expect(fromCanonicalPercent('pages_read', 30, missingPages)).toBeNull();
+    expect(canConvert('percent_complete', 'pages_read', missingPages)).toEqual({
+      canConvert: false,
+      missing: ['total_pages'],
+    });
+  });
+
+  it('converts minutes to canonical percent when totals exist', () => {
+    const totals = { total_pages: 300, total_audio_minutes: 240 };
+    expect(toCanonicalPercent('minutes_listened', 60, totals)).toBe(25);
+    expect(canConvert('minutes_listened', 'percent_complete', totals)).toEqual({
+      canConvert: true,
+      missing: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement Reading Sessions UX v2.1 on book detail with start/resume semantics and explicit unit conversion flow
- migrate logging flow to read cycles + progress logs, including date controls, slider/knob interactions, timeline/chart updates, streak logic, and completed-status behavior
- add backend support for user `default_progress_unit` and edition totals updates, plus totals suggestions from Open Library/Google Books (including audiobook duration parsing)
- add and expand API/web tests for conversions, totals workflows, timeline/chart behavior, and suggestion parsing
- harden web e2e script by running `nuxt prepare` after clearing `.nuxt`

## Validation
- `make quality`

Closes #145
