### PR TITLE
Ignore Codex environment file in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ __marimo__/
 
 # Local worktree helper dirs (should never be committed)
 .worktrees/
+.codex/environments/environment.toml


### PR DESCRIPTION
## Summary
- add Codex environment file path to root `.gitignore`

## Changes
- ignore `.codex/environments/environment.toml`

## Validation
- pre-push `make quality` passed
