### PR TITLE
fix: stabilize Next.js dev env wiring and color-mode hydration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ dev-codex:
 			echo "Port $$port is already free."; \
 		fi; \
 	done
-	@echo "Cleaning apps/web/.nuxt and apps/web/.output..."
-	@rm -rf "$(CURDIR)/apps/web/.nuxt" "$(CURDIR)/apps/web/.output"
+	@echo "Cleaning apps/web/.next..."
+	@rm -rf "$(CURDIR)/apps/web/.next"
 	@echo "Starting dev servers..."
 	@$(MAKE) dev
 
@@ -64,11 +64,11 @@ dev-api-bitwarden:
 dev-web:
 	cd apps/web && pnpm dev
 
-# Link repo root .env for Nuxt runtime config when available
+# Link repo root .env for Next.js runtime config when available
 ensure-web-env:
-	@if [ -f ".env" ] && [ ! -e "apps/web/.env" ]; then \
-		ln -sf "$(CURDIR)/.env" apps/web/.env; \
-		echo "Linked .env to apps/web/.env"; \
+	@if [ -f ".env" ]; then \
+		ln -sfn "$(CURDIR)/.env" apps/web/.env.local; \
+		echo "Linked .env to apps/web/.env.local"; \
 	elif [ ! -f ".env" ]; then \
 		echo "No repo root .env found; run 'make supabase-env' to generate local Supabase env."; \
 	fi
@@ -88,12 +88,12 @@ supabase-env: supabase-start
 			API_URL=*) \
 				value="$${line#API_URL=}"; \
 				echo "SUPABASE_URL=$$value"; \
-				echo "NUXT_PUBLIC_SUPABASE_URL=$$value"; \
+				echo "NEXT_PUBLIC_SUPABASE_URL=$$value"; \
 				;; \
 			ANON_KEY=*) \
 				value="$${line#ANON_KEY=}"; \
 				echo "SUPABASE_ANON_KEY=$$value"; \
-				echo "NUXT_PUBLIC_SUPABASE_ANON_KEY=$$value"; \
+				echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$$value"; \
 				;; \
 			DB_URL=*) \
 				value="$${line#DB_URL=}"; \

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,23 +1,37 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import "./globals.css";
 import { AppReadySignal } from "@/components/app-ready-signal";
 import { ColorModeController } from "@/components/color-mode-controller";
 import { PrimeProvider } from "@/components/prime-react-provider";
 import { ToastProvider } from "@/components/toast-provider";
 import { UserThemeBootstrap } from "@/components/user-theme-bootstrap";
+import type { ColorMode } from "@/lib/color-mode";
 
 export const metadata: Metadata = {
   title: "The Seedbed",
   description: "Reading companion app",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const cookieMode = cookieStore.get("colorMode")?.value;
+  const initialColorMode: ColorMode =
+    cookieMode === "light" || cookieMode === "dark" || cookieMode === "system"
+      ? cookieMode
+      : "system";
+
   return (
-    <html lang="en" data-app-ready="true">
+    <html
+      lang="en"
+      data-app-ready="true"
+      data-color-mode={initialColorMode}
+      suppressHydrationWarning
+    >
       <head>
         {/* eslint-disable-next-line @next/next/no-css-tags -- Runtime theme switching requires a dynamic link tag */}
         <link


### PR DESCRIPTION
## Summary
This PR fixes local Next.js dev startup wiring and resolves the top-bar color mode hydration mismatch.

### Changes
- Update `Makefile` for Next.js dev flow:
  - `dev-codex` now cleans `apps/web/.next` (instead of Nuxt artifacts).
  - `ensure-web-env` now force-links root `.env` to `apps/web/.env.local` every run.
  - `supabase-env` now writes `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
- Fix color-mode hydration mismatch:
  - Read `colorMode` cookie server-side in root layout and emit `data-color-mode` on `<html>`.
  - Initialize `useColorMode` from `document.documentElement.dataset.colorMode` for deterministic SSR/client first render.

## Why
- Prevent runtime "Missing NEXT_PUBLIC_SUPABASE_*" errors caused by stale Vercel-generated `.env.local` files.
- Prevent React hydration warnings in `AppTopBar` where color mode button classes differed between server and client.

## Validation
- `make quality`
- Pre-push hook `make quality`
