### PR TITLE
Implement Issue #147 user-scoped library merge workflow

### DIFF
--- a/apps/api/alembic/versions/0018_library_item_merges.py
+++ b/apps/api/alembic/versions/0018_library_item_merges.py
@@ -1,0 +1,150 @@
+"""Add library item merge events and relax review uniqueness.
+
+Revision ID: 0018_library_item_merges
+Revises: 0017_user_default_progress_unit
+Create Date: 2026-02-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0018_library_item_merges"
+down_revision = "0017_user_default_progress_unit"
+branch_labels = None
+depends_on = None
+
+
+def _has_unique_constraint(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    constraints = inspector.get_unique_constraints(table_name)
+    return any(constraint.get("name") == constraint_name for constraint in constraints)
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    if _has_unique_constraint("reviews", "uq_reviews_user_library_item"):
+        op.drop_constraint(
+            "uq_reviews_user_library_item",
+            "reviews",
+            type_="unique",
+        )
+
+    if not _has_table("library_item_merge_events"):
+        op.create_table(
+            "library_item_merge_events",
+            sa.Column(
+                "id",
+                sa.UUID(as_uuid=True),
+                primary_key=True,
+                nullable=False,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "user_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "target_library_item_id",
+                sa.UUID(as_uuid=True),
+                sa.ForeignKey("library_items.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "source_library_item_ids",
+                postgresql.ARRAY(sa.UUID(as_uuid=True)),
+                nullable=False,
+            ),
+            sa.Column(
+                "field_resolution",
+                postgresql.JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "result_summary",
+                postgresql.JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.CheckConstraint(
+                "cardinality(source_library_item_ids) >= 1",
+                name="ck_library_item_merge_events_source_nonempty",
+            ),
+        )
+        op.create_index(
+            "ix_library_item_merge_events_user_id",
+            "library_item_merge_events",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_library_item_merge_events_created_at",
+            "library_item_merge_events",
+            ["created_at"],
+        )
+        op.create_index(
+            "ix_library_item_merge_events_target_library_item_id",
+            "library_item_merge_events",
+            ["target_library_item_id"],
+        )
+    op.execute(
+        "ALTER TABLE public.library_item_merge_events ENABLE ROW LEVEL SECURITY;"
+    )
+    op.execute(
+        "DROP POLICY IF EXISTS library_item_merge_events_owner ON public.library_item_merge_events;"
+    )
+    op.execute(
+        """
+        CREATE POLICY library_item_merge_events_owner
+        ON public.library_item_merge_events
+        FOR ALL
+        TO authenticated
+        USING (user_id = auth.uid())
+        WITH CHECK (user_id = auth.uid());
+        """
+    )
+
+
+def downgrade() -> None:
+    if _has_table("library_item_merge_events"):
+        op.execute(
+            "DROP POLICY IF EXISTS library_item_merge_events_owner ON public.library_item_merge_events;"
+        )
+        op.drop_index(
+            "ix_library_item_merge_events_target_library_item_id",
+            table_name="library_item_merge_events",
+        )
+        op.drop_index(
+            "ix_library_item_merge_events_created_at",
+            table_name="library_item_merge_events",
+        )
+        op.drop_index(
+            "ix_library_item_merge_events_user_id",
+            table_name="library_item_merge_events",
+        )
+        op.drop_table("library_item_merge_events")
+
+    if not _has_unique_constraint("reviews", "uq_reviews_user_library_item"):
+        op.create_unique_constraint(
+            "uq_reviews_user_library_item",
+            "reviews",
+            ["user_id", "library_item_id"],
+        )

--- a/apps/api/alembic/versions/0019_merge_events_rls_fix.py
+++ b/apps/api/alembic/versions/0019_merge_events_rls_fix.py
@@ -1,0 +1,41 @@
+"""Backfill RLS policy for library item merge events.
+
+Revision ID: 0019_merge_events_rls_fix
+Revises: 0018_library_item_merges
+Create Date: 2026-02-16
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0019_merge_events_rls_fix"
+down_revision = "0018_library_item_merges"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE public.library_item_merge_events ENABLE ROW LEVEL SECURITY;"
+    )
+    op.execute(
+        "DROP POLICY IF EXISTS library_item_merge_events_owner ON public.library_item_merge_events;"
+    )
+    op.execute(
+        """
+        CREATE POLICY library_item_merge_events_owner
+        ON public.library_item_merge_events
+        FOR ALL
+        TO authenticated
+        USING (user_id = auth.uid())
+        WITH CHECK (user_id = auth.uid());
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS library_item_merge_events_owner ON public.library_item_merge_events;"
+    )

--- a/apps/api/app/db/models/__init__.py
+++ b/apps/api/app/db/models/__init__.py
@@ -12,6 +12,7 @@ from app.db.models.imports import (
 from app.db.models.platform import ApiAuditLog, ApiClient
 from app.db.models.users import (
     LibraryItem,
+    LibraryItemMergeEvent,
     ReadingProgressLog,
     ReadingSession,
     ReadingStateEvent,
@@ -28,6 +29,7 @@ __all__ = [
     "GoodreadsImportJobRow",
     "Highlight",
     "LibraryItem",
+    "LibraryItemMergeEvent",
     "Note",
     "ReadingProgressLog",
     "ReadingSession",

--- a/apps/api/app/db/models/content.py
+++ b/apps/api/app/db/models/content.py
@@ -124,11 +124,6 @@ class Highlight(Base):
 class Review(Base):
     __tablename__ = "reviews"
     __table_args__ = (
-        sa.UniqueConstraint(
-            "user_id",
-            "library_item_id",
-            name="uq_reviews_user_library_item",
-        ),
         sa.CheckConstraint(
             "rating >= 0 AND rating <= 10",
             name="ck_reviews_rating_range",

--- a/apps/api/app/services/library_merges.py
+++ b/apps/api/app/services/library_merges.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Literal, TypeAlias
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.db.models.content import Highlight, Note, Review
+from app.db.models.users import (
+    LibraryItem,
+    LibraryItemMergeEvent,
+    ReadingProgressLog,
+    ReadingSession,
+)
+
+ScalarFieldName: TypeAlias = Literal[
+    "status",
+    "visibility",
+    "rating",
+    "preferred_edition_id",
+]
+FieldName: TypeAlias = Literal[
+    "status",
+    "visibility",
+    "rating",
+    "preferred_edition_id",
+    "tags",
+]
+
+
+_DEPENDENCY_COUNT_KEYS: tuple[str, ...] = (
+    "read_cycles",
+    "progress_logs",
+    "notes",
+    "highlights",
+    "reviews",
+)
+
+
+def _normalize_item_ids(item_ids: list[uuid.UUID]) -> list[uuid.UUID]:
+    seen: set[uuid.UUID] = set()
+    normalized: list[uuid.UUID] = []
+    for item_id in item_ids:
+        if item_id in seen:
+            continue
+        seen.add(item_id)
+        normalized.append(item_id)
+    if len(normalized) < 2:
+        raise ValueError("at least two unique item_ids are required")
+    if len(normalized) > 20:
+        raise ValueError("item_ids cannot exceed 20 entries")
+    return normalized
+
+
+def _parse_keep_strategy(value: str, *, field_name: str) -> uuid.UUID:
+    if not value.startswith("keep:"):
+        raise ValueError(f"{field_name} must use keep:<item_id>")
+    raw_item_id = value.removeprefix("keep:").strip()
+    if not raw_item_id:
+        raise ValueError(f"{field_name} keep strategy requires item_id")
+    try:
+        return uuid.UUID(raw_item_id)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} keep strategy has invalid item_id") from exc
+
+
+def _validate_resolution_item(
+    *, field_name: str, selected_item_id: uuid.UUID, allowed_item_ids: set[uuid.UUID]
+) -> None:
+    if selected_item_id not in allowed_item_ids:
+        raise ValueError(f"{field_name} must reference one of the selected items")
+
+
+def _candidate_fields(item: LibraryItem) -> dict[str, Any]:
+    return {
+        "status": item.status,
+        "visibility": item.visibility,
+        "rating": item.rating,
+        "preferred_edition_id": (
+            str(item.preferred_edition_id) if item.preferred_edition_id else None
+        ),
+        "tags": item.tags or [],
+    }
+
+
+def _ensure_owned_items(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    item_ids: list[uuid.UUID],
+    for_update: bool,
+) -> list[LibraryItem]:
+    stmt = sa.select(LibraryItem).where(
+        LibraryItem.user_id == user_id,
+        LibraryItem.id.in_(item_ids),
+    )
+    if for_update:
+        stmt = stmt.with_for_update()
+    rows = session.execute(stmt).scalars().all()
+    by_id = {row.id: row for row in rows}
+    missing = [item_id for item_id in item_ids if item_id not in by_id]
+    if missing:
+        raise LookupError("one or more library items were not found")
+    return [by_id[item_id] for item_id in item_ids]
+
+
+def _count_by_library_item(
+    session: Session,
+    *,
+    model: type[Any],
+    user_id: uuid.UUID,
+    item_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    rows = session.execute(
+        sa.select(model.library_item_id, sa.func.count())
+        .where(model.user_id == user_id, model.library_item_id.in_(item_ids))
+        .group_by(model.library_item_id)
+    ).all()
+    return {library_item_id: int(count) for library_item_id, count in rows}
+
+
+def _build_dependency_counts(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    item_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, dict[str, int]]:
+    per_item: dict[uuid.UUID, dict[str, int]] = {
+        item_id: {key: 0 for key in _DEPENDENCY_COUNT_KEYS} for item_id in item_ids
+    }
+
+    cycle_counts = _count_by_library_item(
+        session,
+        model=ReadingSession,
+        user_id=user_id,
+        item_ids=item_ids,
+    )
+    log_counts = _count_by_library_item(
+        session,
+        model=ReadingProgressLog,
+        user_id=user_id,
+        item_ids=item_ids,
+    )
+    note_counts = _count_by_library_item(
+        session,
+        model=Note,
+        user_id=user_id,
+        item_ids=item_ids,
+    )
+    highlight_counts = _count_by_library_item(
+        session,
+        model=Highlight,
+        user_id=user_id,
+        item_ids=item_ids,
+    )
+    review_counts = _count_by_library_item(
+        session,
+        model=Review,
+        user_id=user_id,
+        item_ids=item_ids,
+    )
+
+    for item_id, value in cycle_counts.items():
+        per_item[item_id]["read_cycles"] = value
+    for item_id, value in log_counts.items():
+        per_item[item_id]["progress_logs"] = value
+    for item_id, value in note_counts.items():
+        per_item[item_id]["notes"] = value
+    for item_id, value in highlight_counts.items():
+        per_item[item_id]["highlights"] = value
+    for item_id, value in review_counts.items():
+        per_item[item_id]["reviews"] = value
+
+    return per_item
+
+
+def _empty_totals() -> dict[str, int]:
+    return {key: 0 for key in _DEPENDENCY_COUNT_KEYS}
+
+
+def _parse_field_resolution(
+    *,
+    item_ids: list[uuid.UUID],
+    target_item_id: uuid.UUID,
+    field_resolution: dict[str, str],
+) -> dict[str, str]:
+    selected_ids = set(item_ids)
+    parsed: dict[str, str] = {}
+
+    for field_name in ("status", "visibility", "rating", "preferred_edition_id"):
+        raw = field_resolution.get(field_name, f"keep:{target_item_id}")
+        keep_item_id = _parse_keep_strategy(raw, field_name=field_name)
+        _validate_resolution_item(
+            field_name=field_name,
+            selected_item_id=keep_item_id,
+            allowed_item_ids=selected_ids,
+        )
+        parsed[field_name] = f"keep:{keep_item_id}"
+
+    tags_raw = field_resolution.get("tags", "combine")
+    if tags_raw == "combine":
+        parsed["tags"] = "combine"
+    else:
+        keep_item_id = _parse_keep_strategy(tags_raw, field_name="tags")
+        _validate_resolution_item(
+            field_name="tags",
+            selected_item_id=keep_item_id,
+            allowed_item_ids=selected_ids,
+        )
+        parsed["tags"] = f"keep:{keep_item_id}"
+
+    return parsed
+
+
+def preview_library_merge(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    item_ids: list[uuid.UUID],
+    target_item_id: uuid.UUID,
+    field_resolution: dict[str, str],
+) -> dict[str, Any]:
+    normalized_item_ids = _normalize_item_ids(item_ids)
+    if target_item_id not in normalized_item_ids:
+        raise ValueError("target_item_id must be one of item_ids")
+
+    items = _ensure_owned_items(
+        session,
+        user_id=user_id,
+        item_ids=normalized_item_ids,
+        for_update=False,
+    )
+    by_id = {item.id: item for item in items}
+
+    resolved = _parse_field_resolution(
+        item_ids=normalized_item_ids,
+        target_item_id=target_item_id,
+        field_resolution=field_resolution,
+    )
+
+    candidates: dict[str, dict[str, Any]] = {
+        "status": {},
+        "visibility": {},
+        "rating": {},
+        "preferred_edition_id": {},
+        "tags": {},
+    }
+    for item_id in normalized_item_ids:
+        item = by_id[item_id]
+        values = _candidate_fields(item)
+        for field_name, value in values.items():
+            candidates[field_name][str(item_id)] = value
+
+    dependency_counts_by_item = _build_dependency_counts(
+        session,
+        user_id=user_id,
+        item_ids=normalized_item_ids,
+    )
+    dependency_by_item_payload = {
+        str(item_id): counts for item_id, counts in dependency_counts_by_item.items()
+    }
+
+    dependency_totals = _empty_totals()
+    source_item_ids = [
+        item_id for item_id in normalized_item_ids if item_id != target_item_id
+    ]
+    for item_id in source_item_ids:
+        for key in _DEPENDENCY_COUNT_KEYS:
+            dependency_totals[key] += dependency_counts_by_item[item_id][key]
+
+    return {
+        "selection": {
+            "target_item_id": str(target_item_id),
+            "source_item_ids": [str(item_id) for item_id in source_item_ids],
+            "selected_item_ids": [str(item_id) for item_id in normalized_item_ids],
+        },
+        "fields": {
+            "candidates": candidates,
+            "resolution": resolved,
+            "defaults": {
+                "status": f"keep:{target_item_id}",
+                "visibility": f"keep:{target_item_id}",
+                "rating": f"keep:{target_item_id}",
+                "preferred_edition_id": f"keep:{target_item_id}",
+                "tags": "combine",
+            },
+        },
+        "dependencies": {
+            "by_item": dependency_by_item_payload,
+            "totals_for_sources": dependency_totals,
+        },
+        "warnings": [],
+    }
+
+
+def _combine_tags(items: list[LibraryItem]) -> list[str]:
+    combined: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        for tag in item.tags or []:
+            normalized = tag.strip()
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            combined.append(normalized)
+    return combined
+
+
+def _resolve_scalar_value(
+    *,
+    field_name: ScalarFieldName,
+    resolution: dict[str, str],
+    by_item_id: dict[uuid.UUID, LibraryItem],
+) -> Any:
+    keep_item_id = _parse_keep_strategy(
+        resolution[field_name],
+        field_name=field_name,
+    )
+    item = by_item_id.get(keep_item_id)
+    if item is None:
+        raise ValueError(f"{field_name} strategy references an unselected item")
+    return getattr(item, field_name)
+
+
+def apply_library_merge(
+    session: Session,
+    *,
+    user_id: uuid.UUID,
+    item_ids: list[uuid.UUID],
+    target_item_id: uuid.UUID,
+    field_resolution: dict[str, str],
+) -> dict[str, Any]:
+    normalized_item_ids = _normalize_item_ids(item_ids)
+    if target_item_id not in normalized_item_ids:
+        raise ValueError("target_item_id must be one of item_ids")
+
+    resolved = _parse_field_resolution(
+        item_ids=normalized_item_ids,
+        target_item_id=target_item_id,
+        field_resolution=field_resolution,
+    )
+
+    items = _ensure_owned_items(
+        session,
+        user_id=user_id,
+        item_ids=normalized_item_ids,
+        for_update=True,
+    )
+    by_item_id = {item.id: item for item in items}
+    target_item = by_item_id[target_item_id]
+    source_item_ids = [
+        item_id for item_id in normalized_item_ids if item_id != target_item_id
+    ]
+
+    source_items = [by_item_id[item_id] for item_id in source_item_ids]
+    cycle_ids_to_move = list(
+        session.execute(
+            sa.select(ReadingSession.id).where(
+                ReadingSession.user_id == user_id,
+                ReadingSession.library_item_id.in_(source_item_ids),
+            )
+        ).scalars()
+    )
+
+    moved_counts = {
+        "read_cycles": int(
+            session.scalar(
+                sa.select(sa.func.count())
+                .select_from(ReadingSession)
+                .where(
+                    ReadingSession.user_id == user_id,
+                    ReadingSession.library_item_id.in_(source_item_ids),
+                )
+            )
+            or 0
+        ),
+        "progress_logs": int(
+            session.scalar(
+                sa.select(sa.func.count())
+                .select_from(ReadingProgressLog)
+                .where(
+                    ReadingProgressLog.user_id == user_id,
+                    sa.or_(
+                        ReadingProgressLog.library_item_id.in_(source_item_ids),
+                        (
+                            ReadingProgressLog.reading_session_id.in_(cycle_ids_to_move)
+                            if cycle_ids_to_move
+                            else sa.false()
+                        ),
+                    ),
+                )
+            )
+            or 0
+        ),
+        "notes": int(
+            session.scalar(
+                sa.select(sa.func.count())
+                .select_from(Note)
+                .where(
+                    Note.user_id == user_id, Note.library_item_id.in_(source_item_ids)
+                )
+            )
+            or 0
+        ),
+        "highlights": int(
+            session.scalar(
+                sa.select(sa.func.count())
+                .select_from(Highlight)
+                .where(
+                    Highlight.user_id == user_id,
+                    Highlight.library_item_id.in_(source_item_ids),
+                )
+            )
+            or 0
+        ),
+        "reviews": int(
+            session.scalar(
+                sa.select(sa.func.count())
+                .select_from(Review)
+                .where(
+                    Review.user_id == user_id,
+                    Review.library_item_id.in_(source_item_ids),
+                )
+            )
+            or 0
+        ),
+    }
+
+    before_fields = _candidate_fields(target_item)
+
+    target_item.status = _resolve_scalar_value(
+        field_name="status",
+        resolution=resolved,
+        by_item_id=by_item_id,
+    )
+    target_item.visibility = _resolve_scalar_value(
+        field_name="visibility",
+        resolution=resolved,
+        by_item_id=by_item_id,
+    )
+    target_item.rating = _resolve_scalar_value(
+        field_name="rating",
+        resolution=resolved,
+        by_item_id=by_item_id,
+    )
+    target_item.preferred_edition_id = _resolve_scalar_value(
+        field_name="preferred_edition_id",
+        resolution=resolved,
+        by_item_id=by_item_id,
+    )
+
+    if resolved["tags"] == "combine":
+        target_item.tags = _combine_tags([target_item, *source_items])
+    else:
+        tags_keep_item_id = _parse_keep_strategy(resolved["tags"], field_name="tags")
+        tags_keep_item = by_item_id.get(tags_keep_item_id)
+        if tags_keep_item is None:
+            raise ValueError("tags strategy references an unselected item")
+        target_item.tags = tags_keep_item.tags or []
+
+    session.execute(
+        sa.update(ReadingSession)
+        .where(
+            ReadingSession.user_id == user_id,
+            ReadingSession.library_item_id.in_(source_item_ids),
+        )
+        .values(library_item_id=target_item_id)
+    )
+
+    log_relocation_predicate: Any = ReadingProgressLog.library_item_id.in_(
+        source_item_ids
+    )
+    if cycle_ids_to_move:
+        log_relocation_predicate = sa.or_(
+            log_relocation_predicate,
+            ReadingProgressLog.reading_session_id.in_(cycle_ids_to_move),
+        )
+
+    session.execute(
+        sa.update(ReadingProgressLog)
+        .where(
+            ReadingProgressLog.user_id == user_id,
+            log_relocation_predicate,
+        )
+        .values(library_item_id=target_item_id)
+    )
+    session.execute(
+        sa.update(Note)
+        .where(Note.user_id == user_id, Note.library_item_id.in_(source_item_ids))
+        .values(library_item_id=target_item_id)
+    )
+    session.execute(
+        sa.update(Highlight)
+        .where(
+            Highlight.user_id == user_id, Highlight.library_item_id.in_(source_item_ids)
+        )
+        .values(library_item_id=target_item_id)
+    )
+    session.execute(
+        sa.update(Review)
+        .where(Review.user_id == user_id, Review.library_item_id.in_(source_item_ids))
+        .values(library_item_id=target_item_id)
+    )
+
+    session.execute(
+        sa.delete(LibraryItem).where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.id.in_(source_item_ids),
+        )
+    )
+
+    after_fields = _candidate_fields(target_item)
+    merge_event = LibraryItemMergeEvent(
+        user_id=user_id,
+        target_library_item_id=target_item_id,
+        source_library_item_ids=source_item_ids,
+        field_resolution=resolved,
+        result_summary={
+            "selection": {
+                "target_item_id": str(target_item_id),
+                "source_item_ids": [str(item_id) for item_id in source_item_ids],
+            },
+            "moved_counts": moved_counts,
+            "fields": {"before": before_fields, "after": after_fields},
+        },
+    )
+    session.add(merge_event)
+    session.commit()
+
+    message = (
+        f"Merged {len(normalized_item_ids)} books into 1. "
+        f"Moved {sum(moved_counts.values())} dependent records."
+    )
+
+    return {
+        "merge_event_id": str(merge_event.id),
+        "target_item_id": str(target_item_id),
+        "merged_source_item_ids": [str(item_id) for item_id in source_item_ids],
+        "moved_counts": moved_counts,
+        "fields": {
+            "before": before_fields,
+            "after": after_fields,
+        },
+        "message": message,
+    }

--- a/apps/api/app/services/reviews.py
+++ b/apps/api/app/services/reviews.py
@@ -102,10 +102,13 @@ def upsert_review_for_work(
         item.preferred_edition_id = edition_id
 
     model = session.scalar(
-        sa.select(Review).where(
+        sa.select(Review)
+        .where(
             Review.user_id == user_id,
             Review.library_item_id == item.id,
         )
+        .order_by(Review.created_at.desc(), Review.id.desc())
+        .limit(1)
     )
     now = dt.datetime.now(tz=dt.UTC)
     if model is None:

--- a/apps/api/tests/test_content_models.py
+++ b/apps/api/tests/test_content_models.py
@@ -156,16 +156,6 @@ def test_reviews_table_schema_and_constraints() -> None:
     assert user_fk.ondelete == "CASCADE"
     assert library_item_fk.ondelete == "CASCADE"
 
-    unique_constraints = [
-        constraint
-        for constraint in table.constraints
-        if isinstance(constraint, sa.UniqueConstraint)
-    ]
-    unique_sets = {
-        tuple(constraint.columns.keys()) for constraint in unique_constraints
-    }
-    assert ("user_id", "library_item_id") in unique_sets
-
     check_constraints = [
         constraint
         for constraint in table.constraints

--- a/apps/api/tests/test_library_merges_service.py
+++ b/apps/api/tests/test_library_merges_service.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any, cast
+
+import pytest
+
+from app.db.models.users import LibraryItem
+from app.services.library_merges import apply_library_merge, preview_library_merge
+
+
+class _ScalarIter:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return list(self._rows)
+
+    def __iter__(self) -> Any:
+        return iter(self._rows)
+
+
+class _ExecResult:
+    def __init__(self, *, rows: list[Any] | None = None) -> None:
+        self._rows = rows or []
+
+    def scalars(self) -> _ScalarIter:
+        return _ScalarIter(self._rows)
+
+    def all(self) -> list[Any]:
+        return list(self._rows)
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.execute_values: list[list[Any]] = []
+        self.scalar_values: list[Any] = []
+        self.added: list[Any] = []
+        self.committed = False
+        self.execute_calls = 0
+
+    def execute(self, _stmt: Any) -> _ExecResult:
+        self.execute_calls += 1
+        rows = self.execute_values.pop(0) if self.execute_values else []
+        return _ExecResult(rows=rows)
+
+    def scalar(self, _stmt: Any) -> Any:
+        if self.scalar_values:
+            return self.scalar_values.pop(0)
+        return 0
+
+    def add(self, obj: Any) -> None:
+        if getattr(obj, "id", None) is None and hasattr(obj, "id"):
+            obj.id = uuid.uuid4()
+        self.added.append(obj)
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def _item(
+    *,
+    item_id: uuid.UUID,
+    user_id: uuid.UUID,
+    work_id: uuid.UUID,
+    status: str,
+    visibility: str,
+    rating: int | None,
+    preferred_edition_id: uuid.UUID | None,
+    tags: list[str] | None,
+) -> LibraryItem:
+    now = dt.datetime.now(tz=dt.UTC)
+    return LibraryItem(
+        id=item_id,
+        user_id=user_id,
+        work_id=work_id,
+        preferred_edition_id=preferred_edition_id,
+        status=status,
+        visibility=visibility,
+        rating=rating,
+        tags=tags,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_preview_library_merge_returns_candidates_and_defaults() -> None:
+    user_id = uuid.uuid4()
+    target_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+
+    target = _item(
+        item_id=target_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="reading",
+        visibility="private",
+        rating=6,
+        preferred_edition_id=uuid.uuid4(),
+        tags=["SciFi", "Space"],
+    )
+    source = _item(
+        item_id=source_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="completed",
+        visibility="public",
+        rating=9,
+        preferred_edition_id=None,
+        tags=["Space", "Award"],
+    )
+
+    session = FakeSession()
+    session.execute_values = [
+        [target, source],
+        [(target_id, 1), (source_id, 2)],
+        [(source_id, 3)],
+        [(source_id, 4)],
+        [(source_id, 5)],
+        [(source_id, 6)],
+    ]
+
+    preview = preview_library_merge(
+        cast(Any, session),
+        user_id=user_id,
+        item_ids=[target_id, source_id],
+        target_item_id=target_id,
+        field_resolution={},
+    )
+
+    assert preview["selection"]["target_item_id"] == str(target_id)
+    assert preview["fields"]["defaults"]["tags"] == "combine"
+    assert preview["fields"]["candidates"]["status"][str(source_id)] == "completed"
+    assert preview["dependencies"]["totals_for_sources"]["reviews"] == 6
+
+
+def test_preview_library_merge_rejects_invalid_target() -> None:
+    user_id = uuid.uuid4()
+    item_id_a = uuid.uuid4()
+    item_id_b = uuid.uuid4()
+    with pytest.raises(ValueError):
+        preview_library_merge(
+            cast(Any, FakeSession()),
+            user_id=user_id,
+            item_ids=[item_id_a, item_id_b],
+            target_item_id=uuid.uuid4(),
+            field_resolution={},
+        )
+
+
+def test_apply_library_merge_moves_records_and_creates_event() -> None:
+    user_id = uuid.uuid4()
+    target_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    target_edition_id = uuid.uuid4()
+
+    target = _item(
+        item_id=target_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="reading",
+        visibility="private",
+        rating=6,
+        preferred_edition_id=target_edition_id,
+        tags=["SciFi", "Space"],
+    )
+    source = _item(
+        item_id=source_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="completed",
+        visibility="public",
+        rating=9,
+        preferred_edition_id=None,
+        tags=["Space", "Award"],
+    )
+
+    session = FakeSession()
+    session.execute_values = [
+        [target, source],
+        [uuid.uuid4()],
+        [],
+        [],
+        [],
+        [],
+        [],
+    ]
+    session.scalar_values = [1, 2, 3, 4, 5]
+
+    result = apply_library_merge(
+        cast(Any, session),
+        user_id=user_id,
+        item_ids=[target_id, source_id],
+        target_item_id=target_id,
+        field_resolution={
+            "status": f"keep:{source_id}",
+            "visibility": f"keep:{target_id}",
+            "rating": f"keep:{source_id}",
+            "preferred_edition_id": f"keep:{target_id}",
+            "tags": "combine",
+        },
+    )
+
+    assert result["target_item_id"] == str(target_id)
+    assert result["moved_counts"]["read_cycles"] == 1
+    assert target.status == "completed"
+    assert target.visibility == "private"
+    assert target.rating == 9
+    assert target.preferred_edition_id == target_edition_id
+    assert target.tags == ["SciFi", "Space", "Award"]
+    assert session.committed is True
+    assert len(session.added) == 1
+
+
+def test_apply_library_merge_rejects_invalid_resolution() -> None:
+    user_id = uuid.uuid4()
+    item_id_a = uuid.uuid4()
+    item_id_b = uuid.uuid4()
+
+    with pytest.raises(ValueError):
+        apply_library_merge(
+            cast(Any, FakeSession()),
+            user_id=user_id,
+            item_ids=[item_id_a, item_id_b],
+            target_item_id=item_id_a,
+            field_resolution={"status": "combine"},
+        )
+
+
+def test_preview_library_merge_raises_when_item_ownership_missing() -> None:
+    user_id = uuid.uuid4()
+    item_id_a = uuid.uuid4()
+    item_id_b = uuid.uuid4()
+    session = FakeSession()
+    session.execute_values = [[]]
+    with pytest.raises(LookupError):
+        preview_library_merge(
+            cast(Any, session),
+            user_id=user_id,
+            item_ids=[item_id_a, item_id_b],
+            target_item_id=item_id_a,
+            field_resolution={},
+        )
+
+
+def test_preview_library_merge_accepts_keep_tags_strategy() -> None:
+    user_id = uuid.uuid4()
+    target_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    target = _item(
+        item_id=target_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="reading",
+        visibility="private",
+        rating=1,
+        preferred_edition_id=None,
+        tags=["A"],
+    )
+    source = _item(
+        item_id=source_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="completed",
+        visibility="public",
+        rating=2,
+        preferred_edition_id=None,
+        tags=["B"],
+    )
+    session = FakeSession()
+    session.execute_values = [
+        [target, source],
+        [],
+        [],
+        [],
+        [],
+        [],
+    ]
+    payload = preview_library_merge(
+        cast(Any, session),
+        user_id=user_id,
+        item_ids=[target_id, source_id],
+        target_item_id=target_id,
+        field_resolution={"tags": f"keep:{source_id}"},
+    )
+    assert payload["fields"]["resolution"]["tags"] == f"keep:{source_id}"
+
+
+def test_apply_library_merge_uses_tags_keep_and_empty_cycle_path() -> None:
+    user_id = uuid.uuid4()
+    target_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    target = _item(
+        item_id=target_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="reading",
+        visibility="private",
+        rating=5,
+        preferred_edition_id=None,
+        tags=["A", "B"],
+    )
+    source = _item(
+        item_id=source_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="completed",
+        visibility="public",
+        rating=7,
+        preferred_edition_id=None,
+        tags=["Z"],
+    )
+    session = FakeSession()
+    session.execute_values = [
+        [target, source],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+    ]
+    session.scalar_values = [0, 0, 0, 0, 0]
+    result = apply_library_merge(
+        cast(Any, session),
+        user_id=user_id,
+        item_ids=[target_id, source_id],
+        target_item_id=target_id,
+        field_resolution={
+            "status": f"keep:{target_id}",
+            "visibility": f"keep:{target_id}",
+            "rating": f"keep:{target_id}",
+            "preferred_edition_id": f"keep:{target_id}",
+            "tags": f"keep:{source_id}",
+        },
+    )
+    assert result["moved_counts"]["read_cycles"] == 0
+    assert target.tags == ["Z"]
+
+
+def test_apply_library_merge_rejects_invalid_tags_keep_reference() -> None:
+    user_id = uuid.uuid4()
+    target_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    bad_id = uuid.uuid4()
+    target = _item(
+        item_id=target_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="reading",
+        visibility="private",
+        rating=5,
+        preferred_edition_id=None,
+        tags=["A"],
+    )
+    source = _item(
+        item_id=source_id,
+        user_id=user_id,
+        work_id=uuid.uuid4(),
+        status="completed",
+        visibility="public",
+        rating=7,
+        preferred_edition_id=None,
+        tags=["B"],
+    )
+    session = FakeSession()
+    session.execute_values = [[target, source]]
+    with pytest.raises(ValueError):
+        apply_library_merge(
+            cast(Any, session),
+            user_id=user_id,
+            item_ids=[target_id, source_id],
+            target_item_id=target_id,
+            field_resolution={
+                "status": f"keep:{target_id}",
+                "visibility": f"keep:{target_id}",
+                "rating": f"keep:{target_id}",
+                "preferred_edition_id": f"keep:{target_id}",
+                "tags": f"keep:{bad_id}",
+            },
+        )
+
+
+def test_library_merge_validates_item_count_limits() -> None:
+    user_id = uuid.uuid4()
+    one = uuid.uuid4()
+    with pytest.raises(ValueError):
+        preview_library_merge(
+            cast(Any, FakeSession()),
+            user_id=user_id,
+            item_ids=[one, one],
+            target_item_id=one,
+            field_resolution={},
+        )
+
+    too_many = [uuid.uuid4() for _ in range(21)]
+    with pytest.raises(ValueError):
+        preview_library_merge(
+            cast(Any, FakeSession()),
+            user_id=user_id,
+            item_ids=too_many,
+            target_item_id=too_many[0],
+            field_resolution={},
+        )

--- a/apps/api/tests/test_rls_policies.py
+++ b/apps/api/tests/test_rls_policies.py
@@ -15,6 +15,7 @@ from psycopg.types.json import Json
 USER_SCOPED_TABLES = {
     "users": "id",
     "library_items": "user_id",
+    "library_item_merge_events": "user_id",
     "reading_sessions": "user_id",
     "reading_progress_logs": "user_id",
     "reading_state_events": "user_id",
@@ -803,6 +804,7 @@ def test_all_public_tables_accounted_for(db_url: str) -> None:
         "alembic_version",
         "users",
         "library_items",
+        "library_item_merge_events",
         "reading_sessions",
         "reading_progress_logs",
         "reading_state_events",

--- a/supabase/migrations/20260216150000_add_library_item_merge_events.sql
+++ b/supabase/migrations/20260216150000_add_library_item_merge_events.sql
@@ -1,0 +1,30 @@
+ALTER TABLE public.reviews
+  DROP CONSTRAINT IF EXISTS uq_reviews_user_library_item;
+
+CREATE TABLE IF NOT EXISTS public.library_item_merge_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  target_library_item_id uuid REFERENCES public.library_items(id) ON DELETE SET NULL,
+  source_library_item_ids uuid[] NOT NULL,
+  field_resolution jsonb NOT NULL DEFAULT '{}'::jsonb,
+  result_summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ck_library_item_merge_events_source_nonempty
+    CHECK (cardinality(source_library_item_ids) >= 1)
+);
+
+CREATE INDEX IF NOT EXISTS ix_library_item_merge_events_user_id
+  ON public.library_item_merge_events (user_id);
+CREATE INDEX IF NOT EXISTS ix_library_item_merge_events_created_at
+  ON public.library_item_merge_events (created_at);
+CREATE INDEX IF NOT EXISTS ix_library_item_merge_events_target_library_item_id
+  ON public.library_item_merge_events (target_library_item_id);
+
+ALTER TABLE public.library_item_merge_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS library_item_merge_events_owner ON public.library_item_merge_events;
+CREATE POLICY library_item_merge_events_owner
+ON public.library_item_merge_events
+FOR ALL
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/20260216183000_backfill_library_item_merge_events_rls.sql
+++ b/supabase/migrations/20260216183000_backfill_library_item_merge_events_rls.sql
@@ -1,0 +1,10 @@
+ALTER TABLE public.library_item_merge_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS library_item_merge_events_owner ON public.library_item_merge_events;
+
+CREATE POLICY library_item_merge_events_owner
+ON public.library_item_merge_events
+FOR ALL
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
This PR implements Issue #147 end-to-end for user-scoped multi-book merge in table view, plus dev startup improvements for migration safety.

### API and data model
- Added merge preview and apply endpoints:
  - `POST /api/v1/library/items/merge/preview`
  - `POST /api/v1/library/items/merge`
- Added merge service:
  - `/Users/ryan/Developer/chapterverse/apps/api/app/services/library_merges.py`
- Added merge audit model/table support (`library_item_merge_events`) with persisted result summaries.
- Removed `reviews` uniqueness on `(user_id, library_item_id)` to allow multiple reviews after merge.
- Kept review endpoint behavior as upsert-latest, and made latest selection deterministic when multiple reviews exist.
- Ensured user-scoped RLS coverage for merge events in both Alembic and Supabase migrations.

### Web merge workflow (table view)
- Added table multi-select merge flow on `/library`.
- Added merge dialog with:
  - target book selection
  - per-field conflict resolution
  - dependency move counts summary
  - irreversible warning
- UX updates requested during review:
  - removed "Canonical" terminology
  - when all selected values are identical, display value text instead of a dropdown
  - for differing values, dropdown text shows `value (book title)`
  - visibility default prefers `Private` if any selected item is private
- On successful merge, dialog now dismisses, selection clears, toast appears, and page data refreshes.

### Dev workflow updates
- Added `dev-codex` target in `/Users/ryan/Developer/chapterverse/Makefile` to:
  - free ports `3000` and `8000`
  - clear `apps/web/.nuxt` and `apps/web/.output`
  - start full dev stack
- Added `ensure-dev-db` and wired `dev` to auto-run DB migrations on startup.

### Migrations
- `/Users/ryan/Developer/chapterverse/apps/api/alembic/versions/0018_library_item_merges.py`
- `/Users/ryan/Developer/chapterverse/apps/api/alembic/versions/0019_merge_events_rls_fix.py`
- `/Users/ryan/Developer/chapterverse/supabase/migrations/20260216150000_add_library_item_merge_events.sql`
- `/Users/ryan/Developer/chapterverse/supabase/migrations/20260216183000_backfill_library_item_merge_events_rls.sql`

## Testing
- `make quality`

Closes #147.
