### PR TITLE
Implement per-book reading statistics aggregation

### DIFF
--- a/apps/api/app/services/reading_statistics.py
+++ b/apps/api/app/services/reading_statistics.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.bibliography import Edition
+from app.db.models.users import LibraryItem, ReadingProgressLog, ReadingSession
+
+ProgressUnit = Literal["pages_read", "percent_complete", "minutes_listened"]
+
+
+@dataclass(frozen=True)
+class _ResolvedLog:
+    model: ReadingProgressLog
+    canonical_percent: float | None
+    local_date: dt.date
+
+
+def _as_aware_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _to_float(value: Decimal | float | int | None) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _get_item_totals(
+    session: Session, *, library_item_id: uuid.UUID
+) -> tuple[int | None, int | None]:
+    preferred = session.execute(
+        sa.select(Edition.total_pages, Edition.total_audio_minutes)
+        .join(LibraryItem, LibraryItem.preferred_edition_id == Edition.id)
+        .where(LibraryItem.id == library_item_id)
+        .limit(1)
+    ).first()
+    if preferred is not None:
+        return preferred[0], preferred[1]
+
+    fallback = session.execute(
+        sa.select(Edition.total_pages, Edition.total_audio_minutes)
+        .join(LibraryItem, LibraryItem.work_id == Edition.work_id)
+        .where(LibraryItem.id == library_item_id)
+        .order_by(Edition.created_at.desc(), Edition.id.desc())
+        .limit(1)
+    ).first()
+    if fallback is not None:
+        return fallback[0], fallback[1]
+
+    return None, None
+
+
+def _canonical_from_log(
+    log: ReadingProgressLog,
+    *,
+    total_pages: int | None,
+    total_audio_minutes: int | None,
+) -> float | None:
+    stored = _to_float(log.canonical_percent)
+    if stored is not None:
+        return min(100.0, max(0.0, stored))
+
+    value = float(log.value)
+    if log.unit == "percent_complete":
+        return min(100.0, max(0.0, value))
+    if log.unit == "pages_read":
+        if not total_pages or total_pages <= 0:
+            return None
+        return min(100.0, max(0.0, (value / total_pages) * 100.0))
+    if log.unit == "minutes_listened":
+        if not total_audio_minutes or total_audio_minutes <= 0:
+            return None
+        return min(100.0, max(0.0, (value / total_audio_minutes) * 100.0))
+    return None
+
+
+def _from_canonical(
+    *,
+    unit: ProgressUnit,
+    canonical_percent: float,
+    total_pages: int | None,
+    total_audio_minutes: int | None,
+    clamp: bool = True,
+) -> float | None:
+    canonical = min(100.0, max(0.0, canonical_percent)) if clamp else canonical_percent
+    if unit == "percent_complete":
+        return canonical
+    if unit == "pages_read":
+        if not total_pages or total_pages <= 0:
+            return None
+        return (canonical / 100.0) * float(total_pages)
+    if unit == "minutes_listened":
+        if not total_audio_minutes or total_audio_minutes <= 0:
+            return None
+        return (canonical / 100.0) * float(total_audio_minutes)
+    return None
+
+
+def _round_number(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(value, 3)
+
+
+def _to_local_date(value: dt.datetime, *, zone: ZoneInfo) -> dt.date:
+    return _as_aware_utc(value).astimezone(zone).date()
+
+
+def _is_import_cycle(cycle: ReadingSession) -> bool:
+    note = (cycle.note or "").lower()
+    return note.startswith("goodreads:") or note.startswith("storygraph:")
+
+
+def get_library_item_statistics(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    library_item_id: uuid.UUID,
+    tz: str = "UTC",
+    days: int = 90,
+) -> dict[str, Any]:
+    if days < 7 or days > 365:
+        raise ValueError("days must be between 7 and 365")
+    try:
+        zone = ZoneInfo(tz)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("invalid timezone") from exc
+
+    item = session.scalar(
+        sa.select(LibraryItem).where(
+            LibraryItem.id == library_item_id,
+            LibraryItem.user_id == user_id,
+        )
+    )
+    if item is None:
+        raise LookupError("library item not found")
+
+    total_pages, total_audio_minutes = _get_item_totals(
+        session, library_item_id=library_item_id
+    )
+
+    cycles = list(
+        session.execute(
+            sa.select(ReadingSession)
+            .where(
+                ReadingSession.user_id == user_id,
+                ReadingSession.library_item_id == library_item_id,
+            )
+            .order_by(ReadingSession.started_at.asc(), ReadingSession.id.asc())
+        ).scalars()
+    )
+    logs = list(
+        session.execute(
+            sa.select(ReadingProgressLog)
+            .where(
+                ReadingProgressLog.user_id == user_id,
+                ReadingProgressLog.library_item_id == library_item_id,
+            )
+            .order_by(ReadingProgressLog.logged_at.asc(), ReadingProgressLog.id.asc())
+        ).scalars()
+    )
+
+    resolved_logs: list[_ResolvedLog] = []
+    unresolved_log_ids: list[str] = []
+    for log in logs:
+        canonical = _canonical_from_log(
+            log,
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        )
+        if canonical is None:
+            unresolved_log_ids.append(str(log.id))
+        resolved_logs.append(
+            _ResolvedLog(
+                model=log,
+                canonical_percent=canonical,
+                local_date=_to_local_date(log.logged_at, zone=zone),
+            )
+        )
+
+    total_cycles = len(cycles)
+    completed_cycles = sum(1 for cycle in cycles if cycle.ended_at is not None)
+    imported_cycles = sum(1 for cycle in cycles if _is_import_cycle(cycle))
+    completed_reads = completed_cycles
+    if completed_reads == 0 and item.status == "completed":
+        completed_reads = 1
+
+    latest_resolved = next(
+        (row for row in reversed(resolved_logs) if row.canonical_percent is not None),
+        None,
+    )
+    current_canonical = (
+        latest_resolved.canonical_percent
+        if latest_resolved is not None and latest_resolved.canonical_percent is not None
+        else 0.0
+    )
+    latest_logged_at = logs[-1].logged_at.isoformat() if logs else None
+
+    today = dt.datetime.now(dt.UTC).astimezone(zone).date()
+    start_date = today - dt.timedelta(days=days - 1)
+
+    latest_by_day: dict[dt.date, float] = {}
+    for row in resolved_logs:
+        if row.canonical_percent is None:
+            continue
+        if row.local_date < start_date or row.local_date > today:
+            continue
+        latest_by_day[row.local_date] = row.canonical_percent
+
+    ordered_progress_points: list[tuple[dt.date, float]] = sorted(
+        latest_by_day.items(), key=lambda entry: entry[0]
+    )
+    progress_points = [
+        {
+            "date": day.isoformat(),
+            "canonical_percent": _round_number(canonical) or 0.0,
+            "pages_read": _round_number(
+                _from_canonical(
+                    unit="pages_read",
+                    canonical_percent=canonical,
+                    total_pages=total_pages,
+                    total_audio_minutes=total_audio_minutes,
+                )
+            ),
+            "minutes_listened": _round_number(
+                _from_canonical(
+                    unit="minutes_listened",
+                    canonical_percent=canonical,
+                    total_pages=total_pages,
+                    total_audio_minutes=total_audio_minutes,
+                )
+            ),
+        }
+        for day, canonical in ordered_progress_points
+    ]
+
+    daily_delta_points: list[dict[str, Any]] = []
+    previous_canonical = 0.0
+    for _day, current in ordered_progress_points:
+        canonical_delta = current - previous_canonical
+        daily_delta_points.append(
+            {
+                "date": _day.isoformat(),
+                "canonical_percent_delta": _round_number(canonical_delta) or 0.0,
+                "pages_read_delta": _round_number(
+                    _from_canonical(
+                        unit="pages_read",
+                        canonical_percent=canonical_delta,
+                        total_pages=total_pages,
+                        total_audio_minutes=total_audio_minutes,
+                        clamp=False,
+                    )
+                ),
+                "minutes_listened_delta": _round_number(
+                    _from_canonical(
+                        unit="minutes_listened",
+                        canonical_percent=canonical_delta,
+                        total_pages=total_pages,
+                        total_audio_minutes=total_audio_minutes,
+                        clamp=False,
+                    )
+                ),
+            }
+        )
+        previous_canonical = current
+
+    non_zero_days = sorted(
+        {
+            row.local_date
+            for row in resolved_logs
+            if row.canonical_percent is not None and row.canonical_percent > 0
+        },
+        reverse=True,
+    )
+    streak = 0
+    if non_zero_days:
+        streak = 1
+        previous_day = non_zero_days[0]
+        for candidate in non_zero_days[1:]:
+            if previous_day - candidate == dt.timedelta(days=1):
+                streak += 1
+                previous_day = candidate
+            else:
+                break
+
+    timeline_rows: list[dict[str, Any]] = []
+    previous_canonical_for_timeline = 0.0
+    for row in resolved_logs:
+        current_for_timeline = (
+            row.canonical_percent if row.canonical_percent is not None else 0.0
+        )
+        start_value = _from_canonical(
+            unit=row.model.unit,  # type: ignore[arg-type]
+            canonical_percent=previous_canonical_for_timeline,
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        )
+        end_value = _from_canonical(
+            unit=row.model.unit,  # type: ignore[arg-type]
+            canonical_percent=current_for_timeline,
+            total_pages=total_pages,
+            total_audio_minutes=total_audio_minutes,
+        )
+        start_safe = start_value or 0.0
+        end_safe = end_value or 0.0
+        timeline_rows.append(
+            {
+                "log_id": str(row.model.id),
+                "logged_at": row.model.logged_at.isoformat(),
+                "date": row.local_date.isoformat(),
+                "unit": row.model.unit,
+                "value": _round_number(float(row.model.value)) or 0.0,
+                "note": row.model.note,
+                "start_value": _round_number(start_safe) or 0.0,
+                "end_value": _round_number(end_safe) or 0.0,
+                "session_delta": _round_number(end_safe - start_safe) or 0.0,
+            }
+        )
+        previous_canonical_for_timeline = current_for_timeline
+
+    return {
+        "library_item_id": str(library_item_id),
+        "window": {
+            "days": days,
+            "tz": tz,
+            "start_date": start_date.isoformat(),
+            "end_date": today.isoformat(),
+        },
+        "totals": {
+            "total_pages": total_pages,
+            "total_audio_minutes": total_audio_minutes,
+        },
+        "counts": {
+            "total_cycles": total_cycles,
+            "completed_cycles": completed_cycles,
+            "imported_cycles": imported_cycles,
+            "completed_reads": completed_reads,
+            "total_logs": len(logs),
+            "logs_with_canonical": len(logs) - len(unresolved_log_ids),
+            "logs_missing_canonical": len(unresolved_log_ids),
+        },
+        "current": {
+            "latest_logged_at": latest_logged_at,
+            "canonical_percent": _round_number(current_canonical) or 0.0,
+            "pages_read": _round_number(
+                _from_canonical(
+                    unit="pages_read",
+                    canonical_percent=current_canonical,
+                    total_pages=total_pages,
+                    total_audio_minutes=total_audio_minutes,
+                )
+            ),
+            "minutes_listened": _round_number(
+                _from_canonical(
+                    unit="minutes_listened",
+                    canonical_percent=current_canonical,
+                    total_pages=total_pages,
+                    total_audio_minutes=total_audio_minutes,
+                )
+            ),
+        },
+        "streak": {
+            "non_zero_days": streak,
+            "last_non_zero_date": (
+                non_zero_days[0].isoformat() if non_zero_days else None
+            ),
+        },
+        "series": {
+            "progress_over_time": progress_points,
+            "daily_delta": daily_delta_points,
+        },
+        "timeline": list(reversed(timeline_rows)),
+        "data_quality": {
+            "has_missing_totals": total_pages is None or total_audio_minutes is None,
+            "unresolved_logs_exist": bool(unresolved_log_ids),
+            "unresolved_log_ids": unresolved_log_ids,
+        },
+    }

--- a/apps/api/tests/test_library_by_work_router.py
+++ b/apps/api/tests/test_library_by_work_router.py
@@ -46,6 +46,71 @@ def app(monkeypatch: pytest.MonkeyPatch) -> Generator[FastAPI, None, None]:
             "created_at": dt.datetime.now(tz=dt.UTC).isoformat(),
         },
     )
+    monkeypatch.setattr(
+        "app.routers.library.get_library_item_statistics",
+        lambda *_args, **_kwargs: {
+            "library_item_id": str(uuid.uuid4()),
+            "window": {
+                "days": 90,
+                "tz": "UTC",
+                "start_date": "2026-01-01",
+                "end_date": "2026-03-31",
+            },
+            "totals": {"total_pages": 300, "total_audio_minutes": 600},
+            "counts": {
+                "total_cycles": 1,
+                "completed_cycles": 1,
+                "imported_cycles": 0,
+                "completed_reads": 1,
+                "total_logs": 2,
+                "logs_with_canonical": 2,
+                "logs_missing_canonical": 0,
+            },
+            "current": {
+                "latest_logged_at": dt.datetime.now(tz=dt.UTC).isoformat(),
+                "canonical_percent": 50.0,
+                "pages_read": 150.0,
+                "minutes_listened": 300.0,
+            },
+            "streak": {"non_zero_days": 2, "last_non_zero_date": "2026-02-09"},
+            "series": {
+                "progress_over_time": [
+                    {
+                        "date": "2026-02-08",
+                        "canonical_percent": 25.0,
+                        "pages_read": 75.0,
+                        "minutes_listened": 150.0,
+                    }
+                ],
+                "daily_delta": [
+                    {
+                        "date": "2026-02-08",
+                        "canonical_percent_delta": 25.0,
+                        "pages_read_delta": 75.0,
+                        "minutes_listened_delta": 150.0,
+                    }
+                ],
+            },
+            "timeline": [
+                {
+                    "log_id": str(uuid.uuid4()),
+                    "logged_at": dt.datetime.now(tz=dt.UTC).isoformat(),
+                    "date": "2026-02-08",
+                    "unit": "percent_complete",
+                    "value": 25.0,
+                    "note": None,
+                    "start_value": 0.0,
+                    "end_value": 25.0,
+                    "session_delta": 25.0,
+                }
+            ],
+            "data_quality": {
+                "has_missing_totals": False,
+                "unresolved_logs_exist": False,
+                "unresolved_log_ids": [],
+            },
+        },
+    )
 
     yield app
 
@@ -67,3 +132,62 @@ def test_get_library_item_by_work_returns_404(
     client = TestClient(app)
     response = client.get(f"/api/v1/library/items/by-work/{uuid.uuid4()}")
     assert response.status_code == 404
+
+
+def test_get_library_item_statistics(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/library/items/{uuid.uuid4()}/statistics",
+        params={"tz": "America/Los_Angeles", "days": 30},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert "counts" in payload
+    assert "series" in payload
+    assert "timeline" in payload
+
+
+def test_get_library_item_statistics_returns_404(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.get_library_item_statistics",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            LookupError("library item not found")
+        ),
+    )
+    client = TestClient(app)
+    response = client.get(f"/api/v1/library/items/{uuid.uuid4()}/statistics")
+    assert response.status_code == 404
+
+
+def test_get_library_item_statistics_returns_400_for_invalid_days(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.get_library_item_statistics",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("days must be between 7 and 365")
+        ),
+    )
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/library/items/{uuid.uuid4()}/statistics",
+        params={"days": 2},
+    )
+    assert response.status_code == 400
+
+
+def test_get_library_item_statistics_returns_400_for_invalid_tz(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "app.routers.library.get_library_item_statistics",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("invalid timezone")),
+    )
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/library/items/{uuid.uuid4()}/statistics",
+        params={"tz": "Mars/OlympusMons"},
+    )
+    assert response.status_code == 400

--- a/apps/api/tests/test_reading_statistics_service.py
+++ b/apps/api/tests/test_reading_statistics_service.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+from typing import Any, cast
+
+import pytest
+import sqlalchemy as sa
+
+from app.db.models.users import LibraryItem, ReadingProgressLog, ReadingSession
+from app.services.reading_statistics import (
+    _as_aware_utc,
+    _canonical_from_log,
+    _from_canonical,
+    _get_item_totals,
+    get_library_item_statistics,
+)
+
+
+class _ScalarIter:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def __iter__(self) -> Any:
+        return iter(self._rows)
+
+
+class _ExecResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> _ScalarIter:
+        return _ScalarIter(self._rows)
+
+    def first(self) -> Any:
+        if not self._rows:
+            return None
+        return self._rows[0]
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.scalar_values: list[Any] = []
+        self.execute_values: list[list[Any]] = []
+
+    def scalar(self, _stmt: sa.Select[Any]) -> Any:
+        if self.scalar_values:
+            return self.scalar_values.pop(0)
+        return None
+
+    def execute(self, _stmt: sa.Select[Any]) -> _ExecResult:
+        rows = self.execute_values.pop(0)
+        return _ExecResult(rows)
+
+
+def _item(*, item_id: uuid.UUID, user_id: uuid.UUID, status: str) -> LibraryItem:
+    now = dt.datetime(2026, 2, 10, tzinfo=dt.UTC)
+    return LibraryItem(
+        id=item_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        preferred_edition_id=None,
+        status=status,
+        visibility="private",
+        rating=None,
+        tags=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _cycle(
+    *,
+    cycle_id: uuid.UUID,
+    user_id: uuid.UUID,
+    item_id: uuid.UUID,
+    started_at: dt.datetime,
+    ended_at: dt.datetime | None,
+    note: str | None = None,
+) -> ReadingSession:
+    return ReadingSession(
+        id=cycle_id,
+        user_id=user_id,
+        library_item_id=item_id,
+        started_at=started_at,
+        ended_at=ended_at,
+        title=None,
+        note=note,
+        created_at=started_at,
+        updated_at=started_at,
+    )
+
+
+def _log(
+    *,
+    log_id: uuid.UUID,
+    user_id: uuid.UUID,
+    item_id: uuid.UUID,
+    cycle_id: uuid.UUID,
+    logged_at: dt.datetime,
+    unit: str,
+    value: float,
+    canonical_percent: float | None,
+    note: str | None = None,
+) -> ReadingProgressLog:
+    return ReadingProgressLog(
+        id=log_id,
+        user_id=user_id,
+        library_item_id=item_id,
+        reading_session_id=cycle_id,
+        logged_at=logged_at,
+        unit=unit,
+        value=Decimal(str(value)),
+        canonical_percent=(
+            Decimal(str(canonical_percent)) if canonical_percent is not None else None
+        ),
+        note=note,
+        created_at=logged_at,
+        updated_at=logged_at,
+    )
+
+
+def test_statistics_aggregates_mixed_units_multi_reads() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle1 = uuid.uuid4()
+    cycle2 = uuid.uuid4()
+    t1 = dt.datetime(2026, 2, 8, 4, tzinfo=dt.UTC)
+    t2 = dt.datetime(2026, 2, 9, 4, tzinfo=dt.UTC)
+    t3 = dt.datetime(2026, 2, 10, 4, tzinfo=dt.UTC)
+
+    session = FakeSession()
+    session.scalar_values = [_item(item_id=item_id, user_id=user_id, status="reading")]
+    session.execute_values = [
+        [(200, 600)],
+        [
+            _cycle(
+                cycle_id=cycle1,
+                user_id=user_id,
+                item_id=item_id,
+                started_at=t1,
+                ended_at=t2,
+                note=None,
+            ),
+            _cycle(
+                cycle_id=cycle2,
+                user_id=user_id,
+                item_id=item_id,
+                started_at=t2,
+                ended_at=None,
+                note="goodreads:abc",
+            ),
+        ],
+        [
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle1,
+                logged_at=t1,
+                unit="pages_read",
+                value=50,
+                canonical_percent=25,
+            ),
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle1,
+                logged_at=t2,
+                unit="minutes_listened",
+                value=150,
+                canonical_percent=25,
+            ),
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle2,
+                logged_at=t3,
+                unit="percent_complete",
+                value=60,
+                canonical_percent=None,
+            ),
+        ],
+    ]
+
+    data = get_library_item_statistics(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+        tz="America/Los_Angeles",
+        days=30,
+    )
+
+    assert data["counts"]["total_cycles"] == 2
+    assert data["counts"]["completed_cycles"] == 1
+    assert data["counts"]["imported_cycles"] == 1
+    assert data["counts"]["completed_reads"] == 1
+    assert data["counts"]["total_logs"] == 3
+    assert data["counts"]["logs_with_canonical"] == 3
+    assert data["current"]["canonical_percent"] == 60.0
+    assert data["current"]["pages_read"] == 120.0
+    assert data["current"]["minutes_listened"] == 360.0
+    assert len(data["series"]["progress_over_time"]) == 3
+    assert len(data["timeline"]) == 3
+
+
+def test_statistics_imported_without_logs_and_completion_fallback() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle = uuid.uuid4()
+    started = dt.datetime(2026, 2, 8, tzinfo=dt.UTC)
+
+    session = FakeSession()
+    session.scalar_values = [
+        _item(item_id=item_id, user_id=user_id, status="completed")
+    ]
+    session.execute_values = [
+        [(None, None), (None, None)],
+        [
+            _cycle(
+                cycle_id=cycle,
+                user_id=user_id,
+                item_id=item_id,
+                started_at=started,
+                ended_at=None,
+                note="storygraph:123",
+            )
+        ],
+        [],
+    ]
+
+    data = get_library_item_statistics(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+    )
+
+    assert data["counts"]["imported_cycles"] == 1
+    assert data["counts"]["completed_cycles"] == 0
+    assert data["counts"]["completed_reads"] == 1
+    assert data["counts"]["total_logs"] == 0
+    assert data["current"]["canonical_percent"] == 0.0
+    assert data["series"]["daily_delta"] == []
+
+
+def test_statistics_flags_unresolved_and_keeps_negative_delta() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle = uuid.uuid4()
+    t1 = dt.datetime(2026, 2, 8, 9, tzinfo=dt.UTC)
+    t2 = dt.datetime(2026, 2, 9, 9, tzinfo=dt.UTC)
+    t3 = dt.datetime(2026, 2, 10, 9, tzinfo=dt.UTC)
+    unresolved_id = uuid.uuid4()
+
+    session = FakeSession()
+    session.scalar_values = [_item(item_id=item_id, user_id=user_id, status="reading")]
+    session.execute_values = [
+        [(None, 120)],
+        [
+            _cycle(
+                cycle_id=cycle,
+                user_id=user_id,
+                item_id=item_id,
+                started_at=t1,
+                ended_at=t3,
+                note=None,
+            )
+        ],
+        [
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=t1,
+                unit="percent_complete",
+                value=50,
+                canonical_percent=50,
+            ),
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=t2,
+                unit="percent_complete",
+                value=30,
+                canonical_percent=30,
+            ),
+            _log(
+                log_id=unresolved_id,
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=t3,
+                unit="pages_read",
+                value=10,
+                canonical_percent=None,
+            ),
+        ],
+    ]
+
+    data = get_library_item_statistics(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+        days=90,
+    )
+
+    assert data["counts"]["logs_missing_canonical"] == 1
+    assert data["data_quality"]["unresolved_logs_exist"] is True
+    assert data["data_quality"]["unresolved_log_ids"] == [str(unresolved_id)]
+    deltas = data["series"]["daily_delta"]
+    assert deltas[1]["canonical_percent_delta"] == -20.0
+    assert any(entry["session_delta"] == -20.0 for entry in data["timeline"])
+
+
+def test_statistics_timezone_and_streak_non_zero_only() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle = uuid.uuid4()
+    # Same UTC day, different local day in America/Los_Angeles.
+    t1 = dt.datetime(2026, 2, 9, 7, 30, tzinfo=dt.UTC)
+    t2 = dt.datetime(2026, 2, 10, 7, 30, tzinfo=dt.UTC)
+
+    session = FakeSession()
+    session.scalar_values = [_item(item_id=item_id, user_id=user_id, status="reading")]
+    session.execute_values = [
+        [(100, 300)],
+        [
+            _cycle(
+                cycle_id=cycle,
+                user_id=user_id,
+                item_id=item_id,
+                started_at=t1,
+                ended_at=None,
+            )
+        ],
+        [
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=t1,
+                unit="percent_complete",
+                value=0,
+                canonical_percent=0,
+            ),
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=t2,
+                unit="percent_complete",
+                value=10,
+                canonical_percent=10,
+            ),
+        ],
+    ]
+
+    data = get_library_item_statistics(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+        tz="America/Los_Angeles",
+    )
+
+    assert data["streak"]["non_zero_days"] == 1
+    assert data["streak"]["last_non_zero_date"] is not None
+    assert data["series"]["progress_over_time"][-1]["canonical_percent"] == 10.0
+
+
+def test_statistics_error_paths() -> None:
+    session = FakeSession()
+    with pytest.raises(ValueError):
+        get_library_item_statistics(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            library_item_id=uuid.uuid4(),
+            days=2,
+        )
+    with pytest.raises(ValueError):
+        get_library_item_statistics(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            library_item_id=uuid.uuid4(),
+            tz="Mars/OlympusMons",
+        )
+
+    session = FakeSession()
+    session.scalar_values = [None]
+    with pytest.raises(LookupError):
+        get_library_item_statistics(
+            cast(Any, session),
+            user_id=uuid.uuid4(),
+            library_item_id=uuid.uuid4(),
+        )
+
+
+def test_statistics_helper_branches() -> None:
+    naive = dt.datetime(2026, 2, 10, 12, 0, 0)
+    aware = _as_aware_utc(naive)
+    assert aware.tzinfo is dt.UTC
+
+    session = FakeSession()
+    session.execute_values = [[], []]
+    assert _get_item_totals(cast(Any, session), library_item_id=uuid.uuid4()) == (
+        None,
+        None,
+    )
+    session = FakeSession()
+    session.execute_values = [[], [(111, 222)]]
+    assert _get_item_totals(cast(Any, session), library_item_id=uuid.uuid4()) == (
+        111,
+        222,
+    )
+
+    log = _log(
+        log_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        item_id=uuid.uuid4(),
+        cycle_id=uuid.uuid4(),
+        logged_at=dt.datetime(2026, 2, 10, tzinfo=dt.UTC),
+        unit="pages_read",
+        value=20,
+        canonical_percent=None,
+    )
+    assert _canonical_from_log(log, total_pages=100, total_audio_minutes=None) == 20.0
+    log.unit = "minutes_listened"
+    assert _canonical_from_log(log, total_pages=None, total_audio_minutes=40) == 50.0
+    assert _canonical_from_log(log, total_pages=None, total_audio_minutes=None) is None
+    log.unit = cast(Any, "unsupported")
+    assert _canonical_from_log(log, total_pages=100, total_audio_minutes=100) is None
+    assert (
+        _from_canonical(
+            unit=cast(Any, "unknown_unit"),
+            canonical_percent=10,
+            total_pages=100,
+            total_audio_minutes=100,
+        )
+        is None
+    )
+
+
+def test_statistics_window_excludes_old_days_and_streak_breaks() -> None:
+    user_id = uuid.uuid4()
+    item_id = uuid.uuid4()
+    cycle = uuid.uuid4()
+    now = dt.datetime.now(dt.UTC)
+    older = now - dt.timedelta(days=30)
+    recent = now - dt.timedelta(days=1)
+
+    session = FakeSession()
+    session.scalar_values = [_item(item_id=item_id, user_id=user_id, status="reading")]
+    session.execute_values = [
+        [(100, 200)],
+        [
+            _cycle(
+                cycle_id=cycle,
+                user_id=user_id,
+                item_id=item_id,
+                started_at=older,
+                ended_at=None,
+            )
+        ],
+        [
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=older,
+                unit="percent_complete",
+                value=20,
+                canonical_percent=20,
+            ),
+            _log(
+                log_id=uuid.uuid4(),
+                user_id=user_id,
+                item_id=item_id,
+                cycle_id=cycle,
+                logged_at=recent,
+                unit="percent_complete",
+                value=40,
+                canonical_percent=40,
+            ),
+        ],
+    ]
+
+    data = get_library_item_statistics(
+        cast(Any, session),
+        user_id=user_id,
+        library_item_id=item_id,
+        days=7,
+    )
+
+    assert len(data["series"]["progress_over_time"]) == 1
+    assert data["streak"]["non_zero_days"] == 1


### PR DESCRIPTION
## Summary
- add a new per-book statistics service that aggregates multi-cycle, multi-unit progress into one canonical payload
- expose `GET /api/v1/library/items/{item_id}/statistics` with timezone/day-window support and strict error handling
- migrate book detail statistics UI to consume server-side aggregates for streak, timeline, and chart data
- refresh statistics after logging interactions while keeping logging UX behavior intact

## API
- new service: `reading_statistics.get_library_item_statistics(...)`
- new route: `GET /api/v1/library/items/{item_id}/statistics?tz=<IANA>&days=<7..365>`
- response includes:
  - totals, counts, current progress, streak
  - series (`progress_over_time`, `daily_delta`)
  - timeline (`start_value`, `end_value`, `session_delta`)
  - data quality flags (`has_missing_totals`, `unresolved_logs_exist`, `unresolved_log_ids`)

## Tests
- added `apps/api/tests/test_reading_statistics_service.py`
- extended `apps/api/tests/test_library_by_work_router.py` for statistics route success and 400/404 cases
- updated `apps/web/tests/unit/pages/book-detail.test.ts` to validate server-driven stats usage and refresh flows

## Validation
- `make quality` (passes)

Closes #146
