### PR TITLE
feat(web+api): theming v2 with user-selectable primary/accent colors and font

### DIFF
--- a/apps/api/alembic/versions/0020_user_theme_preferences.py
+++ b/apps/api/alembic/versions/0020_user_theme_preferences.py
@@ -1,0 +1,49 @@
+"""Add user theme preference columns.
+
+Revision ID: 0020_user_theme_preferences
+Revises: 0019_merge_events_rls_fix
+Create Date: 2026-02-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0020_user_theme_preferences"
+down_revision = "0019_merge_events_rls_fix"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = inspector.get_columns(table_name)
+    return any(column["name"] == column_name for column in columns)
+
+
+def upgrade() -> None:
+    if not _column_exists("users", "theme_primary_color"):
+        op.add_column(
+            "users", sa.Column("theme_primary_color", sa.Text(), nullable=True)
+        )
+    if not _column_exists("users", "theme_accent_color"):
+        op.add_column(
+            "users", sa.Column("theme_accent_color", sa.Text(), nullable=True)
+        )
+    if not _column_exists("users", "theme_font_family"):
+        op.add_column(
+            "users", sa.Column("theme_font_family", sa.String(length=32), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    if _column_exists("users", "theme_font_family"):
+        op.drop_column("users", "theme_font_family")
+    if _column_exists("users", "theme_accent_color"):
+        op.drop_column("users", "theme_accent_color")
+    if _column_exists("users", "theme_primary_color"):
+        op.drop_column("users", "theme_primary_color")

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -58,6 +58,9 @@ class User(Base):
         nullable=False,
         server_default=sa.text("false"),
     )
+    theme_primary_color: Mapped[str | None] = mapped_column(sa.Text)
+    theme_accent_color: Mapped[str | None] = mapped_column(sa.Text)
+    theme_font_family: Mapped[str | None] = mapped_column(sa.String(32))
     default_progress_unit: Mapped[str] = mapped_column(
         reading_progress_unit_enum,
         nullable=False,

--- a/apps/api/app/routers/me.py
+++ b/apps/api/app/routers/me.py
@@ -18,6 +18,9 @@ class UpdateProfileRequest(BaseModel):
     display_name: str | None = Field(default=None, max_length=255)
     avatar_url: str | None = Field(default=None, max_length=2048)
     enable_google_books: bool | None = None
+    theme_primary_color: str | None = Field(default=None, max_length=7)
+    theme_accent_color: str | None = Field(default=None, max_length=7)
+    theme_font_family: str | None = Field(default=None, max_length=32)
     default_progress_unit: (
         Literal["pages_read", "percent_complete", "minutes_listened"] | None
     ) = None
@@ -43,6 +46,9 @@ def get_me(
             "display_name": profile.display_name,
             "avatar_url": profile.avatar_url,
             "enable_google_books": profile.enable_google_books,
+            "theme_primary_color": profile.theme_primary_color,
+            "theme_accent_color": profile.theme_accent_color,
+            "theme_font_family": profile.theme_font_family,
             "default_progress_unit": profile.default_progress_unit,
         }
     )
@@ -62,6 +68,9 @@ def patch_me(
             display_name=payload.display_name,
             avatar_url=payload.avatar_url,
             enable_google_books=payload.enable_google_books,
+            theme_primary_color=payload.theme_primary_color,
+            theme_accent_color=payload.theme_accent_color,
+            theme_font_family=payload.theme_font_family,
             default_progress_unit=payload.default_progress_unit,
         )
     except ValueError as exc:
@@ -74,6 +83,9 @@ def patch_me(
             "display_name": profile.display_name,
             "avatar_url": profile.avatar_url,
             "enable_google_books": profile.enable_google_books,
+            "theme_primary_color": profile.theme_primary_color,
+            "theme_accent_color": profile.theme_accent_color,
+            "theme_font_family": profile.theme_font_family,
             "default_progress_unit": profile.default_progress_unit,
         }
     )

--- a/apps/api/tests/test_user_library_models.py
+++ b/apps/api/tests/test_user_library_models.py
@@ -34,6 +34,9 @@ def test_users_table_schema() -> None:
         "display_name",
         "avatar_url",
         "enable_google_books",
+        "theme_primary_color",
+        "theme_accent_color",
+        "theme_font_family",
         "default_progress_unit",
         "actor_uri",
         "created_at",
@@ -47,6 +50,10 @@ def test_users_table_schema() -> None:
     assert table.columns["display_name"].type.length == 255
     assert isinstance(table.columns["avatar_url"].type, sa.Text)
     assert isinstance(table.columns["enable_google_books"].type, sa.Boolean)
+    assert isinstance(table.columns["theme_primary_color"].type, sa.Text)
+    assert isinstance(table.columns["theme_accent_color"].type, sa.Text)
+    assert isinstance(table.columns["theme_font_family"].type, sa.String)
+    assert table.columns["theme_font_family"].type.length == 32
     assert isinstance(table.columns["default_progress_unit"].type, sa.Enum)
     assert table.columns["default_progress_unit"].type.enums == [
         "pages_read",

--- a/apps/api/tests/test_user_library_service.py
+++ b/apps/api/tests/test_user_library_service.py
@@ -133,6 +133,9 @@ def test_update_profile_validates_handle() -> None:
             display_name=None,
             avatar_url=None,
             enable_google_books=None,
+            theme_primary_color=None,
+            theme_accent_color=None,
+            theme_font_family=None,
             default_progress_unit=None,
         )
 
@@ -151,6 +154,9 @@ def test_update_profile_rejects_duplicate_handle() -> None:
             display_name=None,
             avatar_url=None,
             enable_google_books=None,
+            theme_primary_color=None,
+            theme_accent_color=None,
+            theme_font_family=None,
             default_progress_unit=None,
         )
 
@@ -168,6 +174,9 @@ def test_update_profile_updates_fields() -> None:
         display_name=" Name ",
         avatar_url=" https://example.com/avatar.png ",
         enable_google_books=True,
+        theme_primary_color="#112233",
+        theme_accent_color="#445566",
+        theme_font_family="ibm_plex_sans",
         default_progress_unit="minutes_listened",
     )
     assert updated is profile
@@ -175,7 +184,64 @@ def test_update_profile_updates_fields() -> None:
     assert updated.display_name == "Name"
     assert updated.avatar_url == "https://example.com/avatar.png"
     assert updated.enable_google_books is True
+    assert updated.theme_primary_color == "#112233"
+    assert updated.theme_accent_color == "#445566"
+    assert updated.theme_font_family == "ibm_plex_sans"
     assert updated.default_progress_unit == "minutes_listened"
+
+
+def test_update_profile_rejects_invalid_theme_colors() -> None:
+    session = FakeSession()
+    user_id = uuid.uuid4()
+    get_or_create_profile(cast(Any, session), user_id=user_id)
+
+    with pytest.raises(ValueError):
+        update_profile(
+            cast(Any, session),
+            user_id=user_id,
+            handle=None,
+            display_name=None,
+            avatar_url=None,
+            enable_google_books=None,
+            theme_primary_color="#12345",
+            theme_accent_color=None,
+            theme_font_family=None,
+            default_progress_unit=None,
+        )
+
+    with pytest.raises(ValueError):
+        update_profile(
+            cast(Any, session),
+            user_id=user_id,
+            handle=None,
+            display_name=None,
+            avatar_url=None,
+            enable_google_books=None,
+            theme_primary_color=None,
+            theme_accent_color="red",
+            theme_font_family=None,
+            default_progress_unit=None,
+        )
+
+
+def test_update_profile_rejects_invalid_theme_font() -> None:
+    session = FakeSession()
+    user_id = uuid.uuid4()
+    get_or_create_profile(cast(Any, session), user_id=user_id)
+
+    with pytest.raises(ValueError):
+        update_profile(
+            cast(Any, session),
+            user_id=user_id,
+            handle=None,
+            display_name=None,
+            avatar_url=None,
+            enable_google_books=None,
+            theme_primary_color=None,
+            theme_accent_color=None,
+            theme_font_family=cast(Any, "comic_sans"),
+            default_progress_unit=None,
+        )
 
 
 def test_create_or_get_library_item_handles_missing_work() -> None:

--- a/apps/web/app/app.vue
+++ b/apps/web/app/app.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    class="min-h-screen bg-[var(--p-surface-50)] font-sans text-[var(--p-text-color)] dark:bg-[var(--p-surface-950)]"
+    class="min-h-screen bg-[var(--p-surface-50)] text-[var(--p-text-color)] dark:bg-[var(--p-surface-950)]"
+    style="font-family: var(--app-font-family)"
     :data-test="shellTestId"
   >
     <NuxtRouteAnnouncer />

--- a/apps/web/app/assets/css/base.css
+++ b/apps/web/app/assets/css/base.css
@@ -1,7 +1,21 @@
-/* Intentionally empty.
- *
- * This file exists for compatibility with Nuxt/preview builds that still
- * reference it in generated CSS entrypoints.
- *
- * PrimeVue provides all component styling; avoid custom CSS overrides here.
- */
+:root {
+  --app-theme-primary: #6366f1;
+  --app-theme-primary-safe-light: #4f46e5;
+  --app-theme-primary-safe-dark: #818cf8;
+  --app-theme-primary-contrast: #ffffff;
+  --app-theme-accent: #14b8a6;
+  --app-theme-accent-safe-light: #0f766e;
+  --app-theme-accent-safe-dark: #2dd4bf;
+  --app-theme-accent-contrast: #111827;
+  --app-font-family: 'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif;
+}
+
+.dark {
+  --app-theme-surface-primary: var(--app-theme-primary-safe-dark);
+  --app-theme-surface-accent: var(--app-theme-accent-safe-dark);
+}
+
+:root:not(.dark) {
+  --app-theme-surface-primary: var(--app-theme-primary-safe-light);
+  --app-theme-surface-accent: var(--app-theme-accent-safe-light);
+}

--- a/apps/web/app/composables/useUserTheme.ts
+++ b/apps/web/app/composables/useUserTheme.ts
@@ -1,0 +1,216 @@
+import { updatePreset, updatePrimaryPalette } from '@primeuix/themes';
+
+export type ThemeFontFamily = 'atkinson' | 'ibm_plex_sans' | 'fraunces';
+
+export type UserThemeSettings = {
+  theme_primary_color?: string | null;
+  theme_accent_color?: string | null;
+  theme_font_family?: ThemeFontFamily | null;
+};
+
+export type ThemeWarning = {
+  field: 'theme_primary_color' | 'theme_accent_color';
+  message: string;
+};
+
+const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
+const LIGHT_SURFACE = '#FFFFFF';
+const DARK_SURFACE = '#0F172A';
+const DEFAULT_PRIMARY_COLOR = '#6366F1';
+const DEFAULT_ACCENT_COLOR = '#14B8A6';
+const DEFAULT_FONT_FAMILY: ThemeFontFamily = 'ibm_plex_sans';
+const MIN_SURFACE_CONTRAST = 3;
+
+export const FONT_FAMILY_STACKS: Record<ThemeFontFamily, string> = {
+  atkinson: "'Atkinson Hyperlegible', ui-sans-serif, system-ui, sans-serif",
+  ibm_plex_sans: "'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif",
+  fraunces: "'Fraunces', ui-serif, Georgia, serif",
+};
+
+type Rgb = { r: number; g: number; b: number };
+
+const clamp = (value: number) => Math.max(0, Math.min(255, value));
+
+const toRgb = (hex: string): Rgb => ({
+  r: Number.parseInt(hex.slice(1, 3), 16),
+  g: Number.parseInt(hex.slice(3, 5), 16),
+  b: Number.parseInt(hex.slice(5, 7), 16),
+});
+
+const toHex = ({ r, g, b }: Rgb): string =>
+  `#${[r, g, b]
+    .map((part) => clamp(Math.round(part)).toString(16).padStart(2, '0'))
+    .join('')}`.toUpperCase();
+
+const mix = (base: Rgb, target: Rgb, amount: number): Rgb => ({
+  r: base.r + (target.r - base.r) * amount,
+  g: base.g + (target.g - base.g) * amount,
+  b: base.b + (target.b - base.b) * amount,
+});
+
+const toLinear = (channel: number): number => {
+  const normalized = channel / 255;
+  if (normalized <= 0.03928) return normalized / 12.92;
+  return ((normalized + 0.055) / 1.055) ** 2.4;
+};
+
+const luminance = (hex: string): number => {
+  const rgb = toRgb(hex);
+  return 0.2126 * toLinear(rgb.r) + 0.7152 * toLinear(rgb.g) + 0.0722 * toLinear(rgb.b);
+};
+
+const contrastRatio = (a: string, b: string): number => {
+  const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (high + 0.05) / (low + 0.05);
+};
+
+const bestTextColor = (background: string): string =>
+  contrastRatio(background, '#FFFFFF') >= contrastRatio(background, '#111827')
+    ? '#FFFFFF'
+    : '#111827';
+
+const findSafeColorForSurface = (
+  baseHex: string,
+  surfaceHex: string,
+  minContrast: number,
+  strategy: 'lighten' | 'darken',
+): string => {
+  if (contrastRatio(baseHex, surfaceHex) >= minContrast) return baseHex;
+  const rgb = toRgb(baseHex);
+  const target = strategy === 'lighten' ? toRgb('#FFFFFF') : toRgb('#000000');
+  for (let i = 1; i <= 24; i += 1) {
+    const candidate = toHex(mix(rgb, target, i / 24));
+    if (contrastRatio(candidate, surfaceHex) >= minContrast) return candidate;
+  }
+  return baseHex;
+};
+
+const buildPalette = (hex: string): Record<string, string> => {
+  const base = toRgb(hex);
+  const white = toRgb('#FFFFFF');
+  const black = toRgb('#000000');
+  return {
+    '50': toHex(mix(base, white, 0.9)),
+    '100': toHex(mix(base, white, 0.78)),
+    '200': toHex(mix(base, white, 0.62)),
+    '300': toHex(mix(base, white, 0.46)),
+    '400': toHex(mix(base, white, 0.24)),
+    '500': toHex(base),
+    '600': toHex(mix(base, black, 0.12)),
+    '700': toHex(mix(base, black, 0.24)),
+    '800': toHex(mix(base, black, 0.36)),
+    '900': toHex(mix(base, black, 0.5)),
+    '950': toHex(mix(base, black, 0.64)),
+  };
+};
+
+export const normalizeHexColor = (value: string | null | undefined): string | null => {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!HEX_COLOR_REGEX.test(trimmed)) return null;
+  return trimmed.toUpperCase();
+};
+
+export const isThemeFontFamily = (value: string | null | undefined): value is ThemeFontFamily =>
+  value === 'atkinson' || value === 'ibm_plex_sans' || value === 'fraunces';
+
+export const getThemeWarnings = (settings: UserThemeSettings): ThemeWarning[] => {
+  const warnings: ThemeWarning[] = [];
+  const pairs: Array<{ field: ThemeWarning['field']; value: string | null }> = [
+    { field: 'theme_primary_color', value: normalizeHexColor(settings.theme_primary_color) },
+    { field: 'theme_accent_color', value: normalizeHexColor(settings.theme_accent_color) },
+  ];
+
+  for (const pair of pairs) {
+    if (!pair.value) continue;
+    const lightContrast = contrastRatio(pair.value, LIGHT_SURFACE);
+    const darkContrast = contrastRatio(pair.value, DARK_SURFACE);
+    if (lightContrast < MIN_SURFACE_CONTRAST || darkContrast < MIN_SURFACE_CONTRAST) {
+      const mode = lightContrast < MIN_SURFACE_CONTRAST ? 'light' : 'dark';
+      warnings.push({
+        field: pair.field,
+        message: `${pair.field === 'theme_primary_color' ? 'Primary' : 'Accent'} color may blend in for some users in ${mode} mode. Readability fallbacks will still be applied.`,
+      });
+    }
+  }
+
+  return warnings;
+};
+
+export const applyUserTheme = (settings: UserThemeSettings) => {
+  if (!globalThis.document?.documentElement) return;
+  const root = globalThis.document.documentElement;
+
+  const primary = normalizeHexColor(settings.theme_primary_color) ?? DEFAULT_PRIMARY_COLOR;
+  const accent = normalizeHexColor(settings.theme_accent_color) ?? DEFAULT_ACCENT_COLOR;
+  const fontFamily = isThemeFontFamily(settings.theme_font_family)
+    ? settings.theme_font_family
+    : DEFAULT_FONT_FAMILY;
+
+  const primarySafeLight = findSafeColorForSurface(
+    primary,
+    LIGHT_SURFACE,
+    MIN_SURFACE_CONTRAST,
+    'darken',
+  );
+  const primarySafeDark = findSafeColorForSurface(
+    primary,
+    DARK_SURFACE,
+    MIN_SURFACE_CONTRAST,
+    'lighten',
+  );
+  const accentSafeLight = findSafeColorForSurface(
+    accent,
+    LIGHT_SURFACE,
+    MIN_SURFACE_CONTRAST,
+    'darken',
+  );
+  const accentSafeDark = findSafeColorForSurface(
+    accent,
+    DARK_SURFACE,
+    MIN_SURFACE_CONTRAST,
+    'lighten',
+  );
+
+  root.style.setProperty('--app-theme-primary', primary);
+  root.style.setProperty('--app-theme-primary-safe-light', primarySafeLight);
+  root.style.setProperty('--app-theme-primary-safe-dark', primarySafeDark);
+  root.style.setProperty('--app-theme-primary-contrast', bestTextColor(primary));
+  root.style.setProperty('--app-theme-accent', accent);
+  root.style.setProperty('--app-theme-accent-safe-light', accentSafeLight);
+  root.style.setProperty('--app-theme-accent-safe-dark', accentSafeDark);
+  root.style.setProperty('--app-theme-accent-contrast', bestTextColor(accent));
+  root.style.setProperty('--app-font-family', FONT_FAMILY_STACKS[fontFamily]);
+
+  try {
+    updatePrimaryPalette(buildPalette(primary));
+    updatePreset({
+      semantic: {
+        colorScheme: {
+          light: {
+            highlight: {
+              background: accentSafeLight,
+              color: bestTextColor(accentSafeLight),
+            },
+          },
+          dark: {
+            highlight: {
+              background: accentSafeDark,
+              color: bestTextColor(accentSafeDark),
+            },
+          },
+        },
+      },
+    });
+  } catch {
+    // Keep app theme variables applied even if runtime theme update fails.
+  }
+
+  return {
+    primary,
+    accent,
+    fontFamily,
+    warnings: getThemeWarnings(settings),
+  };
+};

--- a/apps/web/app/plugins/user-theme.client.ts
+++ b/apps/web/app/plugins/user-theme.client.ts
@@ -1,0 +1,17 @@
+import { defineNuxtPlugin, useSupabaseUser } from '#imports';
+import { ensureAuthReady } from '~/composables/useAuthBootstrap';
+import { applyUserTheme, type UserThemeSettings } from '~/composables/useUserTheme';
+import { apiRequest } from '~/utils/api';
+
+export default defineNuxtPlugin(async () => {
+  try {
+    await ensureAuthReady();
+    const user = useSupabaseUser();
+    if (!user.value) return;
+
+    const profile = await apiRequest<UserThemeSettings>('/api/v1/me');
+    applyUserTheme(profile);
+  } catch {
+    // Keep default theme when bootstrap/me request fails.
+  }
+});

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -10,6 +10,7 @@ export default defineNuxtConfig({
     'primeicons/primeicons.css',
     '@fontsource/atkinson-hyperlegible/400.css',
     '@fontsource/atkinson-hyperlegible/700.css',
+    '~/assets/css/base.css',
     '~/assets/css/tailwind.css',
   ],
   // Root is auth-gated; redirect immediately at the server/router level to avoid client flicker

--- a/apps/web/tests/unit/composables/useUserTheme.test.ts
+++ b/apps/web/tests/unit/composables/useUserTheme.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updatePrimaryPaletteMock = vi.hoisted(() => vi.fn());
+const updatePresetMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@primeuix/themes', () => ({
+  updatePrimaryPalette: updatePrimaryPaletteMock,
+  updatePreset: updatePresetMock,
+}));
+
+import {
+  applyUserTheme,
+  getThemeWarnings,
+  normalizeHexColor,
+} from '../../../app/composables/useUserTheme';
+
+describe('useUserTheme', () => {
+  beforeEach(() => {
+    updatePrimaryPaletteMock.mockReset();
+    updatePresetMock.mockReset();
+    document.documentElement.style.cssText = '';
+  });
+
+  it('normalizes valid hex colors and rejects invalid values', () => {
+    expect(normalizeHexColor(null)).toBeNull();
+    expect(normalizeHexColor('')).toBeNull();
+    expect(normalizeHexColor('#abc123')).toBe('#ABC123');
+    expect(normalizeHexColor(' #0011ff ')).toBe('#0011FF');
+    expect(normalizeHexColor('#12345')).toBeNull();
+    expect(normalizeHexColor('blue')).toBeNull();
+  });
+
+  it('applies css variables and primevue runtime palette updates', () => {
+    const result = applyUserTheme({
+      theme_primary_color: '#112233',
+      theme_accent_color: '#445566',
+      theme_font_family: 'fraunces',
+    });
+
+    expect(result?.primary).toBe('#112233'.toUpperCase());
+    expect(document.documentElement.style.getPropertyValue('--app-theme-primary')).toBe(
+      '#112233'.toUpperCase(),
+    );
+    expect(document.documentElement.style.getPropertyValue('--app-theme-accent')).toBe(
+      '#445566'.toUpperCase(),
+    );
+    expect(document.documentElement.style.getPropertyValue('--app-font-family')).toContain(
+      'Fraunces',
+    );
+    expect(updatePrimaryPaletteMock).toHaveBeenCalledTimes(1);
+    expect(updatePresetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to defaults when persisted values are malformed', () => {
+    const result = applyUserTheme({
+      theme_primary_color: 'bad',
+      theme_accent_color: '#12345',
+      theme_font_family: null,
+    });
+
+    expect(result?.primary).toBe('#6366F1');
+    expect(result?.accent).toBe('#14B8A6');
+    expect(result?.fontFamily).toBe('ibm_plex_sans');
+  });
+
+  it('returns warning entries for low-contrast colors', () => {
+    const warnings = getThemeWarnings({
+      theme_primary_color: '#FFFFFF',
+      theme_accent_color: '#000000',
+    });
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.some((item) => item.message.includes('light mode'))).toBe(true);
+    expect(warnings.some((item) => item.message.includes('dark mode'))).toBe(true);
+  });
+
+  it('returns no warnings for colors with sufficient contrast', () => {
+    const warnings = getThemeWarnings({
+      theme_primary_color: '#2563EB',
+      theme_accent_color: '#2563EB',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it('does nothing when document is unavailable', () => {
+    const previous = globalThis.document;
+    // @ts-expect-error test-only
+    globalThis.document = undefined;
+    expect(applyUserTheme({ theme_primary_color: '#123456' })).toBeUndefined();
+    // @ts-expect-error test-only
+    globalThis.document = previous;
+  });
+
+  it('swallows runtime palette update errors', () => {
+    updatePrimaryPaletteMock.mockImplementationOnce(() => {
+      throw new Error('theme failure');
+    });
+    expect(() =>
+      applyUserTheme({
+        theme_primary_color: '#123456',
+        theme_accent_color: '#654321',
+        theme_font_family: 'atkinson',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/tests/unit/plugins/user-theme-client.test.ts
+++ b/apps/web/tests/unit/plugins/user-theme-client.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ensureAuthReadyMock = vi.hoisted(() => vi.fn());
+const apiRequestMock = vi.hoisted(() => vi.fn());
+const applyUserThemeMock = vi.hoisted(() => vi.fn());
+const userRef = vi.hoisted(() => {
+  const { ref } = require('vue');
+  return ref<any>(null);
+});
+
+vi.mock('#imports', () => ({
+  defineNuxtPlugin: (fn: any) => fn,
+  useSupabaseUser: () => userRef,
+}));
+
+vi.mock('~/composables/useAuthBootstrap', () => ({
+  ensureAuthReady: ensureAuthReadyMock,
+}));
+
+vi.mock('~/utils/api', () => ({
+  apiRequest: apiRequestMock,
+}));
+
+vi.mock('~/composables/useUserTheme', () => ({
+  applyUserTheme: applyUserThemeMock,
+}));
+
+import plugin from '../../../app/plugins/user-theme.client';
+
+describe('user-theme.client plugin', () => {
+  beforeEach(() => {
+    ensureAuthReadyMock.mockReset();
+    apiRequestMock.mockReset();
+    applyUserThemeMock.mockReset();
+    userRef.value = null;
+  });
+
+  it('loads and applies user theme when signed in', async () => {
+    userRef.value = { id: 'u1' };
+    ensureAuthReadyMock.mockResolvedValue(undefined);
+    apiRequestMock.mockResolvedValue({
+      theme_primary_color: '#112233',
+      theme_accent_color: '#445566',
+      theme_font_family: 'atkinson',
+    });
+
+    await plugin({} as any);
+
+    expect(ensureAuthReadyMock).toHaveBeenCalledTimes(1);
+    expect(apiRequestMock).toHaveBeenCalledWith('/api/v1/me');
+    expect(applyUserThemeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ theme_primary_color: '#112233' }),
+    );
+  });
+
+  it('skips profile fetch when signed out', async () => {
+    userRef.value = null;
+    ensureAuthReadyMock.mockResolvedValue(undefined);
+
+    await plugin({} as any);
+
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(applyUserThemeMock).not.toHaveBeenCalled();
+  });
+
+  it('fails soft when loading profile throws', async () => {
+    userRef.value = { id: 'u2' };
+    ensureAuthReadyMock.mockResolvedValue(undefined);
+    apiRequestMock.mockRejectedValue(new Error('boom'));
+
+    await expect(plugin({} as any)).resolves.not.toThrow();
+    expect(applyUserThemeMock).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/migrations/20260216193000_add_users_theme_preferences.sql
+++ b/supabase/migrations/20260216193000_add_users_theme_preferences.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.users
+ADD COLUMN IF NOT EXISTS theme_primary_color text,
+ADD COLUMN IF NOT EXISTS theme_accent_color text,
+ADD COLUMN IF NOT EXISTS theme_font_family varchar(32);


### PR DESCRIPTION
## Summary
- implement Theming v2 end to end with user-selectable `theme_primary_color`, `theme_accent_color`, and `theme_font_family`
- persist theme settings through `/api/v1/me` and database migrations
- apply theme globally at runtime with readable light/dark fallback tokens and non-blocking contrast warnings

## Backend
- add nullable user columns for primary color, accent color, and font family in SQLAlchemy model
- extend `/api/v1/me` GET/PATCH request/response payloads to include new fields
- validate colors as strict `#RRGGBB` and font family as one of `atkinson`, `ibm_plex_sans`, `fraunces`
- add Alembic migration and matching Supabase migration
- add/extend API tests for round-trip persistence and validation errors

## Frontend
- add `/Users/ryan/Developer/chapterverse/apps/web/app/composables/useUserTheme.ts` for normalization, contrast-safe token derivation, and runtime theme application
- add `/Users/ryan/Developer/chapterverse/apps/web/app/plugins/user-theme.client.ts` to apply persisted theme at authenticated app boot
- extend settings page with swatches + picker + hex input for primary/accent and bundled font selector
- show non-blocking low-contrast warnings while still allowing save
- apply selected theme immediately after save
- add tests for settings persistence, plugin boot behavior, runtime application, and malformed-value fallback

## Validation
- `make quality`

Closes #148
