### PR TITLE
Fix settings import UX and save button placement

### DIFF
--- a/apps/web/src/components/app-top-bar.tsx
+++ b/apps/web/src/components/app-top-bar.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { Button } from "primereact/button";
 import { Menu } from "primereact/menu";
 import type { MenuItem } from "primereact/menuitem";
@@ -23,6 +29,12 @@ export function AppTopBar() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const accountMenuRef = useRef<Menu>(null);
   const colorMenuRef = useRef<Menu>(null);
+  const colorModeHydrated = useSyncExternalStore(
+    () => () => undefined,
+    () => true,
+    () => false,
+  );
+  const colorModeForButtons = colorModeHydrated ? mode : "system";
 
   useEffect(() => {
     let active = true;
@@ -152,8 +164,8 @@ export function AppTopBar() {
             >
               <Button
                 icon="pi pi-desktop"
-                outlined={mode === "system"}
-                text={mode !== "system"}
+                outlined={colorModeForButtons === "system"}
+                text={colorModeForButtons !== "system"}
                 severity="secondary"
                 size="small"
                 aria-label="System theme"
@@ -162,8 +174,8 @@ export function AppTopBar() {
               />
               <Button
                 icon="pi pi-sun"
-                outlined={mode === "light"}
-                text={mode !== "light"}
+                outlined={colorModeForButtons === "light"}
+                text={colorModeForButtons !== "light"}
                 severity="secondary"
                 size="small"
                 aria-label="Light theme"
@@ -172,8 +184,8 @@ export function AppTopBar() {
               />
               <Button
                 icon="pi pi-moon"
-                outlined={mode === "dark"}
-                text={mode !== "dark"}
+                outlined={colorModeForButtons === "dark"}
+                text={colorModeForButtons !== "dark"}
                 severity="secondary"
                 size="small"
                 aria-label="Dark theme"

--- a/apps/web/src/tests/unit/settings-page.test.tsx
+++ b/apps/web/src/tests/unit/settings-page.test.tsx
@@ -225,8 +225,11 @@ describe("Settings page import + header UX", () => {
 
     expect(issuesPanel).toBeTruthy();
     expect(startButtons).toHaveLength(1);
+    if (!issuesPanel || !startButtons[0]) {
+      throw new Error("Expected StoryGraph issues panel and start button");
+    }
     expect(
-      issuesPanel?.compareDocumentPosition(startButtons[0] as Node) &
+      issuesPanel.compareDocumentPosition(startButtons[0]) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
@@ -277,8 +280,11 @@ describe("Settings page import + header UX", () => {
 
     expect(issuesPanel).toBeTruthy();
     expect(startButtons).toHaveLength(1);
+    if (!issuesPanel || !startButtons[0]) {
+      throw new Error("Expected Goodreads issues panel and start button");
+    }
     expect(
-      issuesPanel?.compareDocumentPosition(startButtons[0] as Node) &
+      issuesPanel.compareDocumentPosition(startButtons[0]) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/apps/web/src/tests/unit/settings-page.test.tsx
+++ b/apps/web/src/tests/unit/settings-page.test.tsx
@@ -1,0 +1,285 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiRequestMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  };
+});
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createBrowserClient: vi.fn(() => ({ auth: { getSession: vi.fn() } })),
+}));
+
+import SettingsPage from "@/app/(app)/settings/page";
+
+type ImportIssueSeed = {
+  row_number: number;
+  field: "title" | "authors" | "read_status";
+  issue_code: "missing_authors" | "missing_title" | "missing_read_status";
+  required: boolean;
+  title: string | null;
+  uid: string | null;
+  suggested_value: string | null;
+  suggestion_source: string | null;
+  suggestion_confidence: "high" | "medium" | null;
+};
+
+const profileResponse = {
+  handle: "reader",
+  display_name: "Reader",
+  avatar_url: null,
+  enable_google_books: false,
+  theme_primary_color: "#6366F1",
+  theme_accent_color: "#14B8A6",
+  theme_font_family: "ibm_plex_sans",
+  theme_heading_font_family: "ibm_plex_sans",
+  default_progress_unit: "pages_read",
+};
+
+function setupApiMock({
+  storygraphItems = [],
+  goodreadsItems = [],
+}: {
+  storygraphItems?: ImportIssueSeed[];
+  goodreadsItems?: ImportIssueSeed[];
+} = {}) {
+  apiRequestMock.mockImplementation(
+    async (_supabase: unknown, path: string, options?: { method?: string }) => {
+      const method = options?.method ?? "GET";
+      if (path === "/api/v1/me" && method === "GET") return profileResponse;
+      if (path === "/api/v1/me" && method === "PATCH") return {};
+      if (
+        path === "/api/v1/imports/storygraph/missing-authors" &&
+        method === "POST"
+      ) {
+        return { items: storygraphItems };
+      }
+      if (
+        path === "/api/v1/imports/goodreads/missing-required" &&
+        method === "POST"
+      ) {
+        return { items: goodreadsItems };
+      }
+      if (path === "/api/v1/imports/storygraph" && method === "POST") {
+        return {
+          job_id: "sg-job",
+          status: "queued",
+          total_rows: 1,
+          processed_rows: 0,
+          imported_rows: 0,
+          failed_rows: 0,
+          skipped_rows: 0,
+        };
+      }
+      if (path === "/api/v1/imports/goodreads" && method === "POST") {
+        return {
+          job_id: "gr-job",
+          status: "queued",
+          total_rows: 1,
+          processed_rows: 0,
+          imported_rows: 0,
+          failed_rows: 0,
+          skipped_rows: 0,
+        };
+      }
+      if (path === "/api/v1/imports/storygraph/sg-job") {
+        return {
+          job_id: "sg-job",
+          status: "completed",
+          total_rows: 1,
+          processed_rows: 1,
+          imported_rows: 1,
+          failed_rows: 0,
+          skipped_rows: 0,
+          error_summary: null,
+          rows_preview: [],
+        };
+      }
+      if (path === "/api/v1/imports/goodreads/gr-job") {
+        return {
+          job_id: "gr-job",
+          status: "completed",
+          total_rows: 1,
+          processed_rows: 1,
+          imported_rows: 1,
+          failed_rows: 0,
+          skipped_rows: 0,
+          error_summary: null,
+          rows_preview: [],
+        };
+      }
+      throw new Error(`Unhandled apiRequest call: ${method} ${path}`);
+    },
+  );
+}
+
+function getUploaderInput(container: HTMLElement, testId: string) {
+  const input = container.querySelector<HTMLInputElement>(
+    `[data-test="${testId}"] input[type=\"file\"]`,
+  );
+  if (!input) throw new Error(`Missing uploader input for ${testId}`);
+  return input;
+}
+
+async function uploadCsv(
+  container: HTMLElement,
+  uploaderTestId: string,
+  selectedFileTestId: string,
+  fileName: string,
+) {
+  const input = getUploaderInput(container, uploaderTestId);
+  const file = new File(["a,b"], fileName, { type: "text/csv" });
+  fireEvent.change(input, { target: { files: [file] } });
+  await waitFor(() => {
+    const selectedFile = container.querySelector(
+      `[data-test="${selectedFileTestId}"]`,
+    );
+    expect(selectedFile).toBeTruthy();
+    expect(selectedFile).toHaveTextContent(fileName);
+  });
+}
+
+describe("Settings page import + header UX", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset();
+  });
+
+  it("renders Save settings in the page header area", async () => {
+    setupApiMock();
+
+    const { container } = render(<SettingsPage />);
+    await waitFor(() =>
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        expect.anything(),
+        "/api/v1/me",
+      ),
+    );
+
+    const heading = screen.getByRole("heading", {
+      name: /profile and settings/i,
+    });
+    const saveButton = screen.getByRole("button", { name: /save settings/i });
+
+    expect(heading.parentElement).toBeTruthy();
+    expect(heading.parentElement).toContainElement(saveButton);
+    expect(
+      container.querySelectorAll('[data-test="settings-save"]'),
+    ).toHaveLength(1);
+  });
+
+  it("hides StoryGraph issue actions after resolving and shows Start import below issues", async () => {
+    setupApiMock({
+      storygraphItems: [
+        {
+          row_number: 1,
+          field: "authors",
+          issue_code: "missing_authors",
+          required: true,
+          title: "Dune",
+          uid: null,
+          suggested_value: "Frank Herbert",
+          suggestion_source: "openlibrary:search",
+          suggestion_confidence: "high",
+        },
+      ],
+    });
+
+    const { container } = render(<SettingsPage />);
+    await uploadCsv(
+      container,
+      "storygraph-file-input",
+      "storygraph-selected-file",
+      "storygraph.csv",
+    );
+
+    expect(
+      container.querySelector('[data-test="storygraph-import-start"]'),
+    ).toBeNull();
+
+    const useSuggestion = await screen.findByRole("button", {
+      name: /use suggestion/i,
+    });
+    fireEvent.click(useSuggestion);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /use suggestion/i }),
+      ).toBeNull();
+      expect(screen.queryByRole("button", { name: /mark skip/i })).toBeNull();
+      expect(screen.getByText("Resolved")).toBeInTheDocument();
+    });
+
+    const issuesPanel = container.querySelector(
+      '[data-test="storygraph-issues-panel"]',
+    );
+    const startButtons = container.querySelectorAll(
+      '[data-test="storygraph-import-start"]',
+    );
+
+    expect(issuesPanel).toBeTruthy();
+    expect(startButtons).toHaveLength(1);
+    expect(
+      issuesPanel?.compareDocumentPosition(startButtons[0] as Node) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("hides Goodreads issue actions after skip and shows Start import below issues", async () => {
+    setupApiMock({
+      goodreadsItems: [
+        {
+          row_number: 1,
+          field: "title",
+          issue_code: "missing_title",
+          required: true,
+          title: null,
+          uid: "9780441172719",
+          suggested_value: null,
+          suggestion_source: null,
+          suggestion_confidence: null,
+        },
+      ],
+    });
+
+    const { container } = render(<SettingsPage />);
+    await uploadCsv(
+      container,
+      "goodreads-file-input",
+      "goodreads-selected-file",
+      "goodreads.csv",
+    );
+
+    expect(
+      container.querySelector('[data-test="goodreads-import-start"]'),
+    ).toBeNull();
+
+    const markSkip = await screen.findByRole("button", { name: /mark skip/i });
+    fireEvent.click(markSkip);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /mark skip/i })).toBeNull();
+      expect(screen.getByText("Skipped")).toBeInTheDocument();
+    });
+
+    const issuesPanel = container.querySelector(
+      '[data-test="goodreads-issues-panel"]',
+    );
+    const startButtons = container.querySelectorAll(
+      '[data-test="goodreads-import-start"]',
+    );
+
+    expect(issuesPanel).toBeTruthy();
+    expect(startButtons).toHaveLength(1);
+    expect(
+      issuesPanel?.compareDocumentPosition(startButtons[0] as Node) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./src/tests/setup/vitest.setup.ts"],
-    include: ["src/tests/unit/**/*.test.ts"],
+    include: ["src/tests/unit/**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
## Summary
- fix import issue row UX in Settings for both StoryGraph and Goodreads
- hide row action buttons once an issue is resolved or skipped while keeping rows visible with status tags
- move `Start import` to render below the issues list only after pending issues reach zero
- move `Save settings` to the top-right header area with responsive layout
- update import step badges to static colors (Step 1 blue, Step 2 teal, Step 3 green)
- adjust spacing so `Start import` has clear top padding from the issues panel
- fix topbar color mode hydration mismatch by keeping button state deterministic through hydration
- add component tests for Settings import state transitions and header save button placement

## Testing
- `make quality`

## Issues
Closes #160
Closes #161
