### PR TITLE
Fix dark mode surface regressions across book flows

### DIFF
--- a/apps/web/src/app/(app)/books/search/page.tsx
+++ b/apps/web/src/app/(app)/books/search/page.tsx
@@ -474,7 +474,7 @@ export default function BookSearchPage() {
               <Card key={book.work_key}>
                 <article className="flex gap-4">
                   <div
-                    className="h-[120px] w-[80px] shrink-0 overflow-hidden rounded border border-slate-300/60 bg-slate-100"
+                    className="h-[120px] w-[80px] shrink-0 overflow-hidden rounded border border-[var(--p-content-border-color)] bg-[var(--surface-hover)]"
                     data-test="search-item-thumb"
                   >
                     {coverVisible(book, brokenCoverKeys) ? (

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1315,7 +1315,7 @@ export default function SettingsPage() {
           />
         ) : null}
         {storygraphImportJob ? (
-          <div className="mt-3 rounded border border-slate-300/60 p-3">
+          <div className="mt-3 rounded border border-[var(--p-content-border-color)] p-3">
             <p
               className="text-sm font-medium"
               data-test="storygraph-import-status"
@@ -1521,7 +1521,7 @@ export default function SettingsPage() {
           />
         ) : null}
         {goodreadsImportJob ? (
-          <div className="mt-3 rounded border border-slate-300/60 p-3">
+          <div className="mt-3 rounded border border-[var(--p-content-border-color)] p-3">
             <p
               className="text-sm font-medium"
               data-test="goodreads-import-status"

--- a/apps/web/src/app/(public)/book/[workId]/page.tsx
+++ b/apps/web/src/app/(public)/book/[workId]/page.tsx
@@ -7,7 +7,7 @@ export default async function PublicBookPage({
 
   return (
     <section
-      className="rounded-xl border border-slate-300/60 bg-white/80 p-6"
+      className="rounded-xl border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-6"
       data-test="public-book-card"
     >
       <h1
@@ -16,7 +16,7 @@ export default async function PublicBookPage({
       >
         Public book page
       </h1>
-      <p className="mt-2 text-sm text-slate-600">
+      <p className="mt-2 text-sm text-[var(--p-text-muted-color)]">
         Reserved canonical URL for public book pages.
       </p>
       <p className="mt-3 text-sm">

--- a/apps/web/src/app/(public)/review/[reviewId]/page.tsx
+++ b/apps/web/src/app/(public)/review/[reviewId]/page.tsx
@@ -7,7 +7,7 @@ export default async function PublicReviewPage({
 
   return (
     <section
-      className="rounded-xl border border-slate-300/60 bg-white/80 p-6"
+      className="rounded-xl border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-6"
       data-test="public-review-card"
     >
       <h1
@@ -16,7 +16,7 @@ export default async function PublicReviewPage({
       >
         Public review
       </h1>
-      <p className="mt-2 text-sm text-slate-600">
+      <p className="mt-2 text-sm text-[var(--p-text-muted-color)]">
         Reserved canonical URL for public reviews.
       </p>
       <p className="mt-3 text-sm">

--- a/apps/web/src/app/(public)/u/[handle]/page.tsx
+++ b/apps/web/src/app/(public)/u/[handle]/page.tsx
@@ -7,7 +7,7 @@ export default async function PublicProfilePage({
 
   return (
     <section
-      className="rounded-xl border border-slate-300/60 bg-white/80 p-6"
+      className="rounded-xl border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-6"
       data-test="public-profile-card"
     >
       <h1
@@ -16,7 +16,7 @@ export default async function PublicProfilePage({
       >
         Public profile
       </h1>
-      <p className="mt-2 text-sm text-slate-600">
+      <p className="mt-2 text-sm text-[var(--p-text-muted-color)]">
         Reserved for federation and public profile pages.
       </p>
       <p className="mt-3 text-sm">

--- a/apps/web/src/components/books/book-discovery-section.tsx
+++ b/apps/web/src/components/books/book-discovery-section.tsx
@@ -153,7 +153,7 @@ export function BookDiscoverySection({
     <Card className="mt-6" data-test="book-discovery">
       <div className="mb-3">
         <p className="text-sm font-medium">Discovery</p>
-        <p className="text-xs text-slate-500">
+        <p className="text-xs text-[var(--p-text-muted-color)]">
           Recommended from related titles and your authors.
         </p>
       </div>
@@ -165,31 +165,33 @@ export function BookDiscoverySection({
         <section>
           <p className="text-sm font-medium">Related books</p>
           {relatedLoading ? (
-            <p className="text-sm text-slate-500">Loading...</p>
+            <p className="text-sm text-[var(--p-text-muted-color)]">
+              Loading...
+            </p>
           ) : visibleRelatedBooks.length ? (
             <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
               {visibleRelatedBooks.map((item) => (
                 <Button
                   key={item.work_key}
                   text
-                  className="rounded border border-slate-200 p-2 text-left hover:bg-slate-50"
+                  className="rounded border border-[var(--p-content-border-color)] p-2 text-left hover:bg-[var(--surface-hover)]"
                   data-test={`related-book-${item.work_key}`}
                   onClick={() => void importAndOpenRelated(item.work_key)}
                 >
                   <p className="line-clamp-2 text-xs font-semibold">
                     {item.title}
                   </p>
-                  <p className="mt-1 text-[11px] text-slate-500">
+                  <p className="mt-1 text-[11px] text-[var(--p-text-muted-color)]">
                     {relatedAuthorLabel(item)}
                   </p>
-                  <p className="text-[11px] text-slate-500">
+                  <p className="text-[11px] text-[var(--p-text-muted-color)]">
                     {item.first_publish_year ?? "Year unknown"}
                   </p>
                 </Button>
               ))}
             </div>
           ) : (
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-[var(--p-text-muted-color)]">
               No related books with covers yet.
             </p>
           )}
@@ -198,17 +200,19 @@ export function BookDiscoverySection({
         <section>
           <p className="text-sm font-medium">More from the author(s)</p>
           {authorLoading ? (
-            <p className="text-sm text-slate-500">Loading...</p>
+            <p className="text-sm text-[var(--p-text-muted-color)]">
+              Loading...
+            </p>
           ) : authorProfilesWithCoverWorks.length ? (
             <div className="mt-2 grid gap-3">
               {authorProfilesWithCoverWorks.map((author) => (
                 <Card
                   key={author.id}
-                  className="rounded border border-slate-200 p-3"
+                  className="rounded border border-[var(--p-content-border-color)] p-3"
                 >
                   <p className="text-sm font-medium">{author.name}</p>
                   {author.bio ? (
-                    <p className="line-clamp-1 text-xs text-slate-500">
+                    <p className="line-clamp-1 text-xs text-[var(--p-text-muted-color)]">
                       {author.bio}
                     </p>
                   ) : null}
@@ -217,7 +221,7 @@ export function BookDiscoverySection({
                       <Button
                         key={`${author.id}-${book.work_key}`}
                         text
-                        className="rounded border border-slate-200 p-2 text-left hover:bg-slate-50"
+                        className="rounded border border-[var(--p-content-border-color)] p-2 text-left hover:bg-[var(--surface-hover)]"
                         data-test={`author-work-${book.work_key}`}
                         onClick={() => void importAndOpenRelated(book.work_key)}
                       >
@@ -231,7 +235,7 @@ export function BookDiscoverySection({
               ))}
             </div>
           ) : (
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-[var(--p-text-muted-color)]">
               No author books with covers yet.
             </p>
           )}

--- a/apps/web/src/components/pages/auth-callback-page.tsx
+++ b/apps/web/src/components/pages/auth-callback-page.tsx
@@ -93,15 +93,15 @@ export function AuthCallbackPageClient({
 
   return (
     <section
-      className="rounded-xl border border-slate-300/60 bg-white/80 p-6 text-center shadow-sm"
+      className="rounded-xl border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-6 text-center shadow-sm"
       data-test="auth-callback-card"
     >
       <h1 className="text-2xl font-semibold tracking-tight">
         Finishing sign-in
       </h1>
-      <p className="mt-2 text-sm text-slate-600">{message}</p>
+      <p className="mt-2 text-sm text-[var(--p-text-muted-color)]">{message}</p>
       {error ? (
-        <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
+        <p className="mt-3 rounded-lg bg-[var(--p-red-50)] px-3 py-2 text-sm text-[var(--p-red-700)]">
           {error}
         </p>
       ) : null}

--- a/apps/web/src/tests/unit/auth-callback-page.test.tsx
+++ b/apps/web/src/tests/unit/auth-callback-page.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createBrowserClient: vi.fn(() => ({
+    auth: {
+      exchangeCodeForSession: vi.fn(),
+      getSession: vi.fn(),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+    },
+  })),
+}));
+
+import { AuthCallbackPageClient } from "@/components/pages/auth-callback-page";
+
+describe("Auth callback page dark-mode surfaces", () => {
+  it("uses tokenized classes for card, message, and error state", async () => {
+    const { container } = render(
+      <AuthCallbackPageClient oauthError="OAuth failed" returnToFromQuery="" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign-in failed.")).toBeInTheDocument();
+      expect(screen.getByText("OAuth failed")).toBeInTheDocument();
+    });
+
+    const card = container.querySelector('[data-test="auth-callback-card"]');
+    const message = screen.getByText("Sign-in failed.");
+    const error = screen.getByText("OAuth failed");
+
+    expect(card).toHaveClass("border-[var(--p-content-border-color)]");
+    expect(card).toHaveClass("bg-[var(--surface-card)]");
+    expect(message).toHaveClass("text-[var(--p-text-muted-color)]");
+    expect(error).toHaveClass("bg-[var(--p-red-50)]");
+    expect(error).toHaveClass("text-[var(--p-red-700)]");
+
+    expect(container.innerHTML).not.toContain("bg-white");
+    expect(container.innerHTML).not.toContain("border-slate");
+    expect(container.innerHTML).not.toContain("text-slate");
+  });
+});

--- a/apps/web/src/tests/unit/book-detail-dark-mode.test.tsx
+++ b/apps/web/src/tests/unit/book-detail-dark-mode.test.tsx
@@ -1,0 +1,201 @@
+import { render, waitFor } from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiRequestMock, chartRenderMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+  chartRenderMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: ComponentPropsWithoutRef<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: () => <div data-test="next-image-mock" />,
+}));
+
+vi.mock("primereact/chart", () => ({
+  Chart: (props: Record<string, unknown>) => {
+    chartRenderMock(props);
+    return <div data-test="mock-progress-chart" />;
+  },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  };
+});
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createBrowserClient: vi.fn(() => ({ auth: { getSession: vi.fn() } })),
+}));
+
+vi.mock("@/components/books/book-discovery-section", () => ({
+  BookDiscoverySection: () => <div data-test="book-discovery-section" />,
+}));
+
+vi.mock("@/components/cover-placeholder", () => ({
+  CoverPlaceholder: () => <div data-test="cover-placeholder" />,
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useAppToast: () => ({ show: vi.fn() }),
+}));
+
+import BookDetailPage from "@/app/(app)/books/[workId]/page";
+
+function setupApiMock() {
+  apiRequestMock.mockImplementation(
+    async (_supabase: unknown, path: string, options?: { method?: string }) => {
+      const method = options?.method ?? "GET";
+      if (method !== "GET") {
+        throw new Error(`Unexpected method in test: ${method} ${path}`);
+      }
+      if (path === "/api/v1/me") {
+        return { default_progress_unit: "pages_read" };
+      }
+      if (path === "/api/v1/works/test-work") {
+        return {
+          id: "work-1",
+          title: "Test Work",
+          description: "A test description",
+          cover_url: null,
+          total_pages: 100,
+          total_audio_minutes: 0,
+          authors: [{ id: "a1", name: "Test Author" }],
+        };
+      }
+      if (path === "/api/v1/library/items/by-work/test-work") {
+        return {
+          id: "item-1",
+          work_id: "work-1",
+          preferred_edition_id: "ed-1",
+          status: "reading",
+          visibility: "private",
+        };
+      }
+      if (path === "/api/v1/works/test-work/editions") {
+        return {
+          items: [
+            { id: "ed-1", title: "Default Edition", format: "Paperback" },
+          ],
+        };
+      }
+      if (path === "/api/v1/library/items/item-1/read-cycles") {
+        return {
+          items: [{ id: "cycle-1", started_at: "2025-01-01T00:00:00Z" }],
+        };
+      }
+      if (path === "/api/v1/read-cycles/cycle-1/progress-logs") {
+        return {
+          items: [
+            {
+              id: "log-1",
+              logged_at: "2025-01-02T00:00:00Z",
+              unit: "pages_read",
+              value: 12,
+              note: null,
+              canonical_percent: 12,
+            },
+          ],
+        };
+      }
+      if (path === "/api/v1/library/items/item-1/notes") {
+        return { items: [] };
+      }
+      if (path === "/api/v1/library/items/item-1/highlights") {
+        return { items: [] };
+      }
+      if (path === "/api/v1/me/reviews") {
+        return { items: [] };
+      }
+      if (path === "/api/v1/library/items/item-1/statistics") {
+        return {
+          totals: { total_pages: 100, total_audio_minutes: 0 },
+          current: {
+            pages_read: 12,
+            canonical_percent: 12,
+            minutes_listened: 0,
+          },
+          timeline: [],
+          data_quality: { has_missing_totals: false },
+        };
+      }
+      throw new Error(`Unhandled apiRequest call: ${method} ${path}`);
+    },
+  );
+}
+
+describe("Book detail dark-mode surfaces", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset();
+    chartRenderMock.mockReset();
+    setupApiMock();
+  });
+
+  it("uses tokenized surface classes and themed chart colors", async () => {
+    const { container } = render(
+      <BookDetailPage params={Promise.resolve({ workId: "test-work" })} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-test="book-detail-card"]'),
+      ).toBeTruthy();
+      expect(chartRenderMock).toHaveBeenCalled();
+    });
+
+    const card = container.querySelector('[data-test="book-detail-card"]');
+    const cover = container.querySelector('[data-test="book-detail-cover"]');
+
+    expect(card).toHaveClass("border-[var(--p-content-border-color)]");
+    expect(card).toHaveClass("bg-[var(--surface-card)]");
+    expect(cover).toHaveClass("bg-[var(--surface-hover)]");
+
+    expect(container.innerHTML).not.toContain("bg-white");
+    expect(container.innerHTML).not.toContain("border-slate");
+    expect(container.innerHTML).not.toContain("bg-slate");
+    expect(container.innerHTML).not.toContain("bg-red-50");
+
+    const lastChartProps = chartRenderMock.mock.calls.at(-1)?.[0] as {
+      data: {
+        datasets: Array<{ borderColor?: string; backgroundColor?: string }>;
+      };
+      options: {
+        scales: {
+          x: { ticks: { color: string }; grid: { color: string } };
+          y: { ticks: { color: string }; grid: { color: string } };
+        };
+      };
+    };
+
+    expect(lastChartProps.data.datasets[0]?.borderColor).toBe("#3b82f6");
+    expect(lastChartProps.data.datasets[0]?.backgroundColor).toBe(
+      "rgba(59, 130, 246, 0.3)",
+    );
+    expect(lastChartProps.options.scales.x.ticks.color).toBe("#64748b");
+    expect(lastChartProps.options.scales.y.ticks.color).toBe("#64748b");
+    expect(lastChartProps.options.scales.x.grid.color).toBe(
+      "rgba(148, 163, 184, 0.5)",
+    );
+    expect(lastChartProps.options.scales.y.grid.color).toBe(
+      "rgba(148, 163, 184, 0.5)",
+    );
+  });
+});

--- a/apps/web/tests/e2e/smoke.spec.ts
+++ b/apps/web/tests/e2e/smoke.spec.ts
@@ -1,4 +1,15 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+async function forceDarkModeCookie(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "colorMode",
+      value: "dark",
+      domain: "localhost",
+      path: "/",
+    },
+  ]);
+}
 
 test("redirects root to login", async ({ page }) => {
   await page.goto("/");
@@ -21,4 +32,51 @@ test("renders public placeholder routes", async ({ page }) => {
   await expect(page.locator('[data-test="public-profile-handle"]')).toHaveText(
     "test-user",
   );
+});
+
+test("uses dark-mode surfaces on public placeholder routes", async ({
+  page,
+}) => {
+  await forceDarkModeCookie(page);
+
+  await page.goto("/book/test-work");
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await expect(page.locator('[data-test="public-book-card"]')).toHaveClass(
+    /bg-\[var\(--surface-card\)\]/,
+  );
+  await expect(page.locator('[data-test="public-book-card"]')).not.toHaveClass(
+    /bg-white|border-slate|text-slate/,
+  );
+
+  await page.goto("/review/test-review");
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await expect(page.locator('[data-test="public-review-card"]')).toHaveClass(
+    /bg-\[var\(--surface-card\)\]/,
+  );
+  await expect(
+    page.locator('[data-test="public-review-card"]'),
+  ).not.toHaveClass(/bg-white|border-slate|text-slate/);
+
+  await page.goto("/u/test-user");
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await expect(page.locator('[data-test="public-profile-card"]')).toHaveClass(
+    /bg-\[var\(--surface-card\)\]/,
+  );
+  await expect(
+    page.locator('[data-test="public-profile-card"]'),
+  ).not.toHaveClass(/bg-white|border-slate|text-slate/);
+});
+
+test("uses tokenized dark-mode surfaces on book details route shell", async ({
+  page,
+}) => {
+  await forceDarkModeCookie(page);
+  await page.goto("/books/test-work");
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  const card = page.locator('[data-test="book-detail-card"]');
+  await expect(card).toBeVisible();
+  await expect(card).toHaveClass(/bg-\[var\(--surface-card\)\]/);
+  await expect(card).toHaveClass(/border-\[var\(--p-content-border-color\)\]/);
+  await expect(card).not.toHaveClass(/bg-white|border-slate/);
 });


### PR DESCRIPTION
## Summary
- fix dark-mode surface/contrast regressions on book details and related UI sections by replacing hard-coded light `slate/white` classes with theme-token classes
- update book details progress chart styling to use theme-aware colors for dataset, grid, and ticks
- add dark-mode regression coverage in both unit tests and Playwright

## Changes
- tokenized surfaces/borders/errors in:
  - `apps/web/src/app/(app)/books/[workId]/page.tsx`
  - `apps/web/src/components/books/book-discovery-section.tsx`
  - `apps/web/src/components/pages/auth-callback-page.tsx`
  - `apps/web/src/app/(public)/book/[workId]/page.tsx`
  - `apps/web/src/app/(public)/review/[reviewId]/page.tsx`
  - `apps/web/src/app/(public)/u/[handle]/page.tsx`
  - `apps/web/src/app/(app)/books/search/page.tsx`
  - `apps/web/src/app/(app)/settings/page.tsx`
- added tests:
  - `apps/web/src/tests/unit/book-detail-dark-mode.test.tsx`
  - `apps/web/src/tests/unit/auth-callback-page.test.tsx`
  - extended `apps/web/tests/e2e/smoke.spec.ts` with dark-mode checks

## Validation
- `make quality`

Closes #163
