### PR TITLE
Issue #162: Library context menu with in-place workflows

### DIFF
--- a/apps/api/app/routers/works.py
+++ b/apps/api/app/routers/works.py
@@ -682,7 +682,11 @@ def _openlibrary_edition_raw_has_compare_fields(raw: object) -> bool:
         _has_selected_value(value)
         for value in (
             _first_string(raw.get("publishers")),
-            raw.get("publish_date") if isinstance(raw.get("publish_date"), str) else None,
+            (
+                raw.get("publish_date")
+                if isinstance(raw.get("publish_date"), str)
+                else None
+            ),
             _first_string(raw.get("isbn_10")),
             _first_string(raw.get("isbn_13")),
             _extract_source_language(raw),

--- a/apps/api/app/routers/works.py
+++ b/apps/api/app/routers/works.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 import uuid
+from datetime import date, datetime
 from typing import Annotated
 
 import httpx
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy.orm import Session
@@ -11,9 +14,13 @@ from sqlalchemy.orm import Session
 from app.core.config import Settings, get_settings
 from app.core.responses import ok
 from app.core.security import AuthContext, require_auth_context
+from app.db.models.bibliography import Author, Edition, Work, WorkAuthor
+from app.db.models.external_provider import ExternalId, SourceRecord
+from app.db.models.users import LibraryItem
 from app.db.session import get_db_session
-from app.services.google_books import GoogleBooksClient
-from app.services.open_library import OpenLibraryClient
+from app.services.catalog import import_openlibrary_bundle
+from app.services.google_books import GoogleBooksClient, GoogleBooksWorkBundle
+from app.services.open_library import OpenLibraryClient, OpenLibraryWorkBundle
 from app.services.storage import StorageNotConfiguredError
 from app.services.user_library import get_or_create_profile
 from app.services.work_covers import (
@@ -172,6 +179,954 @@ class ApplyEnrichmentRequest(BaseModel):
     selections: list[dict[str, object]] = Field(default_factory=list)
 
 
+class ImportOpenLibraryEditionRequest(BaseModel):
+    edition_key: str = Field(min_length=3)
+    work_key: str | None = Field(default=None, min_length=3)
+    set_preferred: bool = True
+
+
+FIELD_LABELS: dict[str, str] = {
+    "work.description": "Description",
+    "work.cover_url": "Cover",
+    "work.first_publish_year": "First Published",
+    "edition.publisher": "Publisher",
+    "edition.publish_date": "Publish Date",
+    "edition.isbn10": "ISBN-10",
+    "edition.isbn13": "ISBN-13",
+    "edition.language": "Language",
+    "edition.format": "Format",
+    "edition.total_pages": "Total Pages",
+    "edition.total_audio_minutes": "Total Audiobook Minutes",
+}
+
+
+def _field_label(field_key: str) -> str:
+    return FIELD_LABELS.get(field_key, field_key)
+
+
+def _openlibrary_work_key_for_work(
+    session: Session, *, work_id: uuid.UUID
+) -> str | None:
+    provider_id = session.scalar(
+        sa.select(ExternalId.provider_id).where(
+            ExternalId.entity_type == "work",
+            ExternalId.entity_id == work_id,
+            ExternalId.provider == "openlibrary",
+        )
+    )
+    if not isinstance(provider_id, str) or not provider_id.strip():
+        return None
+    return provider_id.strip()
+
+
+def _work_title_for_lookup(session: Session, *, work_id: uuid.UUID) -> str | None:
+    work = session.get(Work, work_id)
+    if work is None or not work.title.strip():
+        return None
+    return work.title.strip()
+
+
+def _first_author_for_lookup(session: Session, *, work_id: uuid.UUID) -> str | None:
+    row = session.execute(
+        sa.select(Author.name)
+        .select_from(WorkAuthor)
+        .join(Author, Author.id == WorkAuthor.author_id)
+        .where(WorkAuthor.work_id == work_id)
+        .order_by(Author.name.asc())
+        .limit(1)
+    ).first()
+    if row is None:
+        return None
+    name = row[0]
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
+def _work_authors_for_lookup(session: Session, *, work_id: uuid.UUID) -> list[str]:
+    rows = session.execute(
+        sa.select(Author.name)
+        .select_from(WorkAuthor)
+        .join(Author, Author.id == WorkAuthor.author_id)
+        .where(WorkAuthor.work_id == work_id)
+        .order_by(Author.name.asc())
+    ).all()
+    names: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        name = row[0]
+        if not isinstance(name, str):
+            continue
+        normalized = name.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        names.append(normalized)
+    return names
+
+
+def _ensure_openlibrary_work_mapping(
+    session: Session,
+    *,
+    work_id: uuid.UUID,
+    work_key: str,
+) -> None:
+    existing_mapping = session.scalar(
+        sa.select(ExternalId).where(
+            ExternalId.entity_type == "work",
+            ExternalId.entity_id == work_id,
+            ExternalId.provider == "openlibrary",
+        )
+    )
+    conflicting_mapping = session.scalar(
+        sa.select(ExternalId).where(
+            ExternalId.entity_type == "work",
+            ExternalId.provider == "openlibrary",
+            ExternalId.provider_id == work_key,
+        )
+    )
+    if conflicting_mapping is not None and conflicting_mapping.entity_id != work_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Open Library work key is already linked to a different work.",
+        )
+
+    if existing_mapping is None:
+        session.add(
+            ExternalId(
+                entity_type="work",
+                entity_id=work_id,
+                provider="openlibrary",
+                provider_id=work_key,
+            )
+        )
+    else:
+        existing_mapping.provider_id = work_key
+
+
+def _first_string(values: object) -> str | None:
+    if not isinstance(values, list):
+        return None
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_source_title(raw: object) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    title = raw.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    volume_info = raw.get("volumeInfo")
+    if isinstance(volume_info, dict):
+        value = volume_info.get("title")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_source_authors(raw: object) -> list[str]:
+    if not isinstance(raw, dict):
+        return []
+    if isinstance(raw.get("author_name"), list):
+        return [name for name in raw["author_name"] if isinstance(name, str)]
+    authors = raw.get("authors")
+    if isinstance(authors, list):
+        return [name for name in authors if isinstance(name, str)]
+    volume_info = raw.get("volumeInfo")
+    if isinstance(volume_info, dict):
+        value = volume_info.get("authors")
+        if isinstance(value, list):
+            return [name for name in value if isinstance(name, str)]
+    return []
+
+
+def _extract_source_cover(raw: object) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    if isinstance(raw.get("covers"), list):
+        for cover_id in raw["covers"]:
+            if isinstance(cover_id, int) and cover_id > 0:
+                return f"https://covers.openlibrary.org/b/id/{cover_id}-M.jpg"
+    volume_info = raw.get("volumeInfo")
+    if isinstance(volume_info, dict):
+        image_links = volume_info.get("imageLinks")
+        if isinstance(image_links, dict):
+            for key in ("thumbnail", "smallThumbnail"):
+                value = image_links.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip().replace("http://", "https://", 1)
+    return None
+
+
+def _extract_source_language(raw: object) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    if isinstance(raw.get("languages"), list):
+        for entry in raw["languages"]:
+            if isinstance(entry, dict):
+                key = entry.get("key")
+                if isinstance(key, str) and key.startswith("/languages/"):
+                    return key.removeprefix("/languages/")
+            if isinstance(entry, str) and entry.strip():
+                return entry.strip()
+    volume_info = raw.get("volumeInfo")
+    if isinstance(volume_info, dict):
+        value = volume_info.get("language")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_source_publisher(raw: object) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    value = _first_string(raw.get("publishers"))
+    if value:
+        return value
+    volume_info = raw.get("volumeInfo")
+    if isinstance(volume_info, dict):
+        publisher = volume_info.get("publisher")
+        if isinstance(publisher, str) and publisher.strip():
+            return publisher.strip()
+    return None
+
+
+def _extract_source_publish_date(raw: object) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    value = raw.get("publish_date")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    volume_info = raw.get("volumeInfo")
+    if isinstance(volume_info, dict):
+        published_date = volume_info.get("publishedDate")
+        if isinstance(published_date, str) and published_date.strip():
+            return published_date.strip()
+    return None
+
+
+def _extract_source_identifier(raw: object, fallback: str) -> str:
+    if isinstance(raw, dict):
+        isbn13 = _first_string(raw.get("isbn_13"))
+        if isbn13:
+            return isbn13
+        isbn10 = _first_string(raw.get("isbn_10"))
+        if isbn10:
+            return isbn10
+        volume_info = raw.get("volumeInfo")
+        if isinstance(volume_info, dict):
+            identifiers = volume_info.get("industryIdentifiers")
+            if isinstance(identifiers, list):
+                for identifier in identifiers:
+                    if not isinstance(identifier, dict):
+                        continue
+                    value = identifier.get("identifier")
+                    if isinstance(value, str) and value.strip():
+                        return value.strip()
+    return fallback
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalize_text_tokens(value: str | None) -> list[str]:
+    if not isinstance(value, str):
+        return []
+    return _TOKEN_RE.findall(value.lower())
+
+
+def _title_match_score(expected_title: str, candidate_title: str) -> int:
+    expected_tokens = _normalize_text_tokens(expected_title)
+    candidate_tokens = _normalize_text_tokens(candidate_title)
+    if not expected_tokens or not candidate_tokens:
+        return 0
+    expected_joined = " ".join(expected_tokens)
+    candidate_joined = " ".join(candidate_tokens)
+    if expected_joined == candidate_joined:
+        return 100
+    overlap = len(set(expected_tokens) & set(candidate_tokens))
+    coverage = overlap / max(len(set(expected_tokens)), 1)
+    # Strong coverage of work-title tokens is required to avoid unrelated volumes.
+    if coverage >= 0.95:
+        return 80
+    if coverage >= 0.75:
+        return 60
+    if expected_joined in candidate_joined:
+        return 50
+    return 0
+
+
+def _author_match_score(
+    expected_author: str | None, candidate_authors: list[str]
+) -> int:
+    if not expected_author:
+        return 0
+    expected_tokens = _normalize_text_tokens(expected_author)
+    if not expected_tokens:
+        return 0
+    expected_last = expected_tokens[-1]
+    for candidate in candidate_authors:
+        candidate_tokens = _normalize_text_tokens(candidate)
+        if not candidate_tokens:
+            continue
+        if expected_last and expected_last in candidate_tokens:
+            return 30
+        overlap = len(set(expected_tokens) & set(candidate_tokens))
+        if overlap >= 2:
+            return 25
+        if overlap == 1:
+            return 15
+    return 0
+
+
+async def _collect_google_source_tiles(
+    *,
+    work_id: uuid.UUID,
+    auth: AuthContext,
+    session: Session,
+    google_books: GoogleBooksClient,
+    settings: Settings,
+    limit: int,
+    language: str | None,
+) -> list[dict[str, object]]:
+    profile = get_or_create_profile(session, user_id=auth.user_id)
+    if not profile.enable_google_books:
+        return []
+    work = session.get(Work, work_id)
+    if work is None:
+        return []
+    title = work.title.strip()
+    if not title:
+        return []
+
+    volume_ids: list[str] = []
+    mapped_google_id = session.scalar(
+        sa.select(ExternalId.provider_id).where(
+            ExternalId.entity_type == "work",
+            ExternalId.entity_id == work_id,
+            ExternalId.provider == "googlebooks",
+        )
+    )
+    if isinstance(mapped_google_id, str) and mapped_google_id.strip():
+        volume_ids.append(mapped_google_id.strip())
+
+    first_author = _first_author_for_lookup(session, work_id=work_id)
+    author_queries = [first_author or "", ""]
+    seen_authors: set[str] = set()
+    for author_query in author_queries:
+        normalized_author = author_query.strip().lower()
+        if normalized_author in seen_authors:
+            continue
+        seen_authors.add(normalized_author)
+        search = await google_books.search_books(
+            query=title,
+            limit=min(limit, 10),
+            page=1,
+            author=author_query or None,
+            language=language,
+        )
+        for search_item in search.items:
+            if search_item.volume_id not in volume_ids:
+                volume_ids.append(search_item.volume_id)
+            if len(volume_ids) >= max(limit * 2, 20):
+                break
+        if len(volume_ids) >= max(limit * 2, 20):
+            break
+
+    scored_tiles: list[tuple[int, dict[str, object]]] = []
+    seen_volume_ids: set[str] = set()
+    for volume_id in volume_ids:
+        if volume_id in seen_volume_ids:
+            continue
+        seen_volume_ids.add(volume_id)
+        try:
+            bundle = await google_books.fetch_work_bundle(volume_id=volume_id)
+        except Exception:
+            continue
+        edition = bundle.edition if isinstance(bundle.edition, dict) else {}
+        publish_date = edition.get("publish_date")
+        publish_date_value = (
+            publish_date.isoformat()
+            if isinstance(publish_date, (date, datetime))
+            else publish_date
+        )
+        score = _title_match_score(title, bundle.title) + _author_match_score(
+            first_author, bundle.authors
+        )
+        # Empirically, Google print-edition records for this workflow commonly use
+        # ...ACAAJ volume IDs and are better edition representatives than QBAJ/epub entries.
+        if bundle.volume_id.endswith("ACAAJ"):
+            score += 10
+        if score < 60:
+            continue
+        scored_tiles.append(
+            (
+                score,
+                {
+                    "provider": "googlebooks",
+                    "source_id": bundle.volume_id,
+                    "title": bundle.title,
+                    "authors": bundle.authors,
+                    "publisher": edition.get("publisher"),
+                    "publish_date": publish_date_value,
+                    "language": edition.get("language"),
+                    "identifier": edition.get("isbn13")
+                    or edition.get("isbn10")
+                    or bundle.volume_id,
+                    "cover_url": bundle.cover_url,
+                    "source_label": "Google Books",
+                },
+            )
+        )
+    scored_tiles.sort(key=lambda entry: entry[0], reverse=True)
+    max_google_tiles = min(limit, 2)
+    return [item for _, item in scored_tiles[:max_google_tiles]]
+
+
+def _tile_sort_key(item: dict[str, object]) -> tuple[int, str]:
+    provider = str(item.get("provider") or "")
+    title = str(item.get("title") or "").lower()
+    priority = 0 if provider == "openlibrary" else 1
+    return (priority, title)
+
+
+def _has_selected_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _selected_values_from_openlibrary_bundle(
+    *,
+    bundle: OpenLibraryWorkBundle,
+) -> dict[str, object]:
+    edition = bundle.edition if isinstance(bundle.edition, dict) else {}
+    raw_edition = bundle.raw_edition if isinstance(bundle.raw_edition, dict) else {}
+    return {
+        "work.description": bundle.description,
+        "work.cover_url": bundle.cover_url,
+        "work.first_publish_year": bundle.first_publish_year,
+        "edition.publisher": edition.get("publisher"),
+        "edition.publish_date": edition.get("publish_date_iso")
+        or edition.get("publish_date"),
+        "edition.isbn10": edition.get("isbn10"),
+        "edition.isbn13": edition.get("isbn13"),
+        "edition.language": edition.get("language"),
+        "edition.format": edition.get("format"),
+        "edition.total_pages": edition.get("total_pages")
+        or raw_edition.get("number_of_pages"),
+        "edition.total_audio_minutes": edition.get("total_audio_minutes")
+        or raw_edition.get("duration"),
+    }
+
+
+def _selected_values_from_google_bundle(
+    *,
+    bundle: GoogleBooksWorkBundle,
+) -> dict[str, object]:
+    edition = bundle.edition if isinstance(bundle.edition, dict) else {}
+    return {
+        "work.description": bundle.description,
+        "work.cover_url": bundle.cover_url,
+        "work.first_publish_year": bundle.first_publish_year,
+        "edition.publisher": edition.get("publisher"),
+        "edition.publish_date": edition.get("publish_date_iso"),
+        "edition.isbn10": edition.get("isbn10"),
+        "edition.isbn13": edition.get("isbn13"),
+        "edition.language": edition.get("language"),
+        "edition.format": edition.get("format"),
+        "edition.total_pages": edition.get("total_pages"),
+        "edition.total_audio_minutes": edition.get("total_audio_minutes"),
+    }
+
+
+def _resolve_openlibrary_work_key_for_source(
+    *,
+    session: Session,
+    work_id: uuid.UUID,
+    source_id: str,
+) -> str | None:
+    if source_id.startswith("/works/"):
+        return source_id
+    if source_id.startswith("/books/"):
+        raw = session.scalar(
+            sa.select(SourceRecord.raw).where(
+                SourceRecord.provider == "openlibrary",
+                SourceRecord.entity_type == "edition",
+                SourceRecord.provider_id == source_id,
+            )
+        )
+        if isinstance(raw, dict):
+            works = raw.get("works")
+            if isinstance(works, list):
+                for item in works:
+                    if not isinstance(item, dict):
+                        continue
+                    key = item.get("key")
+                    if isinstance(key, str) and key.startswith("/works/"):
+                        return key
+    return _openlibrary_work_key_for_work(session, work_id=work_id)
+
+
+def _openlibrary_edition_raw_has_compare_fields(raw: object) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    # We require at least one edition-specific metadata field and covers to avoid
+    # stale partial rows forcing work-level fallback values in compare payloads.
+    has_edition_data = any(
+        _has_selected_value(value)
+        for value in (
+            _first_string(raw.get("publishers")),
+            raw.get("publish_date") if isinstance(raw.get("publish_date"), str) else None,
+            _first_string(raw.get("isbn_10")),
+            _first_string(raw.get("isbn_13")),
+            _extract_source_language(raw),
+        )
+    )
+    covers = raw.get("covers")
+    has_cover = isinstance(covers, list) and any(
+        isinstance(cover_id, int) and cover_id > 0 for cover_id in covers
+    )
+    return has_edition_data and has_cover
+
+
+def _upsert_source_record(
+    session: Session,
+    *,
+    provider: str,
+    entity_type: str,
+    provider_id: str,
+    raw: object,
+) -> None:
+    if not isinstance(raw, dict):
+        return
+    existing = session.scalar(
+        sa.select(SourceRecord).where(
+            SourceRecord.provider == provider,
+            SourceRecord.entity_type == entity_type,
+            SourceRecord.provider_id == provider_id,
+        )
+    )
+    if existing is None:
+        session.add(
+            SourceRecord(
+                provider=provider,
+                entity_type=entity_type,
+                provider_id=provider_id,
+                raw=raw,
+            )
+        )
+    else:
+        existing.raw = raw
+
+
+def _parse_openlibrary_description(raw_work: object) -> str | None:
+    if not isinstance(raw_work, dict):
+        return None
+    description = raw_work.get("description")
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    if isinstance(description, dict):
+        value = description.get("value")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _parse_openlibrary_first_publish_year(raw_work: object) -> int | None:
+    if not isinstance(raw_work, dict):
+        return None
+    for key in ("first_publish_year", "first_publish_date"):
+        value = raw_work.get(key)
+        if isinstance(value, int) and 0 < value < 10000:
+            return value
+        if isinstance(value, str):
+            match = re.search(r"\b(\d{4})\b", value)
+            if match:
+                year = int(match.group(1))
+                if 0 < year < 10000:
+                    return year
+    return None
+
+
+def _parse_openlibrary_cover_url(raw_work: object, raw_edition: object) -> str | None:
+    # Prefer the selected edition cover; fall back to work cover when absent.
+    for raw in (raw_edition, raw_work):
+        if not isinstance(raw, dict):
+            continue
+        covers = raw.get("covers")
+        if not isinstance(covers, list):
+            continue
+        for cover_id in covers:
+            if isinstance(cover_id, int) and cover_id > 0:
+                return f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
+    return None
+
+
+def _parse_openlibrary_selected_values(
+    *,
+    raw_work: object,
+    raw_edition: object,
+) -> dict[str, object]:
+    edition = raw_edition if isinstance(raw_edition, dict) else {}
+    return {
+        "work.description": _parse_openlibrary_description(raw_work),
+        "work.cover_url": _parse_openlibrary_cover_url(raw_work, raw_edition),
+        "work.first_publish_year": _parse_openlibrary_first_publish_year(raw_work),
+        "edition.publisher": _first_string(edition.get("publishers")),
+        "edition.publish_date": (
+            edition.get("publish_date")
+            if isinstance(edition.get("publish_date"), str)
+            else None
+        ),
+        "edition.isbn10": _first_string(edition.get("isbn_10")),
+        "edition.isbn13": _first_string(edition.get("isbn_13")),
+        "edition.language": _extract_source_language(edition),
+        "edition.format": (
+            edition.get("physical_format")
+            if isinstance(edition.get("physical_format"), str)
+            else None
+        ),
+        "edition.total_pages": (
+            edition.get("number_of_pages")
+            if isinstance(edition.get("number_of_pages"), int)
+            else None
+        ),
+        "edition.total_audio_minutes": (
+            edition.get("duration")
+            if isinstance(edition.get("duration"), (int, float, str))
+            else None
+        ),
+    }
+
+
+def _parse_google_selected_values(raw_volume: object) -> dict[str, object]:
+    if not isinstance(raw_volume, dict):
+        return {}
+    volume_info = raw_volume.get("volumeInfo")
+    if not isinstance(volume_info, dict):
+        volume_info = {}
+    published_date = (
+        volume_info.get("publishedDate")
+        if isinstance(volume_info.get("publishedDate"), str)
+        else None
+    )
+    publish_year = None
+    if published_date:
+        match = re.search(r"\b(\d{4})\b", published_date)
+        if match:
+            publish_year = int(match.group(1))
+    image_links = volume_info.get("imageLinks")
+    cover_url = None
+    if isinstance(image_links, dict):
+        for key in ("thumbnail", "smallThumbnail"):
+            value = image_links.get(key)
+            if isinstance(value, str) and value.strip():
+                cover_url = value.strip().replace("http://", "https://", 1)
+                break
+    raw_identifiers = volume_info.get("industryIdentifiers")
+    identifiers: list[object] = (
+        raw_identifiers if isinstance(raw_identifiers, list) else []
+    )
+    isbn10 = _first_string(
+        [
+            item.get("identifier")
+            for item in identifiers
+            if isinstance(item, dict)
+            and str(item.get("type") or "").upper() == "ISBN_10"
+            and isinstance(item.get("identifier"), str)
+        ]
+    )
+    isbn13 = _first_string(
+        [
+            item.get("identifier")
+            for item in identifiers
+            if isinstance(item, dict)
+            and str(item.get("type") or "").upper() == "ISBN_13"
+            and isinstance(item.get("identifier"), str)
+        ]
+    )
+    return {
+        "work.description": (
+            volume_info.get("description")
+            if isinstance(volume_info.get("description"), str)
+            else None
+        ),
+        "work.cover_url": cover_url,
+        "work.first_publish_year": publish_year,
+        "edition.publisher": (
+            volume_info.get("publisher")
+            if isinstance(volume_info.get("publisher"), str)
+            else None
+        ),
+        "edition.publish_date": published_date,
+        "edition.isbn10": isbn10,
+        "edition.isbn13": isbn13,
+        "edition.language": (
+            volume_info.get("language")
+            if isinstance(volume_info.get("language"), str)
+            else None
+        ),
+        "edition.format": (
+            volume_info.get("printType")
+            if isinstance(volume_info.get("printType"), str)
+            else None
+        ),
+        "edition.total_pages": (
+            volume_info.get("pageCount")
+            if isinstance(volume_info.get("pageCount"), int)
+            else None
+        ),
+        "edition.total_audio_minutes": None,
+    }
+
+
+def _resolve_edition_target_for_compare(
+    *,
+    session: Session,
+    work_id: uuid.UUID,
+    user_id: uuid.UUID,
+    edition_id: uuid.UUID | None,
+) -> Edition | None:
+    if edition_id is not None:
+        return session.scalar(
+            sa.select(Edition).where(
+                Edition.id == edition_id,
+                Edition.work_id == work_id,
+            )
+        )
+    preferred = session.scalar(
+        sa.select(LibraryItem.preferred_edition_id).where(
+            LibraryItem.user_id == user_id,
+            LibraryItem.work_id == work_id,
+        )
+    )
+    if isinstance(preferred, uuid.UUID):
+        edition = session.scalar(
+            sa.select(Edition).where(
+                Edition.id == preferred,
+                Edition.work_id == work_id,
+            )
+        )
+        if edition is not None:
+            return edition
+    return session.scalar(
+        sa.select(Edition)
+        .where(Edition.work_id == work_id)
+        .order_by(Edition.created_at.desc(), Edition.id.desc())
+        .limit(1)
+    )
+
+
+def _current_field_values_for_compare(
+    *,
+    session: Session,
+    work_id: uuid.UUID,
+    user_id: uuid.UUID,
+    edition_id: uuid.UUID | None,
+) -> dict[str, object]:
+    work = session.get(Work, work_id)
+    if work is None:
+        raise HTTPException(status_code=404, detail="work not found")
+    edition = _resolve_edition_target_for_compare(
+        session=session,
+        work_id=work_id,
+        user_id=user_id,
+        edition_id=edition_id,
+    )
+    return {
+        "work.description": work.description,
+        "work.cover_url": work.default_cover_url,
+        "work.first_publish_year": work.first_publish_year,
+        "edition.publisher": edition.publisher if edition else None,
+        "edition.publish_date": edition.publish_date if edition else None,
+        "edition.isbn10": edition.isbn10 if edition else None,
+        "edition.isbn13": edition.isbn13 if edition else None,
+        "edition.language": edition.language if edition else None,
+        "edition.format": edition.format if edition else None,
+        "edition.total_pages": edition.total_pages if edition else None,
+        "edition.total_audio_minutes": (
+            edition.total_audio_minutes if edition else None
+        ),
+    }
+
+
+async def _build_cover_metadata_compare_payload(
+    *,
+    session: Session,
+    auth: AuthContext,
+    work_id: uuid.UUID,
+    open_library: OpenLibraryClient,
+    google_books: GoogleBooksClient,
+    provider: str,
+    source_id: str,
+    edition_id: uuid.UUID | None,
+) -> dict[str, object]:
+    normalized_provider = provider.strip().lower()
+    if normalized_provider not in {"openlibrary", "googlebooks"}:
+        raise HTTPException(status_code=400, detail="provider must be supported")
+    normalized_source_id = source_id.strip()
+    if not normalized_source_id:
+        raise HTTPException(status_code=400, detail="source_id is required")
+
+    current_values = _current_field_values_for_compare(
+        session=session,
+        work_id=work_id,
+        user_id=auth.user_id,
+        edition_id=edition_id,
+    )
+
+    selected_source_label = None
+    selected_values: dict[str, object] = {}
+    selected_provider_ids: dict[str, str] = {}
+    should_commit = False
+
+    if normalized_provider == "openlibrary":
+        work_key = _resolve_openlibrary_work_key_for_source(
+            session=session,
+            work_id=work_id,
+            source_id=normalized_source_id,
+        )
+        if not work_key:
+            raise HTTPException(
+                status_code=404,
+                detail="Unable to resolve Open Library work for selected source.",
+            )
+        edition_key = (
+            normalized_source_id if normalized_source_id.startswith("/books/") else None
+        )
+        raw_work = session.scalar(
+            sa.select(SourceRecord.raw).where(
+                SourceRecord.provider == "openlibrary",
+                SourceRecord.entity_type == "work",
+                SourceRecord.provider_id == work_key,
+            )
+        )
+        raw_edition = None
+        if edition_key:
+            raw_edition = session.scalar(
+                sa.select(SourceRecord.raw).where(
+                    SourceRecord.provider == "openlibrary",
+                    SourceRecord.entity_type == "edition",
+                    SourceRecord.provider_id == edition_key,
+                )
+            )
+        edition_requires_refresh = bool(
+            edition_key and not _openlibrary_edition_raw_has_compare_fields(raw_edition)
+        )
+        if (
+            not isinstance(raw_work, dict)
+            or (edition_key and not isinstance(raw_edition, dict))
+            or edition_requires_refresh
+        ):
+            openlibrary_bundle = await open_library.fetch_work_bundle(
+                work_key=work_key,
+                edition_key=edition_key,
+            )
+            _upsert_source_record(
+                session,
+                provider="openlibrary",
+                entity_type="work",
+                provider_id=openlibrary_bundle.work_key,
+                raw=openlibrary_bundle.raw_work,
+            )
+            should_commit = True
+            raw_work = openlibrary_bundle.raw_work
+            if openlibrary_bundle.raw_edition and edition_key:
+                _upsert_source_record(
+                    session,
+                    provider="openlibrary",
+                    entity_type="edition",
+                    provider_id=edition_key,
+                    raw=openlibrary_bundle.raw_edition,
+                )
+                should_commit = True
+                raw_edition = openlibrary_bundle.raw_edition
+        selected_values = _parse_openlibrary_selected_values(
+            raw_work=raw_work,
+            raw_edition=raw_edition,
+        )
+        selected_source_label = f"Open Library {normalized_source_id.removeprefix('/works/').removeprefix('/books/')}"
+        for field_key in FIELD_LABELS:
+            provider_id = work_key
+            if field_key.startswith("edition.") and edition_key:
+                provider_id = edition_key
+            selected_provider_ids[field_key] = provider_id
+    else:
+        raw_volume = session.scalar(
+            sa.select(SourceRecord.raw).where(
+                SourceRecord.provider == "googlebooks",
+                SourceRecord.entity_type == "edition",
+                SourceRecord.provider_id == normalized_source_id,
+            )
+        )
+        if not isinstance(raw_volume, dict):
+            google_bundle = await google_books.fetch_work_bundle(
+                volume_id=normalized_source_id
+            )
+            _upsert_source_record(
+                session,
+                provider="googlebooks",
+                entity_type="work",
+                provider_id=google_bundle.volume_id,
+                raw=google_bundle.raw_volume,
+            )
+            _upsert_source_record(
+                session,
+                provider="googlebooks",
+                entity_type="edition",
+                provider_id=google_bundle.volume_id,
+                raw=google_bundle.raw_volume,
+            )
+            should_commit = True
+            raw_volume = google_bundle.raw_volume
+        selected_values = _parse_google_selected_values(raw_volume)
+        selected_source_label = f"Google Books {normalized_source_id}"
+        for field_key in FIELD_LABELS:
+            selected_provider_ids[field_key] = normalized_source_id
+
+    if should_commit:
+        session.commit()
+
+    compared_fields: list[dict[str, object]] = []
+    for field_key in FIELD_LABELS:
+        selected_value = selected_values.get(field_key)
+        selected_available = _has_selected_value(selected_value)
+        compared_fields.append(
+            {
+                "field_key": field_key,
+                "field_label": _field_label(field_key),
+                "current_value": current_values.get(field_key),
+                "selected_value": selected_value if selected_available else None,
+                "selected_available": selected_available,
+                "provider": normalized_provider,
+                "provider_id": selected_provider_ids.get(
+                    field_key, normalized_source_id
+                ),
+            }
+        )
+
+    return {
+        "selected_source": {
+            "provider": normalized_provider,
+            "source_id": normalized_source_id,
+            "source_label": selected_source_label
+            or (
+                "Open Library"
+                if normalized_provider == "openlibrary"
+                else "Google Books"
+            ),
+            "edition_id": str(edition_id) if edition_id else None,
+        },
+        "fields": compared_fields,
+    }
+
+
 @router.post("/api/v1/works/{work_id}/covers/select")
 async def select_cover(
     work_id: uuid.UUID,
@@ -221,6 +1176,369 @@ async def select_cover(
         ) from exc
 
     return ok(result)
+
+
+@router.get("/api/v1/works/{work_id}/cover-metadata/sources")
+async def list_cover_metadata_sources(
+    work_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+    google_books: Annotated[GoogleBooksClient, Depends(get_google_books_client)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 30,
+    language: str | None = Query(default=None, min_length=1, max_length=32),
+    include_prefetch_compare: bool = Query(default=False),
+    prefetch_limit: Annotated[int, Query(ge=1, le=6)] = 3,
+) -> dict[str, object]:
+    mapped_work_key = _openlibrary_work_key_for_work(session, work_id=work_id)
+    work_author_names = _work_authors_for_lookup(session, work_id=work_id)
+    if mapped_work_key and not work_author_names:
+        try:
+            mapped_bundle = await open_library.fetch_work_bundle(
+                work_key=mapped_work_key
+            )
+            bundle_authors = (
+                mapped_bundle.authors if isinstance(mapped_bundle.authors, list) else []
+            )
+            names: list[str] = []
+            for author in bundle_authors:
+                if not isinstance(author, dict):
+                    continue
+                name = author.get("name")
+                if isinstance(name, str) and name.strip():
+                    names.append(name.strip())
+            if names:
+                work_author_names = names
+        except Exception:
+            pass
+    candidate_works: list[tuple[str, str, list[str]]] = []
+    if mapped_work_key:
+        candidate_works.append(
+            (mapped_work_key, "Mapped Open Library work", work_author_names)
+        )
+    else:
+        lookup_title = _work_title_for_lookup(session, work_id=work_id)
+        if lookup_title:
+            lookup_author = _first_author_for_lookup(session, work_id=work_id)
+            matches = await open_library.search_books(
+                query=lookup_title,
+                limit=min(5, limit),
+                page=1,
+                author=lookup_author,
+                language=language,
+                sort="relevance",
+            )
+            seen_work_keys: set[str] = set()
+            for match_item in matches.items:
+                normalized_work_key = match_item.work_key.strip()
+                if not normalized_work_key or normalized_work_key in seen_work_keys:
+                    continue
+                seen_work_keys.add(normalized_work_key)
+                candidate_works.append(
+                    (
+                        normalized_work_key,
+                        match_item.title,
+                        match_item.author_names,
+                    )
+                )
+                if len(candidate_works) >= 3:
+                    break
+
+    openlibrary_items: list[dict[str, object]] = []
+    seen_openlibrary_ids: set[str] = set()
+    per_work_limit = max(5, min(limit, 20))
+    for work_key, work_title, work_authors in candidate_works:
+        editions = await open_library.fetch_work_editions(
+            work_key=work_key,
+            limit=per_work_limit,
+            language=language,
+        )
+        for entry in editions:
+            if entry.key in seen_openlibrary_ids:
+                continue
+            seen_openlibrary_ids.add(entry.key)
+            openlibrary_items.append(
+                {
+                    "provider": "openlibrary",
+                    "source_id": entry.key,
+                    "title": entry.title or work_title,
+                    "authors": work_authors or work_author_names,
+                    "publisher": entry.publisher,
+                    "publish_date": entry.publish_date,
+                    "language": entry.language,
+                    "identifier": entry.isbn13 or entry.isbn10 or entry.key,
+                    "cover_url": entry.cover_url,
+                    "source_label": "Open Library",
+                }
+            )
+            if len(openlibrary_items) >= limit:
+                break
+        if len(openlibrary_items) >= limit:
+            break
+
+    google_items = await _collect_google_source_tiles(
+        work_id=work_id,
+        auth=auth,
+        session=session,
+        google_books=google_books,
+        settings=settings,
+        limit=limit,
+        language=language,
+    )
+
+    deduped: list[dict[str, object]] = []
+    seen_keys: set[tuple[str, str]] = set()
+    for source_item in [*openlibrary_items, *google_items]:
+        provider = str(source_item.get("provider") or "")
+        source_id = str(source_item.get("source_id") or "")
+        if not provider or not source_id:
+            continue
+        key = (provider, source_id)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append(source_item)
+    deduped.sort(key=_tile_sort_key)
+
+    source_records = session.execute(
+        sa.select(
+            SourceRecord.provider, SourceRecord.provider_id, SourceRecord.raw
+        ).where(SourceRecord.provider.in_(["openlibrary", "googlebooks"]))
+    ).all()
+    source_lookup = {
+        (provider, provider_id): raw
+        for provider, provider_id, raw in source_records
+        if isinstance(provider, str) and isinstance(provider_id, str)
+    }
+    for source_item in deduped:
+        provider = str(source_item.get("provider") or "")
+        source_id = str(source_item.get("source_id") or "")
+        raw = source_lookup.get((provider, source_id))
+        if not source_item.get("title"):
+            source_item["title"] = _extract_source_title(raw) or "Untitled"
+        if not isinstance(source_item.get("authors"), list):
+            source_item["authors"] = _extract_source_authors(raw)
+        if not source_item.get("publisher"):
+            source_item["publisher"] = _extract_source_publisher(raw)
+        if not source_item.get("publish_date"):
+            source_item["publish_date"] = _extract_source_publish_date(raw)
+        if not source_item.get("language"):
+            source_item["language"] = _extract_source_language(raw)
+        if not source_item.get("cover_url"):
+            source_item["cover_url"] = _extract_source_cover(raw)
+        identifier = str(source_item.get("identifier") or "").strip()
+        if not identifier:
+            source_item["identifier"] = _extract_source_identifier(raw, source_id)
+
+    items = deduped[:limit]
+    prefetch_compare: dict[str, object] = {}
+    if include_prefetch_compare:
+        for source_item in items[:prefetch_limit]:
+            provider = str(source_item.get("provider") or "").strip().lower()
+            source_id = str(source_item.get("source_id") or "").strip()
+            if not provider or not source_id:
+                continue
+            payload = await _build_cover_metadata_compare_payload(
+                session=session,
+                auth=auth,
+                work_id=work_id,
+                open_library=open_library,
+                google_books=google_books,
+                provider=provider,
+                source_id=source_id,
+                edition_id=None,
+            )
+            prefetch_compare[f"{provider}:{source_id}"] = payload
+
+    return ok(
+        {
+            "items": items,
+            "prefetch_compare": prefetch_compare,
+        }
+    )
+
+
+@router.get("/api/v1/works/{work_id}/cover-metadata/compare")
+async def compare_cover_metadata_source(
+    work_id: uuid.UUID,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+    google_books: Annotated[GoogleBooksClient, Depends(get_google_books_client)],
+    provider: Annotated[str, Query(min_length=1, max_length=32)],
+    source_id: Annotated[str, Query(min_length=1, max_length=255)],
+    edition_id: uuid.UUID | None = None,
+) -> dict[str, object]:
+    payload = await _build_cover_metadata_compare_payload(
+        session=session,
+        auth=auth,
+        work_id=work_id,
+        open_library=open_library,
+        google_books=google_books,
+        provider=provider,
+        source_id=source_id,
+        edition_id=edition_id,
+    )
+    return ok(payload)
+
+
+@router.get("/api/v1/works/{work_id}/provider-editions/openlibrary")
+async def list_openlibrary_editions(
+    work_id: uuid.UUID,
+    _auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    language: str | None = Query(default=None, min_length=1, max_length=32),
+) -> dict[str, object]:
+    mapped_work_key = _openlibrary_work_key_for_work(session, work_id=work_id)
+    candidate_works: list[tuple[str, str, list[str]]] = []
+    if mapped_work_key:
+        candidate_works.append((mapped_work_key, "Mapped Open Library work", []))
+    else:
+        lookup_title = _work_title_for_lookup(session, work_id=work_id)
+        if lookup_title:
+            lookup_author = _first_author_for_lookup(session, work_id=work_id)
+            matches = await open_library.search_books(
+                query=lookup_title,
+                limit=min(5, limit),
+                page=1,
+                author=lookup_author,
+                language=language,
+                sort="relevance",
+            )
+            seen_work_keys: set[str] = set()
+            for item in matches.items:
+                normalized_work_key = item.work_key.strip()
+                if not normalized_work_key or normalized_work_key in seen_work_keys:
+                    continue
+                seen_work_keys.add(normalized_work_key)
+                candidate_works.append(
+                    (normalized_work_key, item.title, item.author_names)
+                )
+                if len(candidate_works) >= 3:
+                    break
+
+    items: list[dict[str, object | None]] = []
+    seen_edition_keys: set[str] = set()
+    per_work_limit = max(5, min(limit, 20))
+    for work_key, work_title, work_authors in candidate_works:
+        editions = await open_library.fetch_work_editions(
+            work_key=work_key,
+            limit=per_work_limit,
+            language=language,
+        )
+        for entry in editions:
+            if entry.key in seen_edition_keys:
+                continue
+            seen_edition_keys.add(entry.key)
+            items.append(
+                {
+                    "work_key": work_key,
+                    "work_title": work_title,
+                    "work_authors": work_authors,
+                    "edition_key": entry.key,
+                    "title": entry.title,
+                    "publisher": entry.publisher,
+                    "publish_date": entry.publish_date,
+                    "language": entry.language,
+                    "isbn10": entry.isbn10,
+                    "isbn13": entry.isbn13,
+                    "cover_url": entry.cover_url,
+                }
+            )
+            if len(items) >= limit:
+                break
+        if len(items) >= limit:
+            break
+
+    edition_keys = [str(entry["edition_key"]) for entry in items]
+    imported_lookup: dict[str, str] = {}
+    if edition_keys:
+        imported_rows = session.execute(
+            sa.select(ExternalId.provider_id, ExternalId.entity_id)
+            .join(Edition, Edition.id == ExternalId.entity_id)
+            .where(
+                ExternalId.entity_type == "edition",
+                ExternalId.provider == "openlibrary",
+                ExternalId.provider_id.in_(edition_keys),
+                Edition.work_id == work_id,
+            )
+        ).all()
+        imported_lookup = {
+            provider_id: str(entity_id) for provider_id, entity_id in imported_rows
+        }
+
+    return ok(
+        {
+            "items": [
+                {
+                    **entry,
+                    "imported_edition_id": imported_lookup.get(
+                        str(entry["edition_key"])
+                    ),
+                }
+                for entry in items
+            ],
+            "mapped_work_key": mapped_work_key,
+        }
+    )
+
+
+@router.post("/api/v1/works/{work_id}/provider-editions/openlibrary/import")
+async def import_openlibrary_edition(
+    work_id: uuid.UUID,
+    payload: ImportOpenLibraryEditionRequest,
+    auth: Annotated[AuthContext, Depends(require_auth_context)],
+    session: Annotated[Session, Depends(get_db_session)],
+    open_library: Annotated[OpenLibraryClient, Depends(get_open_library_client)],
+) -> dict[str, object]:
+    payload_work_key = (payload.work_key or "").strip()
+    existing_work_key = _openlibrary_work_key_for_work(session, work_id=work_id)
+    openlibrary_work_key = payload_work_key or existing_work_key
+    if not openlibrary_work_key:
+        raise HTTPException(
+            status_code=400,
+            detail="Select an Open Library work before importing an edition.",
+        )
+
+    _ensure_openlibrary_work_mapping(
+        session,
+        work_id=work_id,
+        work_key=openlibrary_work_key,
+    )
+
+    bundle = await open_library.fetch_work_bundle(
+        work_key=openlibrary_work_key,
+        edition_key=payload.edition_key,
+    )
+    result = import_openlibrary_bundle(session, bundle=bundle)
+    imported_edition = result.get("edition")
+    imported_edition_id = (
+        imported_edition.get("id")
+        if isinstance(imported_edition, dict)
+        and isinstance(imported_edition.get("id"), str)
+        else None
+    )
+
+    if payload.set_preferred and imported_edition_id is not None:
+        item = session.scalar(
+            sa.select(LibraryItem).where(
+                LibraryItem.user_id == auth.user_id,
+                LibraryItem.work_id == work_id,
+            )
+        )
+        if item is not None:
+            item.preferred_edition_id = uuid.UUID(imported_edition_id)
+            session.commit()
+
+    return ok(
+        {
+            "imported_edition_id": imported_edition_id,
+            "edition": imported_edition,
+        }
+    )
 
 
 @router.get("/api/v1/works/{work_id}/enrichment/candidates")

--- a/apps/api/tests/test_works_router.py
+++ b/apps/api/tests/test_works_router.py
@@ -7,20 +7,51 @@ from typing import Any, cast
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from app.core.config import Settings, get_settings
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
 from app.routers.works import (
+    _author_match_score,
+    _build_cover_metadata_compare_payload,
+    _collect_google_source_tiles,
+    _current_field_values_for_compare,
     _ensure_openlibrary_work_mapping,
+    _extract_source_authors,
+    _extract_source_cover,
+    _extract_source_identifier,
+    _extract_source_language,
+    _extract_source_publish_date,
+    _extract_source_publisher,
+    _extract_source_title,
     _first_author_for_lookup,
+    _first_string,
+    _google_books_enabled_for_user,
+    _has_selected_value,
+    _normalize_text_tokens,
+    _openlibrary_edition_raw_has_compare_fields,
+    _parse_google_selected_values,
+    _parse_openlibrary_cover_url,
+    _parse_openlibrary_description,
+    _parse_openlibrary_first_publish_year,
+    _parse_openlibrary_selected_values,
+    _resolve_edition_target_for_compare,
+    _resolve_openlibrary_work_key_for_source,
+    _selected_values_from_google_bundle,
+    _selected_values_from_openlibrary_bundle,
+    _tile_sort_key,
+    _title_match_score,
+    _upsert_source_record,
+    _work_authors_for_lookup,
     _work_title_for_lookup,
     get_google_books_client,
     get_open_library_client,
 )
 from app.routers.works import router as works_router
+from app.services.google_books import GoogleBooksWorkBundle
+from app.services.open_library import OpenLibraryWorkBundle
 from app.services.storage import StorageNotConfiguredError
 
 
@@ -125,6 +156,23 @@ def test_get_work(app: FastAPI) -> None:
 
 def test_get_open_library_client_constructs_client() -> None:
     client = get_open_library_client()
+    assert client is not None
+
+
+def test_get_google_books_client_constructs_client() -> None:
+    client = get_google_books_client(
+        Settings(
+            supabase_url="https://example.supabase.co",
+            supabase_jwt_audience="authenticated",
+            supabase_jwt_secret=None,
+            supabase_jwks_cache_ttl_seconds=60,
+            supabase_service_role_key="service-role",
+            supabase_storage_covers_bucket="covers",
+            public_highlight_max_chars=280,
+            google_books_api_key="test-key",
+            api_version="0.1.0",
+        )
+    )
     assert client is not None
 
 
@@ -725,6 +773,69 @@ def test_work_title_for_lookup_returns_none_for_missing_work() -> None:
     assert _work_title_for_lookup(cast(Any, session), work_id=uuid.uuid4()) is None
 
 
+def test_google_books_enabled_for_user_requires_setting_key_and_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = AuthContext(claims={}, client_id=None, user_id=uuid.uuid4())
+    session = cast(Any, _FakeSession(scalar_values=[]))
+    monkeypatch.setattr(
+        "app.routers.works.get_or_create_profile",
+        lambda *_args, **_kwargs: SimpleNamespace(enable_google_books=True),
+    )
+    assert not _google_books_enabled_for_user(
+        auth=auth,
+        session=session,
+        settings=Settings(
+            supabase_url="https://example.supabase.co",
+            supabase_jwt_audience="authenticated",
+            supabase_jwt_secret=None,
+            supabase_jwks_cache_ttl_seconds=60,
+            supabase_service_role_key="service-role",
+            supabase_storage_covers_bucket="covers",
+            public_highlight_max_chars=280,
+            book_provider_google_enabled=False,
+            google_books_api_key="key",
+            api_version="0.1.0",
+        ),
+    )
+    assert not _google_books_enabled_for_user(
+        auth=auth,
+        session=session,
+        settings=Settings(
+            supabase_url="https://example.supabase.co",
+            supabase_jwt_audience="authenticated",
+            supabase_jwt_secret=None,
+            supabase_jwks_cache_ttl_seconds=60,
+            supabase_service_role_key="service-role",
+            supabase_storage_covers_bucket="covers",
+            public_highlight_max_chars=280,
+            book_provider_google_enabled=True,
+            google_books_api_key=None,
+            api_version="0.1.0",
+        ),
+    )
+    monkeypatch.setattr(
+        "app.routers.works.get_or_create_profile",
+        lambda *_args, **_kwargs: SimpleNamespace(enable_google_books=False),
+    )
+    assert not _google_books_enabled_for_user(
+        auth=auth,
+        session=session,
+        settings=Settings(
+            supabase_url="https://example.supabase.co",
+            supabase_jwt_audience="authenticated",
+            supabase_jwt_secret=None,
+            supabase_jwks_cache_ttl_seconds=60,
+            supabase_service_role_key="service-role",
+            supabase_storage_covers_bucket="covers",
+            public_highlight_max_chars=280,
+            book_provider_google_enabled=True,
+            google_books_api_key="key",
+            api_version="0.1.0",
+        ),
+    )
+
+
 def test_first_author_for_lookup_returns_none_for_missing_or_invalid_row() -> None:
     session_none = _FakeSession(scalar_values=[], execute_rows=[[]])
     assert (
@@ -736,6 +847,19 @@ def test_first_author_for_lookup_returns_none_for_missing_or_invalid_row() -> No
         _first_author_for_lookup(cast(Any, session_invalid), work_id=uuid.uuid4())
         is None
     )
+
+
+def test_work_authors_for_lookup_filters_invalid_blank_and_duplicates() -> None:
+    session = _FakeSession(
+        scalar_values=[],
+        execute_rows=[
+            [(123,), (" Matt Dinniman ",), ("",), ("Matt Dinniman",), ("A",)]
+        ],
+    )
+    assert _work_authors_for_lookup(cast(Any, session), work_id=uuid.uuid4()) == [
+        "Matt Dinniman",
+        "A",
+    ]
 
 
 def test_ensure_openlibrary_work_mapping_updates_existing_mapping() -> None:
@@ -1095,3 +1219,1420 @@ def test_import_openlibrary_provider_edition_skips_preferred_when_disabled(
 
     assert response.status_code == 200
     assert fake_session.commit_calls == 0
+
+
+def test_source_extract_helpers_and_matching() -> None:
+    openlibrary_raw = {
+        "title": " This Inevitable Ruin ",
+        "author_name": ["Matt Dinniman"],
+        "covers": [15142977],
+        "languages": [{"key": "/languages/eng"}],
+        "publishers": ["Ace"],
+        "publish_date": "2025-09-23",
+        "isbn_13": ["9798217190041"],
+    }
+    google_raw = {
+        "volumeInfo": {
+            "title": "This Inevitable Ruin",
+            "authors": ["Matt Dinniman"],
+            "imageLinks": {"thumbnail": "http://books.google.com/cover.jpg"},
+            "language": "en",
+            "publisher": "Penguin",
+            "publishedDate": "2025-02-11",
+            "industryIdentifiers": [{"identifier": "9780593820254"}],
+        }
+    }
+
+    assert _first_string(["", "  ", "value "]) == "value"
+    assert _extract_source_title(openlibrary_raw) == "This Inevitable Ruin"
+    assert _extract_source_title(google_raw) == "This Inevitable Ruin"
+    assert _extract_source_authors(openlibrary_raw) == ["Matt Dinniman"]
+    assert _extract_source_authors(google_raw) == ["Matt Dinniman"]
+    openlibrary_cover = _extract_source_cover(openlibrary_raw)
+    assert openlibrary_cover is not None
+    assert openlibrary_cover.endswith("-M.jpg")
+    assert _extract_source_cover(google_raw) == "https://books.google.com/cover.jpg"
+    assert _extract_source_language(openlibrary_raw) == "eng"
+    assert _extract_source_language(google_raw) == "en"
+    assert _extract_source_publisher(openlibrary_raw) == "Ace"
+    assert _extract_source_publish_date(google_raw) == "2025-02-11"
+    assert _extract_source_identifier(openlibrary_raw, "fallback") == "9798217190041"
+    assert _extract_source_identifier({}, "fallback") == "fallback"
+    assert _normalize_text_tokens("This, Inevitable RUIN!") == [
+        "this",
+        "inevitable",
+        "ruin",
+    ]
+    assert _title_match_score("This Inevitable Ruin", "This Inevitable Ruin") == 100
+    assert _author_match_score("Matt Dinniman", ["Matt Dinniman"]) >= 25
+    assert _tile_sort_key({"provider": "openlibrary", "title": "A"}) < _tile_sort_key(
+        {"provider": "googlebooks", "title": "A"}
+    )
+    assert _has_selected_value("x")
+    assert not _has_selected_value("  ")
+
+
+def test_openlibrary_and_google_selected_value_parsers() -> None:
+    raw_work = {
+        "description": {"value": "A desc"},
+        "first_publish_year": 2024,
+        "covers": [99],
+    }
+    raw_edition = {
+        "covers": [100],
+        "publishers": ["Ace"],
+        "publish_date": "2025-09-23",
+        "isbn_13": ["9798217190041"],
+        "languages": [{"key": "/languages/eng"}],
+        "physical_format": "Hardcover",
+        "number_of_pages": 880,
+        "duration": "10:37:00",
+        "works": [{"key": "/works/OL41914127W"}],
+    }
+    parsed = _parse_openlibrary_selected_values(
+        raw_work=raw_work, raw_edition=raw_edition
+    )
+    assert parsed["work.description"] == "A desc"
+    assert parsed["work.cover_url"] is not None
+    assert str(parsed["work.cover_url"]).endswith("/100-L.jpg")
+    assert parsed["edition.publisher"] == "Ace"
+    assert parsed["edition.total_pages"] == 880
+    assert _parse_openlibrary_description({"description": "x"}) == "x"
+    assert (
+        _parse_openlibrary_first_publish_year({"first_publish_date": "2025-09-23"})
+        == 2025
+    )
+    cover_url = _parse_openlibrary_cover_url({"covers": [1]}, {"covers": [2]})
+    assert cover_url is not None
+    assert cover_url.endswith("/2-L.jpg")
+    assert _openlibrary_edition_raw_has_compare_fields(raw_edition)
+
+    google_raw = {
+        "volumeInfo": {
+            "description": "Google desc",
+            "publishedDate": "2025-02-11",
+            "imageLinks": {"thumbnail": "http://books.google.com/x.jpg"},
+            "industryIdentifiers": [
+                {"type": "ISBN_10", "identifier": "0593820254"},
+                {"type": "ISBN_13", "identifier": "9780593820254"},
+            ],
+            "publisher": "Penguin",
+            "language": "en",
+            "printType": "BOOK",
+            "pageCount": 810,
+        }
+    }
+    google_parsed = _parse_google_selected_values(google_raw)
+    assert google_parsed["work.description"] == "Google desc"
+    assert google_parsed["edition.isbn13"] == "9780593820254"
+    assert google_parsed["edition.total_pages"] == 810
+
+
+def test_selected_values_from_bundles() -> None:
+    ol_bundle = OpenLibraryWorkBundle(
+        work_key="/works/OL1W",
+        title="Title",
+        description="Desc",
+        first_publish_year=2024,
+        cover_url="https://covers.openlibrary.org/b/id/1-L.jpg",
+        authors=[],
+        edition={
+            "publisher": "Ace",
+            "publish_date_iso": "2025-09-23",
+            "isbn10": "111",
+            "isbn13": "222",
+            "language": "eng",
+            "format": "Hardcover",
+            "total_pages": None,
+            "total_audio_minutes": None,
+        },
+        raw_work={},
+        raw_edition={"number_of_pages": 880, "duration": "10:37:00"},
+    )
+    ol_values = _selected_values_from_openlibrary_bundle(bundle=ol_bundle)
+    assert ol_values["edition.total_pages"] == 880
+    assert ol_values["edition.total_audio_minutes"] == "10:37:00"
+
+    gb_bundle = GoogleBooksWorkBundle(
+        volume_id="id",
+        title="Title",
+        description="Desc",
+        first_publish_year=2025,
+        cover_url="https://books.google.com/cover.jpg",
+        authors=["Matt Dinniman"],
+        edition={
+            "publisher": "Penguin",
+            "publish_date_iso": "2025-02-11",
+            "isbn10": "0593820254",
+            "isbn13": "9780593820254",
+            "language": "en",
+            "format": "BOOK",
+            "total_pages": 810,
+            "total_audio_minutes": None,
+        },
+        raw_volume={},
+        attribution_url=None,
+    )
+    gb_values = _selected_values_from_google_bundle(bundle=gb_bundle)
+    assert gb_values["edition.publisher"] == "Penguin"
+    assert gb_values["edition.total_pages"] == 810
+
+
+def test_resolve_openlibrary_work_key_for_source_and_upsert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_id = uuid.uuid4()
+    session = _FakeSession(scalar_values=[{"works": [{"key": "/works/OL41914127W"}]}])
+    assert (
+        _resolve_openlibrary_work_key_for_source(
+            session=cast(Any, session),
+            work_id=work_id,
+            source_id="/books/OL60639135M",
+        )
+        == "/works/OL41914127W"
+    )
+    monkeypatch.setattr(
+        "app.routers.works._openlibrary_work_key_for_work",
+        lambda *_args, **_kwargs: "/works/FALLBACK",
+    )
+    assert (
+        _resolve_openlibrary_work_key_for_source(
+            session=cast(Any, _FakeSession(scalar_values=[None])),
+            work_id=work_id,
+            source_id="unknown",
+        )
+        == "/works/FALLBACK"
+    )
+
+    add_session = _FakeSession(scalar_values=[None])
+    _upsert_source_record(
+        cast(Any, add_session),
+        provider="openlibrary",
+        entity_type="edition",
+        provider_id="/books/OL1M",
+        raw={"k": "v"},
+    )
+    assert len(add_session.added) == 1
+
+    existing = SimpleNamespace(raw={})
+    update_session = _FakeSession(scalar_values=[existing])
+    _upsert_source_record(
+        cast(Any, update_session),
+        provider="openlibrary",
+        entity_type="edition",
+        provider_id="/books/OL1M",
+        raw={"fresh": True},
+    )
+    assert existing.raw == {"fresh": True}
+
+
+def test_resolve_openlibrary_work_key_for_source_returns_work_key_input() -> None:
+    session = _FakeSession(scalar_values=[])
+    assert (
+        _resolve_openlibrary_work_key_for_source(
+            session=cast(Any, session),
+            work_id=uuid.uuid4(),
+            source_id="/works/OL41914127W",
+        )
+        == "/works/OL41914127W"
+    )
+
+
+@pytest.mark.anyio
+async def test_collect_google_source_tiles_filters_and_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_id = uuid.uuid4()
+    auth = AuthContext(claims={}, client_id=None, user_id=uuid.uuid4())
+    session = _FakeSession(
+        scalar_values=["mappedVolumeId"],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    monkeypatch.setattr(
+        "app.routers.works.get_or_create_profile",
+        lambda *_args, **_kwargs: SimpleNamespace(enable_google_books=True),
+    )
+    monkeypatch.setattr(
+        "app.routers.works._first_author_for_lookup",
+        lambda *_args, **_kwargs: "Matt Dinniman",
+    )
+
+    async def _fake_search_books(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(volume_id="mappedVolumeId"),
+                SimpleNamespace(volume_id="goodACAAJ"),
+                SimpleNamespace(volume_id="otherQBAJ"),
+                SimpleNamespace(volume_id="badMatch"),
+            ]
+        )
+
+    async def _fake_fetch_work_bundle(*, volume_id: str) -> GoogleBooksWorkBundle:
+        if volume_id == "badMatch":
+            return GoogleBooksWorkBundle(
+                volume_id=volume_id,
+                title="Unrelated Book",
+                description=None,
+                first_publish_year=None,
+                cover_url=None,
+                authors=["Someone Else"],
+                edition={},
+                raw_volume={},
+                attribution_url=None,
+            )
+        if volume_id == "otherQBAJ":
+            raise RuntimeError("skip")
+        return GoogleBooksWorkBundle(
+            volume_id=volume_id,
+            title="This Inevitable Ruin",
+            description=None,
+            first_publish_year=2025,
+            cover_url="https://books.google.com/cover.jpg",
+            authors=["Matt Dinniman"],
+            edition={
+                "publisher": "Penguin",
+                "publish_date": "2025-02-11",
+                "language": "en",
+                "isbn13": "9780593820254",
+            },
+            raw_volume={},
+            attribution_url=None,
+        )
+
+    google_books = SimpleNamespace(
+        search_books=_fake_search_books,
+        fetch_work_bundle=_fake_fetch_work_bundle,
+    )
+
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
+
+    tiles = await _collect_google_source_tiles(
+        work_id=work_id,
+        auth=auth,
+        session=cast(Any, session),
+        google_books=cast(Any, google_books),
+        settings=settings,
+        limit=10,
+        language="en",
+    )
+
+    assert len(tiles) <= 2
+    assert tiles[0]["provider"] == "googlebooks"
+    assert all(tile["source_id"] != "badMatch" for tile in tiles)
+
+
+@pytest.mark.anyio
+async def test_build_cover_metadata_compare_payload_openlibrary_refreshes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeSession(
+        scalar_values=[
+            None,
+            None,
+        ]
+    )
+    monkeypatch.setattr(
+        "app.routers.works._current_field_values_for_compare",
+        lambda **_kwargs: {"work.description": None, "edition.publisher": None},
+    )
+    monkeypatch.setattr(
+        "app.routers.works._resolve_openlibrary_work_key_for_source",
+        lambda **_kwargs: "/works/OL41914127W",
+    )
+
+    async def _fake_fetch_work_bundle(*, work_key: str, edition_key: str | None) -> Any:
+        assert work_key == "/works/OL41914127W"
+        assert edition_key == "/books/OL60639135M"
+        return OpenLibraryWorkBundle(
+            work_key=work_key,
+            title="This Inevitable Ruin",
+            description="Selected description",
+            first_publish_year=2024,
+            cover_url="https://covers.openlibrary.org/b/id/1-L.jpg",
+            authors=[{"name": "Matt Dinniman"}],
+            edition={"publisher": "Ace"},
+            raw_work={"description": {"value": "Selected description"}},
+            raw_edition={
+                "covers": [15142977],
+                "publishers": ["Ace"],
+                "publish_date": "2025-09-23",
+                "works": [{"key": "/works/OL41914127W"}],
+            },
+        )
+
+    payload = await _build_cover_metadata_compare_payload(
+        session=cast(Any, session),
+        auth=AuthContext(claims={}, client_id=None, user_id=uuid.uuid4()),
+        work_id=uuid.uuid4(),
+        open_library=cast(
+            Any, SimpleNamespace(fetch_work_bundle=_fake_fetch_work_bundle)
+        ),
+        google_books=cast(Any, SimpleNamespace()),
+        provider="openlibrary",
+        source_id="/books/OL60639135M",
+        edition_id=None,
+    )
+
+    payload_obj = cast(dict[str, Any], payload)
+    assert (
+        cast(dict[str, Any], payload_obj["selected_source"])["provider"]
+        == "openlibrary"
+    )
+    assert session.commit_calls == 1
+    fields = cast(list[dict[str, Any]], payload_obj["fields"])
+    assert any(field["provider_id"] == "/books/OL60639135M" for field in fields)
+
+
+@pytest.mark.anyio
+async def test_build_cover_metadata_compare_payload_google_fetches_and_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeSession(scalar_values=[None])
+    monkeypatch.setattr(
+        "app.routers.works._current_field_values_for_compare",
+        lambda **_kwargs: {"work.description": None, "edition.publisher": None},
+    )
+
+    async def _fake_fetch_work_bundle(*, volume_id: str) -> Any:
+        assert volume_id == "zwT-0AEACAAJ"
+        return GoogleBooksWorkBundle(
+            volume_id=volume_id,
+            title="This Inevitable Ruin",
+            description="Google description",
+            first_publish_year=2025,
+            cover_url="https://books.google.com/cover.jpg",
+            authors=["Matt Dinniman"],
+            edition={"publisher": "Penguin"},
+            raw_volume={
+                "volumeInfo": {
+                    "description": "Google description",
+                    "publisher": "Penguin",
+                    "publishedDate": "2025-02-11",
+                }
+            },
+            attribution_url=None,
+        )
+
+    payload = await _build_cover_metadata_compare_payload(
+        session=cast(Any, session),
+        auth=AuthContext(claims={}, client_id=None, user_id=uuid.uuid4()),
+        work_id=uuid.uuid4(),
+        open_library=cast(Any, SimpleNamespace()),
+        google_books=cast(
+            Any, SimpleNamespace(fetch_work_bundle=_fake_fetch_work_bundle)
+        ),
+        provider="googlebooks",
+        source_id="zwT-0AEACAAJ",
+        edition_id=None,
+    )
+
+    payload_obj = cast(dict[str, Any], payload)
+    assert (
+        cast(dict[str, Any], payload_obj["selected_source"])["provider"]
+        == "googlebooks"
+    )
+    assert session.commit_calls == 1
+    fields = cast(list[dict[str, Any]], payload_obj["fields"])
+    assert all(field["provider"] == "googlebooks" for field in fields)
+
+
+def test_list_cover_metadata_sources_uses_mapped_authors_when_missing(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL41914127W"],
+        execute_rows=[[]],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_fetch_work_bundle(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(authors=[{"name": "Matt Dinniman"}])
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL60639135M",
+                title="This Inevitable Ruin",
+                publisher="Ace",
+                publish_date="2025-09-23",
+                language="eng",
+                isbn10=None,
+                isbn13="9798217190041",
+                cover_url="https://covers.openlibrary.org/b/id/1-M.jpg",
+            )
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_bundle=_fake_fetch_work_bundle,
+        fetch_work_editions=_fake_fetch_work_editions,
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources")
+    assert response.status_code == 200
+    authors = response.json()["data"]["items"][0]["authors"]
+    assert authors == ["Matt Dinniman"]
+
+
+def test_list_cover_metadata_sources_search_fallback_dedupes(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[None],
+        execute_rows=[[]],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_search_books(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    work_key="/works/OL1W",
+                    title="This Inevitable Ruin",
+                    author_names=["Matt Dinniman"],
+                ),
+                SimpleNamespace(
+                    work_key="/works/OL1W", title="Duplicate", author_names=[]
+                ),
+                SimpleNamespace(work_key=" ", title="Blank", author_names=[]),
+                SimpleNamespace(
+                    work_key="/works/OL2W",
+                    title="This Inevitable Ruin 2",
+                    author_names=["Matt Dinniman"],
+                ),
+            ]
+        )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="Edition 1",
+                publisher="Ace",
+                publish_date="2025-09-23",
+                language="eng",
+                isbn10=None,
+                isbn13="9798217190041",
+                cover_url="https://covers.openlibrary.org/b/id/1-M.jpg",
+            ),
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="Edition 1 duplicate",
+                publisher=None,
+                publish_date=None,
+                language=None,
+                isbn10=None,
+                isbn13=None,
+                cover_url=None,
+            ),
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        search_books=_fake_search_books,
+        fetch_work_editions=_fake_fetch_work_editions,
+    )
+    app.dependency_overrides[get_google_books_client] = lambda: SimpleNamespace()
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources?limit=2")
+    assert response.status_code == 200
+    items = response.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["source_id"] == "/books/OL1M"
+
+
+def test_list_cover_metadata_sources_ignores_mapped_author_fetch_failure(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL41914127W"],
+        execute_rows=[[]],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _boom_fetch_work_bundle(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return []
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_bundle=_boom_fetch_work_bundle,
+        fetch_work_editions=_fake_fetch_work_editions,
+    )
+    app.dependency_overrides[get_google_books_client] = lambda: SimpleNamespace()
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources")
+    assert response.status_code == 200
+    assert response.json()["data"]["items"] == []
+
+
+@pytest.mark.anyio
+async def test_build_cover_metadata_compare_payload_google_uses_cached_raw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cached_raw = {
+        "volumeInfo": {
+            "description": "Cached description",
+            "language": "en",
+            "publishedDate": "2025-02-11",
+        }
+    }
+    session = _FakeSession(scalar_values=[cached_raw])
+    monkeypatch.setattr(
+        "app.routers.works._current_field_values_for_compare",
+        lambda **_kwargs: {"work.description": None},
+    )
+
+    payload = await _build_cover_metadata_compare_payload(
+        session=cast(Any, session),
+        auth=AuthContext(claims={}, client_id=None, user_id=uuid.uuid4()),
+        work_id=uuid.uuid4(),
+        open_library=cast(Any, SimpleNamespace()),
+        google_books=cast(
+            Any,
+            SimpleNamespace(
+                fetch_work_bundle=lambda **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("should not fetch")
+                )
+            ),
+        ),
+        provider="googlebooks",
+        source_id="cached-vol",
+        edition_id=None,
+    )
+    payload_obj = cast(dict[str, Any], payload)
+    assert (
+        cast(dict[str, Any], payload_obj["selected_source"])["provider"]
+        == "googlebooks"
+    )
+    assert session.commit_calls == 0
+
+
+def test_openlibrary_parsers_cover_more_branches() -> None:
+    assert _parse_openlibrary_description({"description": {"value": " v "}}) == "v"
+    assert _parse_openlibrary_description({"description": {"value": "   "}}) is None
+    assert _parse_openlibrary_first_publish_year({"first_publish_year": 0}) is None
+    assert (
+        _parse_openlibrary_first_publish_year({"first_publish_date": "unknown"}) is None
+    )
+    assert (
+        _parse_openlibrary_cover_url({"covers": [1]}, {"covers": ["bad", 2]})
+        == "https://covers.openlibrary.org/b/id/2-L.jpg"
+    )
+    assert (
+        _parse_openlibrary_cover_url({"covers": ["bad"]}, {"covers": ["bad"]}) is None
+    )
+    assert not _openlibrary_edition_raw_has_compare_fields({"covers": [1]})
+
+
+@pytest.mark.anyio
+async def test_build_cover_metadata_compare_payload_rejects_blank_source_id() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await _build_cover_metadata_compare_payload(
+            session=cast(Any, _FakeSession(scalar_values=[])),
+            auth=AuthContext(claims={}, client_id=None, user_id=uuid.uuid4()),
+            work_id=uuid.uuid4(),
+            open_library=cast(Any, SimpleNamespace()),
+            google_books=cast(Any, SimpleNamespace()),
+            provider="openlibrary",
+            source_id="   ",
+            edition_id=None,
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_list_cover_metadata_sources_fills_missing_fields_from_source_records(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL41914127W"],
+        execute_rows=[
+            [],
+            [
+                (
+                    "openlibrary",
+                    "/books/OL1M",
+                    {
+                        "title": "Recovered title",
+                        "authors": ["Recovered Author"],
+                        "publishers": ["Recovered Publisher"],
+                        "publish_date": "2025-09-23",
+                        "languages": [{"key": "/languages/eng"}],
+                        "covers": [15142977],
+                        "isbn_13": ["9798217190041"],
+                    },
+                )
+            ],
+        ],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL1M",
+                title=None,
+                publisher=None,
+                publish_date=None,
+                language=None,
+                isbn10=None,
+                isbn13=None,
+                cover_url=None,
+            )
+        ]
+
+    async def _fake_google_tiles(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {"provider": "", "source_id": "bad"},
+            {"provider": "googlebooks", "source_id": ""},
+            {"provider": "openlibrary", "source_id": "/books/OL1M"},
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions,
+        fetch_work_bundle=lambda **_kwargs: SimpleNamespace(authors=[]),
+    )
+    monkeypatch.setattr(
+        "app.routers.works._collect_google_source_tiles", _fake_google_tiles
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources?limit=1")
+    assert response.status_code == 200
+    item = response.json()["data"]["items"][0]
+    assert item["title"] == "Mapped Open Library work"
+    assert item["publisher"] == "Recovered Publisher"
+    assert item["language"] == "eng"
+    assert item["identifier"] == "/books/OL1M"
+    assert item["cover_url"].endswith("-M.jpg")
+
+
+def test_helper_extractors_handle_invalid_inputs() -> None:
+    assert _extract_source_title(None) is None
+    assert _extract_source_authors(None) == []
+    assert _extract_source_cover(None) is None
+    assert _extract_source_language(None) is None
+    assert _extract_source_publisher(None) is None
+    assert _extract_source_publish_date(None) is None
+    assert _extract_source_identifier(None, "fallback") == "fallback"
+    assert _first_string("not-a-list") is None
+    assert (
+        _extract_source_publisher({"volumeInfo": {"publisher": "Penguin"}}) == "Penguin"
+    )
+    assert (
+        _extract_source_identifier(
+            {
+                "volumeInfo": {
+                    "industryIdentifiers": [
+                        {},
+                        {"type": "ISBN_13"},
+                        {"identifier": "9780593820254"},
+                    ]
+                }
+            },
+            "fallback",
+        )
+        == "9780593820254"
+    )
+
+
+def test_title_and_author_match_score_branches() -> None:
+    assert _title_match_score("a b c d", "a b c x") == 60
+    assert _title_match_score("a b c", "a b c x") == 80
+    assert _title_match_score("a b c", "x a b c y") == 80
+    assert _title_match_score("a", "z") == 0
+
+    assert _author_match_score(None, ["a"]) == 0
+    assert _author_match_score("  ", ["a"]) == 0
+    assert _author_match_score("Matt Dinniman", ["Matt Dinniman"]) == 30
+    assert _author_match_score("A B C", ["A B X"]) == 25
+    assert _author_match_score("A B", ["A X"]) == 15
+    assert _author_match_score("A B", ["Z Y"]) == 0
+    assert _author_match_score("", ["A"]) == 0
+    assert _author_match_score("!!!", ["A"]) == 0
+    assert _author_match_score("Matt Dinniman", ["!!!", "Matt Dinniman"]) == 30
+    assert _normalize_text_tokens(None) == []
+    assert _title_match_score("", "This Inevitable Ruin") == 0
+
+
+def test_extract_source_helpers_cover_fallback_paths() -> None:
+    assert _extract_source_title({"volumeInfo": {"title": "  "}}) is None
+    assert _extract_source_authors({"volumeInfo": {"authors": "bad"}}) == []
+    assert (
+        _extract_source_cover(
+            {
+                "covers": [0, -1, "x"],
+                "volumeInfo": {
+                    "imageLinks": {"thumbnail": " ", "smallThumbnail": "http://img"}
+                },
+            }
+        )
+        == "https://img"
+    )
+    assert _extract_source_cover({"covers": [0, -1]}) is None
+    assert _extract_source_language({"languages": [{}, " eng "]}) == "eng"
+    assert (
+        _extract_source_language(
+            {"languages": [{"key": "/not-language"}], "volumeInfo": {"language": "fr"}}
+        )
+        == "fr"
+    )
+    assert (
+        _extract_source_identifier(
+            {"volumeInfo": {"industryIdentifiers": [None, {"identifier": " "}, {}]}},
+            "fallback",
+        )
+        == "fallback"
+    )
+    assert _extract_source_identifier({"isbn_10": ["123"]}, "fallback") == "123"
+    assert (
+        _extract_source_publisher(
+            {"publishers": [" "], "volumeInfo": {"publisher": " "}}
+        )
+        is None
+    )
+    assert (
+        _extract_source_publish_date(
+            {"publish_date": " ", "volumeInfo": {"publishedDate": " "}}
+        )
+        is None
+    )
+
+
+@pytest.mark.anyio
+async def test_collect_google_source_tiles_handles_missing_work_and_blank_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = AuthContext(claims={}, client_id=None, user_id=uuid.uuid4())
+    monkeypatch.setattr(
+        "app.routers.works.get_or_create_profile",
+        lambda *_args, **_kwargs: SimpleNamespace(enable_google_books=True),
+    )
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
+    google_books = cast(
+        Any,
+        SimpleNamespace(
+            search_books=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("should not search")
+            ),
+            fetch_work_bundle=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("should not fetch")
+            ),
+        ),
+    )
+    missing_work_tiles = await _collect_google_source_tiles(
+        work_id=uuid.uuid4(),
+        auth=auth,
+        session=cast(Any, _FakeSession(scalar_values=[], work=None)),
+        google_books=google_books,
+        settings=settings,
+        limit=5,
+        language=None,
+    )
+    assert missing_work_tiles == []
+
+    blank_title_tiles = await _collect_google_source_tiles(
+        work_id=uuid.uuid4(),
+        auth=auth,
+        session=cast(
+            Any,
+            _FakeSession(
+                scalar_values=[],
+                work=SimpleNamespace(title="   "),
+            ),
+        ),
+        google_books=google_books,
+        settings=settings,
+        limit=5,
+        language=None,
+    )
+    assert blank_title_tiles == []
+
+
+@pytest.mark.anyio
+async def test_collect_google_source_tiles_breaks_on_high_volume_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_id = uuid.uuid4()
+    auth = AuthContext(claims={}, client_id=None, user_id=uuid.uuid4())
+    session = _FakeSession(
+        scalar_values=["mappedVolumeId"],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+    search_calls = {"count": 0}
+
+    monkeypatch.setattr(
+        "app.routers.works.get_or_create_profile",
+        lambda *_args, **_kwargs: SimpleNamespace(enable_google_books=True),
+    )
+    monkeypatch.setattr(
+        "app.routers.works._first_author_for_lookup",
+        lambda *_args, **_kwargs: "",
+    )
+
+    async def _fake_search_books(*_args: Any, **_kwargs: Any) -> Any:
+        search_calls["count"] += 1
+        return SimpleNamespace(
+            items=[SimpleNamespace(volume_id=f"id-{idx}") for idx in range(25)]
+        )
+
+    async def _fake_fetch_work_bundle(*, volume_id: str) -> GoogleBooksWorkBundle:
+        return GoogleBooksWorkBundle(
+            volume_id=volume_id,
+            title="This Inevitable Ruin",
+            description=None,
+            first_publish_year=None,
+            cover_url=None,
+            authors=["Matt Dinniman"],
+            edition={},
+            raw_volume={},
+            attribution_url=None,
+        )
+
+    google_books = SimpleNamespace(
+        search_books=_fake_search_books,
+        fetch_work_bundle=_fake_fetch_work_bundle,
+    )
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_jwt_audience="authenticated",
+        supabase_jwt_secret=None,
+        supabase_jwks_cache_ttl_seconds=60,
+        supabase_service_role_key="service-role",
+        supabase_storage_covers_bucket="covers",
+        public_highlight_max_chars=280,
+        api_version="0.1.0",
+    )
+
+    tiles = await _collect_google_source_tiles(
+        work_id=work_id,
+        auth=auth,
+        session=cast(Any, session),
+        google_books=cast(Any, google_books),
+        settings=settings,
+        limit=10,
+        language=None,
+    )
+    assert search_calls["count"] == 1
+    assert len(tiles) <= 2
+
+
+def test_resolve_edition_target_for_compare_prefers_explicit_edition() -> None:
+    edition_id = uuid.uuid4()
+    work_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    edition_obj = SimpleNamespace(id=edition_id)
+    session = _FakeSession(scalar_values=[edition_obj])
+    result = _resolve_edition_target_for_compare(
+        session=cast(Any, session),
+        work_id=work_id,
+        user_id=user_id,
+        edition_id=edition_id,
+    )
+    assert result is not None
+
+
+def test_current_field_values_for_compare_raises_when_work_missing() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _current_field_values_for_compare(
+            session=cast(Any, _FakeSession(scalar_values=[], work=None)),
+            work_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            edition_id=None,
+        )
+    assert exc_info.value.status_code == 404
+
+
+def test_resolve_edition_target_for_compare_uses_preferred_and_fallback() -> None:
+    work_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    preferred = uuid.uuid4()
+    preferred_obj = SimpleNamespace(id=preferred)
+    fallback_obj = SimpleNamespace(id=uuid.uuid4())
+    session = _FakeSession(
+        scalar_values=[
+            preferred,
+            preferred_obj,
+        ]
+    )
+    resolved = _resolve_edition_target_for_compare(
+        session=cast(Any, session),
+        work_id=work_id,
+        user_id=user_id,
+        edition_id=None,
+    )
+    assert resolved is not None
+
+    session2 = _FakeSession(scalar_values=[None, fallback_obj])
+    resolved2 = _resolve_edition_target_for_compare(
+        session=cast(Any, session2),
+        work_id=work_id,
+        user_id=user_id,
+        edition_id=None,
+    )
+    assert resolved2 is not None
+
+
+def test_resolve_edition_target_for_compare_falls_back_when_preferred_missing() -> None:
+    work_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    fallback_obj = SimpleNamespace(id=uuid.uuid4())
+    session = _FakeSession(
+        scalar_values=[
+            uuid.uuid4(),
+            None,
+            fallback_obj,
+        ]
+    )
+    resolved = _resolve_edition_target_for_compare(
+        session=cast(Any, session),
+        work_id=work_id,
+        user_id=user_id,
+        edition_id=None,
+    )
+    assert resolved is not None
+    assert resolved.id == fallback_obj.id
+
+
+@pytest.mark.anyio
+async def test_compare_cover_metadata_source_returns_404_when_work_key_missing(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_session = _FakeSession(
+        scalar_values=[],
+        work=SimpleNamespace(
+            title="Work",
+            description=None,
+            default_cover_url=None,
+            first_publish_year=None,
+        ),
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    monkeypatch.setattr(
+        "app.routers.works._resolve_openlibrary_work_key_for_source",
+        lambda **_kwargs: None,
+    )
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{uuid.uuid4()}/cover-metadata/compare",
+        params={"provider": "openlibrary", "source_id": "/books/OL1M"},
+    )
+    assert response.status_code == 404
+
+
+def test_list_cover_metadata_sources_handles_empty_lookup_title_without_search(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[None],
+        execute_rows=[[]],
+        work=SimpleNamespace(title=" "),
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        raise AssertionError("should not fetch editions without candidate works")
+
+    async def _fake_search_books(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("should not search when lookup title is blank")
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions,
+        search_books=_fake_search_books,
+    )
+
+    async def _fake_google_tiles(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(
+        "app.routers.works._collect_google_source_tiles", _fake_google_tiles
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources")
+    assert response.status_code == 200
+    assert response.json()["data"]["items"] == []
+
+
+def test_list_cover_metadata_sources_hydrates_google_missing_fields(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL41914127W"],
+        execute_rows=[
+            [],
+            [
+                (
+                    "googlebooks",
+                    "vol-1",
+                    {
+                        "volumeInfo": {
+                            "title": "Recovered Google Title",
+                            "authors": ["Matt Dinniman"],
+                            "publisher": "Penguin",
+                            "publishedDate": "2025-02-11",
+                            "language": "en",
+                            "imageLinks": {
+                                "smallThumbnail": "http://books.google.com/c.jpg"
+                            },
+                            "industryIdentifiers": [{"identifier": "9780593820254"}],
+                        }
+                    },
+                )
+            ],
+        ],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return []
+
+    async def _fake_google_tiles(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "provider": "googlebooks",
+                "source_id": "vol-1",
+                "title": None,
+                "authors": None,
+                "publisher": None,
+                "publish_date": None,
+                "language": None,
+                "identifier": " ",
+                "cover_url": None,
+                "source_label": "Google Books",
+            }
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions,
+        fetch_work_bundle=lambda **_kwargs: SimpleNamespace(authors=[]),
+    )
+    monkeypatch.setattr(
+        "app.routers.works._collect_google_source_tiles",
+        _fake_google_tiles,
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources?limit=1")
+    assert response.status_code == 200
+    item = response.json()["data"]["items"][0]
+    assert item["title"] == "Recovered Google Title"
+    assert item["authors"] == ["Matt Dinniman"]
+    assert item["identifier"] == "9780593820254"
+    assert item["cover_url"] == "https://books.google.com/c.jpg"
+
+
+def test_list_openlibrary_editions_dedupes_duplicate_edition_keys(app: FastAPI) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL41914127W"],
+        execute_rows=[[]],
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="Edition 1",
+                publisher="Ace",
+                publish_date="2025-01-01",
+                language="eng",
+                isbn10=None,
+                isbn13=None,
+                cover_url=None,
+            ),
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="Edition 1 dup",
+                publisher="Ace",
+                publish_date="2025-01-01",
+                language="eng",
+                isbn10=None,
+                isbn13=None,
+                cover_url=None,
+            ),
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions
+    )
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/provider-editions/openlibrary")
+    assert response.status_code == 200
+    assert len(response.json()["data"]["items"]) == 1
+
+
+def test_import_openlibrary_provider_edition_set_preferred_with_missing_item(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(scalar_values=["/works/OL41914127W", None, None, None])
+
+    async def _fake_fetch_work_bundle(*, work_key: str, edition_key: str) -> Any:
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        "app.routers.works.import_openlibrary_bundle",
+        lambda *_args, **_kwargs: {"edition": {"id": str(uuid.uuid4())}},
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_bundle=_fake_fetch_work_bundle
+    )
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary/import",
+        json={"edition_key": "/books/OL60639135M", "set_preferred": True},
+    )
+    assert response.status_code == 200
+    assert fake_session.commit_calls == 0
+
+
+@pytest.mark.anyio
+async def test_build_cover_metadata_compare_payload_openlibrary_without_raw_edition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeSession(scalar_values=[None, None])
+    monkeypatch.setattr(
+        "app.routers.works._current_field_values_for_compare",
+        lambda **_kwargs: {"work.description": None},
+    )
+    monkeypatch.setattr(
+        "app.routers.works._resolve_openlibrary_work_key_for_source",
+        lambda **_kwargs: "/works/OL1W",
+    )
+
+    async def _fake_fetch_work_bundle(*, work_key: str, edition_key: str | None) -> Any:
+        return OpenLibraryWorkBundle(
+            work_key=work_key,
+            title="Title",
+            description="Desc",
+            first_publish_year=2024,
+            cover_url=None,
+            authors=[],
+            edition=None,
+            raw_work={"description": "Desc"},
+            raw_edition=None,
+        )
+
+    payload = await _build_cover_metadata_compare_payload(
+        session=cast(Any, session),
+        auth=AuthContext(claims={}, client_id=None, user_id=uuid.uuid4()),
+        work_id=uuid.uuid4(),
+        open_library=cast(
+            Any, SimpleNamespace(fetch_work_bundle=_fake_fetch_work_bundle)
+        ),
+        google_books=cast(Any, SimpleNamespace()),
+        provider="openlibrary",
+        source_id="/books/OL1M",
+        edition_id=None,
+    )
+    assert cast(dict[str, Any], payload["selected_source"])["provider"] == "openlibrary"
+
+
+def test_resolve_openlibrary_work_key_for_source_handles_invalid_works_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeSession(
+        scalar_values=[
+            {"works": ["bad", {"key": 123}, {"key": "/works/OLGOOD"}]},
+            {"works": ["bad-only"]},
+        ]
+    )
+    assert (
+        _resolve_openlibrary_work_key_for_source(
+            session=cast(Any, session),
+            work_id=uuid.uuid4(),
+            source_id="/books/OL1M",
+        )
+        == "/works/OLGOOD"
+    )
+    monkeypatch.setattr(
+        "app.routers.works._openlibrary_work_key_for_work",
+        lambda *_args, **_kwargs: "/works/FALLBACK",
+    )
+    assert (
+        _resolve_openlibrary_work_key_for_source(
+            session=cast(Any, session),
+            work_id=uuid.uuid4(),
+            source_id="/books/OL2M",
+        )
+        == "/works/FALLBACK"
+    )
+
+
+def test_upsert_source_record_ignores_non_dict_raw() -> None:
+    session = _FakeSession(scalar_values=[None])
+    _upsert_source_record(
+        cast(Any, session),
+        provider="openlibrary",
+        entity_type="edition",
+        provider_id="/books/OL1M",
+        raw="not-dict",
+    )
+    assert session.added == []
+
+
+def test_list_enrichment_candidates_returns_400_on_value_error(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _invalid(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise ValueError("invalid")
+
+    monkeypatch.setattr("app.routers.works.get_enrichment_candidates", _invalid)
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{uuid.uuid4()}/enrichment/candidates")
+    assert response.status_code == 400
+
+
+def test_apply_enrichment_returns_404_and_502(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _missing(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise LookupError("missing")
+
+    monkeypatch.setattr("app.routers.works.apply_enrichment_selections", _missing)
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{uuid.uuid4()}/enrichment/apply",
+        json={"selections": []},
+    )
+    assert response.status_code == 404
+
+    async def _boom(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise httpx.ConnectError("down")
+
+    monkeypatch.setattr("app.routers.works.apply_enrichment_selections", _boom)
+    response = client.post(
+        f"/api/v1/works/{uuid.uuid4()}/enrichment/apply",
+        json={"selections": []},
+    )
+    assert response.status_code == 502
+
+
+def test_parse_google_selected_values_edge_branches() -> None:
+    assert _parse_google_selected_values(None) == {}
+    assert _parse_google_selected_values({"volumeInfo": []})["work.cover_url"] is None
+    no_year = _parse_google_selected_values(
+        {
+            "volumeInfo": {
+                "publishedDate": "not-a-date",
+                "imageLinks": {"thumbnail": "   ", "smallThumbnail": "http://x"},
+                "industryIdentifiers": [{"type": "OTHER", "identifier": "x"}],
+            }
+        }
+    )
+    assert no_year["work.first_publish_year"] is None
+    assert no_year["work.cover_url"] == "https://x"
+
+
+def test_parse_openlibrary_description_and_year_edge_branches() -> None:
+    assert _parse_openlibrary_description({"description": {"value": "   "}}) is None
+    assert _parse_openlibrary_description({"description": 123}) is None
+    assert _parse_openlibrary_first_publish_year({"first_publish_year": 10001}) is None
+    assert _parse_openlibrary_first_publish_year({"first_publish_date": "2025"}) == 2025
+
+
+def test_extract_source_authors_non_string_entries() -> None:
+    assert _extract_source_authors({"author_name": ["a", 1, None]}) == ["a"]
+    assert _extract_source_authors({"authors": ["b", None]}) == ["b"]
+
+
+def test_list_cover_metadata_sources_prefetch_skips_blank_provider_after_strip(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL1W"],
+        execute_rows=[[]],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return []
+
+    async def _fake_google_tiles(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [{"provider": " ", "source_id": "x", "title": "x"}]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions,
+        fetch_work_bundle=lambda **_kwargs: SimpleNamespace(authors=[]),
+    )
+    monkeypatch.setattr(
+        "app.routers.works._collect_google_source_tiles", _fake_google_tiles
+    )
+    monkeypatch.setattr(
+        "app.routers.works._build_cover_metadata_compare_payload",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("should not prefetch")),
+    )
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{work_id}/cover-metadata/sources?include_prefetch_compare=true"
+    )
+    assert response.status_code == 200

--- a/apps/api/tests/test_works_router.py
+++ b/apps/api/tests/test_works_router.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Generator
+from types import SimpleNamespace
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -11,7 +13,13 @@ from fastapi.testclient import TestClient
 from app.core.config import Settings, get_settings
 from app.core.security import AuthContext, require_auth_context
 from app.db.session import get_db_session
-from app.routers.works import get_google_books_client, get_open_library_client
+from app.routers.works import (
+    _ensure_openlibrary_work_mapping,
+    _first_author_for_lookup,
+    _work_title_for_lookup,
+    get_google_books_client,
+    get_open_library_client,
+)
 from app.routers.works import router as works_router
 from app.services.storage import StorageNotConfiguredError
 
@@ -485,3 +493,605 @@ def test_apply_enrichment_returns_400(
         },
     )
     assert response.status_code == 400
+
+
+def test_list_cover_metadata_sources_returns_mixed_provider_tiles(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[],
+        execute_rows=[[("openlibrary", "/books/OL1M", {"title": "Source title"})]],
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="OL Edition",
+                publisher="Ace",
+                publish_date="2025-09-23",
+                language="eng",
+                isbn10=None,
+                isbn13="9780000000001",
+                cover_url="https://covers.openlibrary.org/b/id/1-M.jpg",
+            )
+        ]
+
+    async def _fake_google_tiles(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "provider": "googlebooks",
+                "source_id": "vol-1",
+                "title": "Google Edition",
+                "authors": ["Matt Dinniman"],
+                "publisher": "Ace",
+                "publish_date": "2025-09-23",
+                "language": "eng",
+                "identifier": "9780000000002",
+                "cover_url": "https://books.google.com/cover.jpg",
+                "source_label": "Google Books",
+            }
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions
+    )
+    monkeypatch.setattr(
+        "app.routers.works._openlibrary_work_key_for_work",
+        lambda *_args, **_kwargs: "/works/OL1W",
+    )
+    monkeypatch.setattr(
+        "app.routers.works._collect_google_source_tiles",
+        _fake_google_tiles,
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/cover-metadata/sources")
+
+    assert response.status_code == 200
+    items = response.json()["data"]["items"]
+    assert any(item["provider"] == "openlibrary" for item in items)
+    assert any(item["provider"] == "googlebooks" for item in items)
+
+
+def test_list_cover_metadata_sources_includes_prefetch_compare_when_requested(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL1W"],
+        execute_rows=[[]],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="This Inevitable Ruin",
+                publisher="Ace",
+                publish_date="2025-09-23",
+                language="eng",
+                isbn10=None,
+                isbn13="9780000000001",
+                cover_url="https://covers.openlibrary.org/b/id/1-M.jpg",
+            )
+        ]
+
+    async def _fake_compare_payload(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "selected_source": {
+                "provider": "openlibrary",
+                "source_id": "/books/OL1M",
+                "source_label": "Open Library OL1M",
+                "edition_id": None,
+            },
+            "fields": [],
+        }
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions
+    )
+    monkeypatch.setattr(
+        "app.routers.works._build_cover_metadata_compare_payload",
+        _fake_compare_payload,
+    )
+
+    async def _fake_no_google(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(
+        "app.routers.works._collect_google_source_tiles",
+        _fake_no_google,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{work_id}/cover-metadata/sources",
+        params={"include_prefetch_compare": "true", "prefetch_limit": 3},
+    )
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["items"][0]["source_id"] == "/books/OL1M"
+    assert "openlibrary:/books/OL1M" in payload["prefetch_compare"]
+
+
+def test_compare_cover_metadata_source_returns_normalized_fields(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_session = _FakeSession(
+        scalar_values=[
+            None,
+            None,
+            {
+                "description": {"value": "Selected description"},
+                "covers": [1],
+                "first_publish_year": 2024,
+            },
+        ],
+        work=SimpleNamespace(
+            title="Work title",
+            description="Current description",
+            default_cover_url="https://example.com/current.jpg",
+            first_publish_year=2020,
+        ),
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    monkeypatch.setattr(
+        "app.routers.works._resolve_openlibrary_work_key_for_source",
+        lambda *_args, **_kwargs: "/works/OL1W",
+    )
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{uuid.uuid4()}/cover-metadata/compare",
+        params={"provider": "openlibrary", "source_id": "/works/OL1W"},
+    )
+    assert response.status_code == 200
+    field = response.json()["data"]["fields"][0]
+    assert field["field_key"] == "work.description"
+    assert field["field_label"] == "Description"
+    assert field["selected_available"] is True
+
+
+def test_compare_cover_metadata_source_rejects_invalid_provider(app: FastAPI) -> None:
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{uuid.uuid4()}/cover-metadata/compare",
+        params={"provider": "unsupported", "source_id": "abc"},
+    )
+    assert response.status_code == 400
+
+
+class _FakeResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def first(self) -> Any:
+        return self._rows[0] if self._rows else None
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        *,
+        scalar_values: list[Any],
+        execute_rows: list[list[Any]] | None = None,
+        work: Any = None,
+    ) -> None:
+        self._scalar_values = list(scalar_values)
+        self._execute_rows = list(execute_rows or [])
+        self._work = work
+        self.added: list[Any] = []
+        self.commit_calls = 0
+
+    def scalar(self, *_args: Any, **_kwargs: Any) -> Any:
+        if not self._scalar_values:
+            return None
+        return self._scalar_values.pop(0)
+
+    def execute(self, *_args: Any, **_kwargs: Any) -> _FakeResult:
+        if not self._execute_rows:
+            return _FakeResult([])
+        return _FakeResult(self._execute_rows.pop(0))
+
+    def get(self, *_args: Any, **_kwargs: Any) -> Any:
+        return self._work
+
+    def add(self, value: Any) -> None:
+        self.added.append(value)
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+
+
+def test_work_title_for_lookup_returns_none_for_missing_work() -> None:
+    session = _FakeSession(scalar_values=[], work=None)
+    assert _work_title_for_lookup(cast(Any, session), work_id=uuid.uuid4()) is None
+
+
+def test_first_author_for_lookup_returns_none_for_missing_or_invalid_row() -> None:
+    session_none = _FakeSession(scalar_values=[], execute_rows=[[]])
+    assert (
+        _first_author_for_lookup(cast(Any, session_none), work_id=uuid.uuid4()) is None
+    )
+
+    session_invalid = _FakeSession(scalar_values=[], execute_rows=[[(123,)]])
+    assert (
+        _first_author_for_lookup(cast(Any, session_invalid), work_id=uuid.uuid4())
+        is None
+    )
+
+
+def test_ensure_openlibrary_work_mapping_updates_existing_mapping() -> None:
+    work_id = uuid.uuid4()
+    existing_mapping = SimpleNamespace(provider_id="/works/OLD")
+    session = _FakeSession(
+        scalar_values=[existing_mapping, SimpleNamespace(entity_id=work_id)]
+    )
+
+    _ensure_openlibrary_work_mapping(
+        cast(Any, session), work_id=work_id, work_key="/works/OL41914127W"
+    )
+
+    assert existing_mapping.provider_id == "/works/OL41914127W"
+    assert session.added == []
+
+
+def test_list_openlibrary_provider_editions_falls_back_to_search(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[None],
+        execute_rows=[[("Matt Dinniman",)], []],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_search_books(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    work_key="/works/OL41914127W",
+                    title="This Inevitable Ruin",
+                    author_names=["Matt Dinniman"],
+                )
+            ]
+        )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL60639135M",
+                title="This Inevitable Ruin",
+                publisher="Ace",
+                publish_date="2025-09-23",
+                language="eng",
+                isbn10=None,
+                isbn13="9780594009041",
+                cover_url="https://covers.openlibrary.org/b/id/1-M.jpg",
+            )
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        search_books=_fake_search_books,
+        fetch_work_editions=_fake_fetch_work_editions,
+    )
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/provider-editions/openlibrary")
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["mapped_work_key"] is None
+    assert payload["items"][0]["work_key"] == "/works/OL41914127W"
+    assert payload["items"][0]["edition_key"] == "/books/OL60639135M"
+    assert payload["items"][0]["work_title"] == "This Inevitable Ruin"
+
+
+def test_list_openlibrary_provider_editions_handles_empty_lookup(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[None],
+        work=None,
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace()
+
+    client = TestClient(app)
+    response = client.get(f"/api/v1/works/{work_id}/provider-editions/openlibrary")
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["mapped_work_key"] is None
+    assert payload["items"] == []
+
+
+def test_list_openlibrary_provider_editions_uses_existing_mapping(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    imported_edition_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=["/works/OL41914127W"],
+        execute_rows=[[("/books/OL60639135M", imported_edition_id)]],
+    )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL60639135M",
+                title="This Inevitable Ruin",
+                publisher="Ace",
+                publish_date="2025-09-23",
+                language="eng",
+                isbn10=None,
+                isbn13="9780594009041",
+                cover_url="https://covers.openlibrary.org/b/id/1-M.jpg",
+            )
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_editions=_fake_fetch_work_editions,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary?language=eng"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["mapped_work_key"] == "/works/OL41914127W"
+    assert payload["items"][0]["imported_edition_id"] == str(imported_edition_id)
+
+
+def test_list_openlibrary_provider_editions_dedupes_and_respects_limit(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[None],
+        execute_rows=[[("Matt Dinniman",)], []],
+        work=SimpleNamespace(title="This Inevitable Ruin"),
+    )
+
+    async def _fake_search_books(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    work_key="/works/OL1W",
+                    title="This Inevitable Ruin",
+                    author_names=["Matt Dinniman"],
+                ),
+                SimpleNamespace(
+                    work_key="/works/OL1W",
+                    title="Duplicate",
+                    author_names=[],
+                ),
+                SimpleNamespace(work_key=" ", title="Blank", author_names=[]),
+                SimpleNamespace(
+                    work_key="/works/OL2W",
+                    title="This Inevitable Ruin 2",
+                    author_names=["Matt Dinniman"],
+                ),
+                SimpleNamespace(
+                    work_key="/works/OL3W",
+                    title="This Inevitable Ruin 3",
+                    author_names=["Matt Dinniman"],
+                ),
+                SimpleNamespace(
+                    work_key="/works/OL4W",
+                    title="Overflow",
+                    author_names=["Matt Dinniman"],
+                ),
+            ]
+        )
+
+    async def _fake_fetch_work_editions(*_args: Any, **_kwargs: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="Edition 1",
+                publisher=None,
+                publish_date=None,
+                language=None,
+                isbn10=None,
+                isbn13=None,
+                cover_url=None,
+            ),
+            SimpleNamespace(
+                key="/books/OL1M",
+                title="Edition 1 duplicate",
+                publisher=None,
+                publish_date=None,
+                language=None,
+                isbn10=None,
+                isbn13=None,
+                cover_url=None,
+            ),
+        ]
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        search_books=_fake_search_books,
+        fetch_work_editions=_fake_fetch_work_editions,
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary?limit=1"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["data"]
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["edition_key"] == "/books/OL1M"
+
+
+def test_import_openlibrary_provider_edition_sets_mapping_and_preferred(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    imported_edition_id = str(uuid.uuid4())
+    library_item = SimpleNamespace(preferred_edition_id=None)
+    fake_session = _FakeSession(
+        scalar_values=[None, None, None, library_item],
+    )
+    fetched: dict[str, str] = {}
+
+    async def _fake_fetch_work_bundle(*, work_key: str, edition_key: str) -> Any:
+        fetched["work_key"] = work_key
+        fetched["edition_key"] = edition_key
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        "app.routers.works.import_openlibrary_bundle",
+        lambda *_args, **_kwargs: {"edition": {"id": imported_edition_id}},
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_bundle=_fake_fetch_work_bundle,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary/import",
+        json={
+            "work_key": "/works/OL41914127W",
+            "edition_key": "/books/OL60639135M",
+            "set_preferred": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert fetched["work_key"] == "/works/OL41914127W"
+    assert fetched["edition_key"] == "/books/OL60639135M"
+    assert response.json()["data"]["imported_edition_id"] == imported_edition_id
+    assert library_item.preferred_edition_id == uuid.UUID(imported_edition_id)
+    assert fake_session.commit_calls == 1
+    assert len(fake_session.added) == 1
+    assert fake_session.added[0].provider_id == "/works/OL41914127W"
+
+
+def test_import_openlibrary_provider_edition_requires_work_selection(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(scalar_values=[None])
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace()
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary/import",
+        json={"edition_key": "/books/OL60639135M", "set_preferred": True},
+    )
+
+    assert response.status_code == 400
+
+
+def test_import_openlibrary_provider_edition_returns_409_for_conflict(
+    app: FastAPI,
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(
+        scalar_values=[
+            None,
+            None,
+            SimpleNamespace(entity_id=uuid.uuid4()),
+        ]
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace()
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary/import",
+        json={
+            "work_key": "/works/OL41914127W",
+            "edition_key": "/books/OL60639135M",
+            "set_preferred": False,
+        },
+    )
+
+    assert response.status_code == 409
+
+
+def test_import_openlibrary_provider_edition_skips_preferred_when_disabled(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_id = uuid.uuid4()
+    fake_session = _FakeSession(scalar_values=["/works/OL41914127W", None, None])
+
+    async def _fake_fetch_work_bundle(*, work_key: str, edition_key: str) -> Any:
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        "app.routers.works.import_openlibrary_bundle",
+        lambda *_args, **_kwargs: {"edition": {"id": str(uuid.uuid4())}},
+    )
+
+    def _override_session() -> Generator[object, None, None]:
+        yield fake_session
+
+    app.dependency_overrides[get_db_session] = _override_session
+    app.dependency_overrides[get_open_library_client] = lambda: SimpleNamespace(
+        fetch_work_bundle=_fake_fetch_work_bundle
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/works/{work_id}/provider-editions/openlibrary/import",
+        json={
+            "edition_key": "/books/OL60639135M",
+            "set_preferred": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_session.commit_calls == 0

--- a/apps/web/src/components/library/workflows/AddNoteDialog.tsx
+++ b/apps/web/src/components/library/workflows/AddNoteDialog.tsx
@@ -2,10 +2,10 @@
 
 import { Button } from "primereact/button";
 import { Dialog } from "primereact/dialog";
-import { Dropdown } from "primereact/dropdown";
 import { InputTextarea } from "primereact/inputtextarea";
 import { InputText } from "primereact/inputtext";
 import { Message } from "primereact/message";
+import { SelectButton } from "primereact/selectbutton";
 
 type Props = {
   visible: boolean;
@@ -62,20 +62,24 @@ export function AddNoteDialog({
           placeholder="Write a note"
           onChange={(event) => onBodyChange(event.target.value)}
         />
-        <div className="flex items-center justify-between gap-2">
-          <Dropdown
-            value={visibility}
-            options={[
-              { label: "Private", value: "private" },
-              { label: "Public", value: "public" },
-            ]}
-            optionLabel="label"
-            optionValue="value"
-            onChange={(event) =>
-              onVisibilityChange(event.value as "private" | "public")
-            }
-          />
+        <div className="grid items-center gap-2 sm:grid-cols-[auto_12rem]">
+          <div className="flex justify-center sm:justify-start">
+            <SelectButton
+              value={visibility}
+              options={[
+                { label: "Private", value: "private" },
+                { label: "Public", value: "public" },
+              ]}
+              optionLabel="label"
+              optionValue="value"
+              className="h-[3rem] [&_.p-button]:h-full [&_.p-button]:px-4"
+              onChange={(event) =>
+                onVisibilityChange(event.value as "private" | "public")
+              }
+            />
+          </div>
           <Button
+            className="h-[3rem]"
             label="Add note"
             loading={saving}
             disabled={!body.trim()}

--- a/apps/web/src/components/library/workflows/AddNoteDialog.tsx
+++ b/apps/web/src/components/library/workflows/AddNoteDialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Button } from "primereact/button";
+import { Dialog } from "primereact/dialog";
+import { Dropdown } from "primereact/dropdown";
+import { InputTextarea } from "primereact/inputtextarea";
+import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
+
+type Props = {
+  visible: boolean;
+  headerTitle: string;
+  workflowError: string;
+  title: string;
+  body: string;
+  visibility: "private" | "public";
+  saving: boolean;
+  onHide: () => void;
+  onTitleChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+  onVisibilityChange: (value: "private" | "public") => void;
+  onSubmit: () => void;
+};
+
+export function AddNoteDialog({
+  visible,
+  headerTitle,
+  workflowError,
+  title,
+  body,
+  visibility,
+  saving,
+  onHide,
+  onTitleChange,
+  onBodyChange,
+  onVisibilityChange,
+  onSubmit,
+}: Props) {
+  return (
+    <Dialog
+      visible={visible}
+      onHide={onHide}
+      className="w-full max-w-[36rem]"
+      header={headerTitle}
+      modal
+      draggable={false}
+      data-test="library-workflow-add-note-dialog"
+    >
+      <div className="flex flex-col gap-3">
+        {workflowError ? (
+          <Message severity="error" text={workflowError} />
+        ) : null}
+        <InputText
+          value={title}
+          placeholder="Title (optional)"
+          onChange={(event) => onTitleChange(event.target.value)}
+        />
+        <InputTextarea
+          rows={5}
+          autoResize
+          value={body}
+          placeholder="Write a note"
+          onChange={(event) => onBodyChange(event.target.value)}
+        />
+        <div className="flex items-center justify-between gap-2">
+          <Dropdown
+            value={visibility}
+            options={[
+              { label: "Private", value: "private" },
+              { label: "Public", value: "public" },
+            ]}
+            optionLabel="label"
+            optionValue="value"
+            onChange={(event) =>
+              onVisibilityChange(event.value as "private" | "public")
+            }
+          />
+          <Button
+            label="Add note"
+            loading={saving}
+            disabled={!body.trim()}
+            onClick={onSubmit}
+          />
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/library/workflows/AddReviewDialog.tsx
+++ b/apps/web/src/components/library/workflows/AddReviewDialog.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Button } from "primereact/button";
+import { Dialog } from "primereact/dialog";
+import { Dropdown } from "primereact/dropdown";
+import { InputTextarea } from "primereact/inputtextarea";
+import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
+import { Rating } from "primereact/rating";
+
+type Props = {
+  visible: boolean;
+  headerTitle: string;
+  workflowError: string;
+  title: string;
+  body: string;
+  visibility: "private" | "public";
+  rating: string;
+  saving: boolean;
+  onHide: () => void;
+  onTitleChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+  onVisibilityChange: (value: "private" | "public") => void;
+  onRatingChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+export function AddReviewDialog({
+  visible,
+  headerTitle,
+  workflowError,
+  title,
+  body,
+  visibility,
+  rating,
+  saving,
+  onHide,
+  onTitleChange,
+  onBodyChange,
+  onVisibilityChange,
+  onRatingChange,
+  onSubmit,
+}: Props) {
+  return (
+    <Dialog
+      visible={visible}
+      onHide={onHide}
+      className="w-full max-w-[36rem]"
+      header={headerTitle}
+      modal
+      draggable={false}
+      data-test="library-workflow-add-review-dialog"
+    >
+      <div className="flex flex-col gap-3">
+        {workflowError ? (
+          <Message severity="error" text={workflowError} />
+        ) : null}
+        <InputText
+          value={title}
+          placeholder="Review title"
+          onChange={(event) => onTitleChange(event.target.value)}
+        />
+        <InputTextarea
+          rows={6}
+          autoResize
+          value={body}
+          placeholder="Write your review"
+          onChange={(event) => onBodyChange(event.target.value)}
+        />
+        <div className="grid gap-2 sm:grid-cols-3">
+          <Rating
+            value={Number.parseFloat(rating || "0") || 0}
+            stars={5}
+            cancel
+            onChange={(event) =>
+              onRatingChange(String((event.value as number) ?? 0))
+            }
+          />
+          <Dropdown
+            value={visibility}
+            options={[
+              { label: "Private", value: "private" },
+              { label: "Public", value: "public" },
+            ]}
+            optionLabel="label"
+            optionValue="value"
+            onChange={(event) =>
+              onVisibilityChange(
+                event.value === "public" ? "public" : "private",
+              )
+            }
+          />
+          <Button label="Save review" loading={saving} onClick={onSubmit} />
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/library/workflows/AddReviewDialog.tsx
+++ b/apps/web/src/components/library/workflows/AddReviewDialog.tsx
@@ -2,11 +2,10 @@
 
 import { Button } from "primereact/button";
 import { Dialog } from "primereact/dialog";
-import { Dropdown } from "primereact/dropdown";
 import { InputTextarea } from "primereact/inputtextarea";
 import { InputText } from "primereact/inputtext";
 import { Message } from "primereact/message";
-import { Rating } from "primereact/rating";
+import { SelectButton } from "primereact/selectbutton";
 
 type Props = {
   visible: boolean;
@@ -24,6 +23,55 @@ type Props = {
   onRatingChange: (value: string) => void;
   onSubmit: () => void;
 };
+
+function HalfStarRating({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (starValue: number) => void;
+}) {
+  return (
+    <span
+      className="flex items-center gap-1 leading-none"
+      role="slider"
+      aria-label="Rating"
+      aria-valuenow={Math.round(value * 2)}
+      aria-valuemin={0}
+      aria-valuemax={10}
+    >
+      {Array.from({ length: 5 }, (_, i) => {
+        const fill = Math.max(0, Math.min(1, value - i));
+        return (
+          <span
+            key={i}
+            className="relative inline-block cursor-pointer text-[2rem] leading-none transition-transform hover:scale-110"
+            onClick={(event) => {
+              const rect = event.currentTarget.getBoundingClientRect();
+              const isLeftHalf = event.clientX - rect.left < rect.width / 2;
+              const newValue = isLeftHalf ? i + 0.5 : i + 1;
+              onChange(newValue === value ? 0 : newValue);
+            }}
+          >
+            <i
+              className="pi pi-star"
+              style={{ color: "var(--p-text-muted-color)", opacity: 0.3 }}
+            />
+            {fill > 0 ? (
+              <i
+                className="pi pi-star-fill absolute inset-0"
+                style={{
+                  color: "var(--p-primary-color)",
+                  clipPath: `inset(0 ${(1 - fill) * 100}% 0 0)`,
+                }}
+              />
+            ) : null}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
 
 export function AddReviewDialog({
   visible,
@@ -67,30 +115,41 @@ export function AddReviewDialog({
           placeholder="Write your review"
           onChange={(event) => onBodyChange(event.target.value)}
         />
-        <div className="grid gap-2 sm:grid-cols-3">
-          <Rating
-            value={Number.parseFloat(rating || "0") || 0}
-            stars={5}
-            cancel
-            onChange={(event) =>
-              onRatingChange(String((event.value as number) ?? 0))
-            }
+        <div className="grid items-center gap-2 sm:grid-cols-[auto_auto_12.5rem]">
+          <div className="grid min-h-[3.5rem] grid-rows-[1fr_auto] items-center px-1 py-1">
+            <div className="flex items-center justify-center self-center">
+              <HalfStarRating
+                value={Number.parseFloat(rating || "0") || 0}
+                onChange={(value) => onRatingChange(String(value))}
+              />
+            </div>
+            <span className="text-center text-sm leading-none text-[var(--p-text-muted-color)]">
+              Rating
+            </span>
+          </div>
+          <div className="flex justify-center">
+            <SelectButton
+              value={visibility}
+              options={[
+                { label: "Private", value: "private" },
+                { label: "Public", value: "public" },
+              ]}
+              optionLabel="label"
+              optionValue="value"
+              className="h-[3.5rem] [&_.p-button]:h-full [&_.p-button]:px-4"
+              onChange={(event) =>
+                onVisibilityChange(
+                  event.value === "public" ? "public" : "private",
+                )
+              }
+            />
+          </div>
+          <Button
+            className="h-[3.5rem]"
+            label="Save review"
+            loading={saving}
+            onClick={onSubmit}
           />
-          <Dropdown
-            value={visibility}
-            options={[
-              { label: "Private", value: "private" },
-              { label: "Public", value: "public" },
-            ]}
-            optionLabel="label"
-            optionValue="value"
-            onChange={(event) =>
-              onVisibilityChange(
-                event.value === "public" ? "public" : "private",
-              )
-            }
-          />
-          <Button label="Save review" loading={saving} onClick={onSubmit} />
         </div>
       </div>
     </Dialog>

--- a/apps/web/src/components/library/workflows/EnrichMetadataDialog.tsx
+++ b/apps/web/src/components/library/workflows/EnrichMetadataDialog.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import Image from "next/image";
+import { type ReactNode } from "react";
+import { Button } from "primereact/button";
+import { Dialog } from "primereact/dialog";
+import { Dropdown } from "primereact/dropdown";
+import { Message } from "primereact/message";
+import { Tag } from "primereact/tag";
+import type {
+  Edition,
+  EnrichmentCandidate,
+  EnrichmentField,
+} from "@/components/library/workflows/types";
+
+type SelectionValue = "keep" | "openlibrary" | "googlebooks";
+
+type Props = {
+  visible: boolean;
+  headerTitle: string;
+  workflowError: string;
+  workflowEditionId: string;
+  workflowEditionsLoading: boolean;
+  workflowEditions: Edition[];
+  showEditionPicker: boolean;
+  editionResolver?: ReactNode;
+  enrichmentLoading: boolean;
+  enrichmentApplying: boolean;
+  enrichmentFields: EnrichmentField[];
+  enrichmentSelection: Record<string, SelectionValue>;
+  onHide: () => void;
+  onEditionChange: (editionId: string) => void;
+  onRefresh: () => void;
+  onApplySelected: () => void;
+  onPreferOpenLibrary: () => void;
+  onPreferGoogleBooks: () => void;
+  onResetCurrent: () => void;
+  onSelectionChange: (fieldKey: string, value: SelectionValue) => void;
+};
+
+const formatEnrichmentValue = (value: unknown) => {
+  if (value === null || value === undefined) return "(empty)";
+  if (typeof value === "string") return value.trim() || "(empty)";
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const providerValue = (
+  candidates: EnrichmentCandidate[],
+  provider: "openlibrary" | "googlebooks",
+) => candidates.find((candidate) => candidate.provider === provider);
+
+const toImageUrl = (value: unknown) => {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return trimmed;
+  }
+  return "";
+};
+
+export function EnrichMetadataDialog({
+  visible,
+  headerTitle,
+  workflowError,
+  workflowEditionId,
+  workflowEditionsLoading,
+  workflowEditions,
+  showEditionPicker,
+  editionResolver,
+  enrichmentLoading,
+  enrichmentApplying,
+  enrichmentFields,
+  enrichmentSelection,
+  onHide,
+  onEditionChange,
+  onRefresh,
+  onApplySelected,
+  onPreferOpenLibrary,
+  onPreferGoogleBooks,
+  onResetCurrent,
+  onSelectionChange,
+}: Props) {
+  return (
+    <Dialog
+      visible={visible}
+      onHide={onHide}
+      className="w-full max-w-[80rem]"
+      header={headerTitle}
+      modal
+      draggable={false}
+      data-test="library-workflow-enrich-dialog"
+    >
+      <div className="flex max-h-[78vh] flex-col gap-4 overflow-hidden">
+        {workflowError ? (
+          <Message severity="error" text={workflowError} />
+        ) : null}
+        {editionResolver}
+
+        <div className="flex flex-wrap items-center gap-2">
+          {showEditionPicker ? (
+            <Dropdown
+              value={workflowEditionId}
+              disabled={workflowEditionsLoading}
+              options={workflowEditions.map((edition) => ({
+                label:
+                  (edition.title || "Untitled edition") +
+                  (edition.format ? ` (${edition.format})` : ""),
+                value: edition.id,
+              }))}
+              optionLabel="label"
+              optionValue="value"
+              placeholder="Select edition target"
+              onChange={(event) => onEditionChange(event.value as string)}
+            />
+          ) : (
+            <p className="text-sm text-[var(--p-text-muted-color)]">
+              Applying to your only available edition target.
+            </p>
+          )}
+          <Button
+            label="Refresh candidates"
+            severity="secondary"
+            outlined
+            loading={enrichmentLoading}
+            onClick={onRefresh}
+          />
+          <Button
+            label="Apply selected"
+            loading={enrichmentApplying}
+            disabled={enrichmentApplying || enrichmentFields.length === 0}
+            onClick={onApplySelected}
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            label="Prefer Open Library"
+            outlined
+            severity="secondary"
+            disabled={enrichmentFields.length === 0}
+            onClick={onPreferOpenLibrary}
+          />
+          <Button
+            label="Prefer Google Books"
+            outlined
+            severity="secondary"
+            disabled={enrichmentFields.length === 0}
+            onClick={onPreferGoogleBooks}
+          />
+          <Button
+            label="Reset all to current"
+            text
+            severity="secondary"
+            disabled={enrichmentFields.length === 0}
+            onClick={onResetCurrent}
+          />
+        </div>
+
+        {enrichmentLoading ? (
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-8 rounded border border-[var(--p-content-border-color)] bg-[var(--surface-ground)]"
+              />
+            ))}
+          </div>
+        ) : enrichmentFields.length ? (
+          <div className="flex max-h-[58vh] flex-col gap-3 overflow-auto pr-1">
+            <div className="hidden gap-3 border-b border-[var(--p-content-border-color)] px-2 pb-2 text-xs font-semibold uppercase tracking-wide text-[var(--p-text-muted-color)] md:grid md:grid-cols-[180px_1fr_1fr_1fr]">
+              <p>Field</p>
+              <p>Current</p>
+              <p>Open Library</p>
+              <p>Google Books</p>
+            </div>
+
+            {enrichmentFields.map((field) => {
+              const openLibrary = providerValue(
+                field.candidates,
+                "openlibrary",
+              );
+              const googleBooks = providerValue(
+                field.candidates,
+                "googlebooks",
+              );
+              const fieldIsCover = field.field_key === "work.cover_url";
+              return (
+                <div
+                  key={field.field_key}
+                  className="rounded-lg border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-3"
+                  data-test={`book-enrich-field-${field.field_key}`}
+                >
+                  <div className="grid gap-3 md:grid-cols-[180px_1fr_1fr_1fr]">
+                    <div className="md:pt-2">
+                      <div className="flex items-center justify-between gap-2 md:block">
+                        <p className="text-sm font-medium">{field.field_key}</p>
+                        {field.has_conflict ? (
+                          <Tag value="Conflict" severity="warning" />
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <label
+                      className={`flex cursor-pointer flex-col gap-2 rounded border p-3 transition ${
+                        enrichmentSelection[field.field_key] === "keep"
+                          ? "border-[var(--p-primary-color)] bg-[color-mix(in_srgb,var(--p-primary-color)_8%,transparent)]"
+                          : "border-[var(--p-content-border-color)]"
+                      }`}
+                    >
+                      <span className="inline-flex items-center gap-2 text-sm font-medium">
+                        <input
+                          type="radio"
+                          checked={
+                            enrichmentSelection[field.field_key] === "keep"
+                          }
+                          onChange={() =>
+                            onSelectionChange(field.field_key, "keep")
+                          }
+                          name={`pick-${field.field_key}`}
+                          value="keep"
+                          className="h-4 w-4"
+                        />
+                        Current
+                      </span>
+                      {fieldIsCover ? (
+                        <div className="mt-1">
+                          <div className="overflow-hidden rounded border border-[var(--p-content-border-color)]">
+                            {toImageUrl(field.current_value) ? (
+                              <Image
+                                src={toImageUrl(field.current_value)}
+                                alt=""
+                                width={240}
+                                height={144}
+                                unoptimized
+                                className="h-36 w-full bg-black/5 object-contain"
+                              />
+                            ) : (
+                              <div className="flex h-36 items-center justify-center bg-[var(--p-surface-100)] px-2 text-sm text-[var(--p-text-muted-color)] dark:bg-[var(--p-surface-800)]">
+                                No current cover
+                              </div>
+                            )}
+                          </div>
+                          <details className="mt-2 text-xs text-[var(--p-text-muted-color)]">
+                            <summary className="cursor-pointer select-none">
+                              Show raw value
+                            </summary>
+                            <p className="mt-2 break-all">
+                              {formatEnrichmentValue(field.current_value)}
+                            </p>
+                          </details>
+                        </div>
+                      ) : (
+                        <p className="whitespace-pre-wrap break-words text-sm">
+                          {formatEnrichmentValue(field.current_value)}
+                        </p>
+                      )}
+                    </label>
+
+                    {(
+                      [
+                        ["openlibrary", openLibrary, "Open Library"],
+                        ["googlebooks", googleBooks, "Google Books"],
+                      ] as const
+                    ).map(([provider, candidate, label]) => (
+                      <label
+                        key={provider}
+                        className={`flex flex-col gap-2 rounded border p-3 transition ${
+                          !candidate
+                            ? "cursor-not-allowed opacity-60"
+                            : enrichmentSelection[field.field_key] === provider
+                              ? "cursor-pointer border-[var(--p-primary-color)] bg-[color-mix(in_srgb,var(--p-primary-color)_8%,transparent)]"
+                              : "cursor-pointer border-[var(--p-content-border-color)]"
+                        }`}
+                      >
+                        <span className="inline-flex items-center gap-2 text-sm font-medium">
+                          <input
+                            type="radio"
+                            checked={
+                              enrichmentSelection[field.field_key] === provider
+                            }
+                            onChange={() =>
+                              onSelectionChange(field.field_key, provider)
+                            }
+                            name={`pick-${field.field_key}`}
+                            value={provider}
+                            disabled={!candidate}
+                            className="h-4 w-4"
+                          />
+                          {label}
+                        </span>
+                        {fieldIsCover ? (
+                          <div className="mt-1">
+                            <div className="overflow-hidden rounded border border-[var(--p-content-border-color)]">
+                              {toImageUrl(
+                                candidate?.display_value || candidate?.value,
+                              ) ? (
+                                <Image
+                                  src={toImageUrl(
+                                    candidate?.display_value ||
+                                      candidate?.value,
+                                  )}
+                                  alt=""
+                                  width={240}
+                                  height={144}
+                                  unoptimized
+                                  className="h-36 w-full bg-black/5 object-contain"
+                                />
+                              ) : (
+                                <div className="flex h-36 items-center justify-center bg-[var(--p-surface-100)] px-2 text-sm text-[var(--p-text-muted-color)] dark:bg-[var(--p-surface-800)]">
+                                  No {label} result
+                                </div>
+                              )}
+                            </div>
+                            <details className="mt-2 text-xs text-[var(--p-text-muted-color)]">
+                              <summary className="cursor-pointer select-none">
+                                Show raw value
+                              </summary>
+                              <p className="mt-2 break-all">
+                                {formatEnrichmentValue(
+                                  candidate?.display_value,
+                                )}
+                              </p>
+                            </details>
+                          </div>
+                        ) : (
+                          <p className="whitespace-pre-wrap break-words text-sm">
+                            {formatEnrichmentValue(
+                              candidate?.display_value || "No suggestion",
+                            )}
+                          </p>
+                        )}
+                        {candidate?.source_label ? (
+                          <p className="text-xs text-[var(--p-text-muted-color)]">
+                            {candidate.source_label}
+                          </p>
+                        ) : null}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--p-text-muted-color)]">
+            No enrichment candidates loaded.
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/library/workflows/LogProgressDialog.tsx
+++ b/apps/web/src/components/library/workflows/LogProgressDialog.tsx
@@ -1,12 +1,21 @@
 "use client";
 
+import { useMemo, useState } from "react";
+import { Avatar } from "primereact/avatar";
 import { Button } from "primereact/button";
 import { Calendar } from "primereact/calendar";
 import { Dialog } from "primereact/dialog";
 import { Dropdown } from "primereact/dropdown";
 import { InputTextarea } from "primereact/inputtextarea";
-import { InputText } from "primereact/inputtext";
+import { Knob } from "primereact/knob";
 import { Message } from "primereact/message";
+import { Slider } from "primereact/slider";
+import { Tag } from "primereact/tag";
+import {
+  fromCanonicalPercent,
+  toCanonicalPercent,
+  type ProgressTotals,
+} from "@/lib/progress-conversion";
 
 type ProgressUnit = "pages_read" | "percent_complete" | "minutes_listened";
 
@@ -14,12 +23,16 @@ type Props = {
   visible: boolean;
   headerTitle: string;
   workflowError: string;
+  statisticsLoading: boolean;
+  progressTotals: ProgressTotals;
+  streakDays: number;
   progressUnit: ProgressUnit;
   progressValue: string;
   progressDate: string;
   progressNote: string;
   progressSaving: boolean;
   onHide: () => void;
+  onRetryStatistics: () => void;
   onProgressUnitChange: (unit: ProgressUnit) => void;
   onProgressValueChange: (value: string) => void;
   onProgressDateChange: (value: string) => void;
@@ -27,81 +40,216 @@ type Props = {
   onSubmit: () => void;
 };
 
+const formatDuration = (minutesValue: number): string => {
+  const safe =
+    Number.isFinite(minutesValue) && minutesValue >= 0 ? minutesValue : 0;
+  const totalMinutes = Math.round(safe);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}:${String(minutes).padStart(2, "0")}:00`;
+};
+
 export function LogProgressDialog({
   visible,
   headerTitle,
   workflowError,
+  statisticsLoading,
+  progressTotals,
+  streakDays,
   progressUnit,
   progressValue,
   progressDate,
   progressNote,
   progressSaving,
   onHide,
+  onRetryStatistics,
   onProgressUnitChange,
   onProgressValueChange,
   onProgressDateChange,
   onProgressNoteChange,
   onSubmit,
 }: Props) {
+  const [showConvertUnitSelect, setShowConvertUnitSelect] = useState(false);
+  const parsedProgressValue = Number(progressValue.trim());
+  const currentNumeric =
+    Number.isFinite(parsedProgressValue) && parsedProgressValue >= 0
+      ? parsedProgressValue
+      : 0;
+  const canonicalPercent = useMemo(
+    () => toCanonicalPercent(progressUnit, currentNumeric, progressTotals) ?? 0,
+    [currentNumeric, progressTotals, progressUnit],
+  );
+  const displayPagesValue = Math.round(
+    fromCanonicalPercent("pages_read", canonicalPercent, progressTotals) ?? 0,
+  );
+  const displayPercentValue = Math.round(
+    fromCanonicalPercent(
+      "percent_complete",
+      canonicalPercent,
+      progressTotals,
+    ) ?? 0,
+  );
+  const displayMinutesValue = Math.round(
+    fromCanonicalPercent(
+      "minutes_listened",
+      canonicalPercent,
+      progressTotals,
+    ) ?? 0,
+  );
+  const sliderMax = useMemo(() => {
+    if (progressUnit === "percent_complete") return 100;
+    if (progressUnit === "pages_read")
+      return Math.max(progressTotals.total_pages ?? 1000, 1);
+    return Math.max(progressTotals.total_audio_minutes ?? 1440, 1);
+  }, [
+    progressTotals.total_audio_minutes,
+    progressTotals.total_pages,
+    progressUnit,
+  ]);
+  const totalsTimeDisplay = formatDuration(
+    progressTotals.total_audio_minutes ?? 0,
+  );
+
   return (
     <Dialog
       visible={visible}
       onHide={onHide}
-      className="w-full max-w-[36rem]"
+      className="w-full max-w-[60rem]"
       header={headerTitle}
       modal
       draggable={false}
       data-test="library-workflow-log-progress-dialog"
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-4">
         {workflowError ? (
           <Message severity="error" text={workflowError} />
         ) : null}
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <Dropdown
-            value={progressUnit}
-            options={[
-              { label: "Pages", value: "pages_read" },
-              { label: "Percent", value: "percent_complete" },
-              { label: "Time", value: "minutes_listened" },
-            ]}
-            optionLabel="label"
-            optionValue="value"
-            onChange={(event) =>
-              onProgressUnitChange(event.value as ProgressUnit)
-            }
-          />
-          <InputText
-            value={progressValue}
-            placeholder="Progress value"
-            onChange={(event) => onProgressValueChange(event.target.value)}
-          />
-          <Calendar
-            value={progressDate ? new Date(`${progressDate}T00:00:00`) : null}
-            maxDate={new Date()}
-            showIcon
-            dateFormat="mm/dd/yy"
-            onChange={(event) => {
-              if (event.value instanceof Date) {
-                onProgressDateChange(event.value.toISOString().slice(0, 10));
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <Avatar icon="pi pi-clock" shape="circle" aria-hidden="true" />
+            <p className="m-0 font-heading text-lg font-semibold tracking-tight">
+              Reading sessions
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="small"
+              severity="secondary"
+              disabled={statisticsLoading}
+              onClick={onRetryStatistics}
+            >
+              Retry
+            </Button>
+            {!showConvertUnitSelect ? (
+              <Button
+                outlined
+                size="small"
+                severity="secondary"
+                onClick={() => setShowConvertUnitSelect(true)}
+              >
+                Convert progress unit
+              </Button>
+            ) : (
+              <Dropdown
+                value={progressUnit}
+                options={[
+                  { label: "Pages", value: "pages_read" },
+                  { label: "Percentage", value: "percent_complete" },
+                  { label: "Time", value: "minutes_listened" },
+                ]}
+                optionLabel="label"
+                optionValue="value"
+                onChange={(event) => {
+                  onProgressUnitChange(event.value as ProgressUnit);
+                  setShowConvertUnitSelect(false);
+                }}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[var(--p-content-border-color)] p-4">
+          <div className="mx-auto flex w-[300px] max-w-full flex-col items-center gap-4">
+            <div className="relative h-[210px] w-[210px]">
+              <Knob
+                value={Math.max(0, Math.min(100, canonicalPercent))}
+                min={0}
+                max={100}
+                readOnly
+                size={210}
+                showValue={false}
+                strokeWidth={14}
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="text-3xl font-semibold">
+                  {displayPercentValue}%
+                </span>
+              </div>
+            </div>
+            <Slider
+              className="w-full"
+              min={0}
+              max={sliderMax}
+              step={1}
+              value={Math.max(0, Math.round(currentNumeric))}
+              onChange={(event) =>
+                onProgressValueChange(String((event.value as number) ?? 0))
               }
-            }}
-          />
+            />
+            <p className="text-xs text-[var(--p-text-muted-color)]">
+              Pages: {displayPagesValue} • Percentage: {displayPercentValue}% •
+              Time: {formatDuration(displayMinutesValue)}
+            </p>
+            <Tag value={`${streakDays}-day streak`} severity="info" />
+            <div className="flex flex-col items-center gap-1">
+              <label className="text-xs font-medium">Log date</label>
+              <Calendar
+                value={
+                  progressDate ? new Date(`${progressDate}T00:00:00`) : null
+                }
+                maxDate={new Date()}
+                showIcon
+                dateFormat="mm/dd/yy"
+                onChange={(event) => {
+                  if (event.value instanceof Date) {
+                    onProgressDateChange(
+                      event.value.toISOString().slice(0, 10),
+                    );
+                  }
+                }}
+              />
+            </div>
+            <InputTextarea
+              className="w-full max-w-[500px]"
+              rows={5}
+              autoResize
+              value={progressNote}
+              placeholder="Session note"
+              onChange={(event) => onProgressNoteChange(event.target.value)}
+            />
+            <Button
+              label="Log session"
+              loading={progressSaving}
+              onClick={onSubmit}
+            />
+          </div>
         </div>
-        <InputTextarea
-          rows={4}
-          autoResize
-          value={progressNote}
-          placeholder="Session note (optional)"
-          onChange={(event) => onProgressNoteChange(event.target.value)}
-        />
-        <div className="flex justify-end">
-          <Button
-            label="Log progress"
-            loading={progressSaving}
-            onClick={onSubmit}
-          />
+
+        <div className="flex flex-col items-center gap-0 text-sm">
+          <p className="m-0 font-medium">Totals</p>
+          <p className="m-0 text-xs text-[var(--p-text-muted-color)]">
+            Pages: {progressTotals.total_pages ?? 0} • Time: {totalsTimeDisplay}
+          </p>
         </div>
+
+        {statisticsLoading ? (
+          <div className="flex justify-center">
+            <small className="text-[var(--p-text-muted-color)]">
+              Loading reading statistics...
+            </small>
+          </div>
+        ) : null}
       </div>
     </Dialog>
   );

--- a/apps/web/src/components/library/workflows/LogProgressDialog.tsx
+++ b/apps/web/src/components/library/workflows/LogProgressDialog.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Button } from "primereact/button";
+import { Calendar } from "primereact/calendar";
+import { Dialog } from "primereact/dialog";
+import { Dropdown } from "primereact/dropdown";
+import { InputTextarea } from "primereact/inputtextarea";
+import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
+
+type ProgressUnit = "pages_read" | "percent_complete" | "minutes_listened";
+
+type Props = {
+  visible: boolean;
+  headerTitle: string;
+  workflowError: string;
+  progressUnit: ProgressUnit;
+  progressValue: string;
+  progressDate: string;
+  progressNote: string;
+  progressSaving: boolean;
+  onHide: () => void;
+  onProgressUnitChange: (unit: ProgressUnit) => void;
+  onProgressValueChange: (value: string) => void;
+  onProgressDateChange: (value: string) => void;
+  onProgressNoteChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+export function LogProgressDialog({
+  visible,
+  headerTitle,
+  workflowError,
+  progressUnit,
+  progressValue,
+  progressDate,
+  progressNote,
+  progressSaving,
+  onHide,
+  onProgressUnitChange,
+  onProgressValueChange,
+  onProgressDateChange,
+  onProgressNoteChange,
+  onSubmit,
+}: Props) {
+  return (
+    <Dialog
+      visible={visible}
+      onHide={onHide}
+      className="w-full max-w-[36rem]"
+      header={headerTitle}
+      modal
+      draggable={false}
+      data-test="library-workflow-log-progress-dialog"
+    >
+      <div className="flex flex-col gap-3">
+        {workflowError ? (
+          <Message severity="error" text={workflowError} />
+        ) : null}
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <Dropdown
+            value={progressUnit}
+            options={[
+              { label: "Pages", value: "pages_read" },
+              { label: "Percent", value: "percent_complete" },
+              { label: "Time", value: "minutes_listened" },
+            ]}
+            optionLabel="label"
+            optionValue="value"
+            onChange={(event) =>
+              onProgressUnitChange(event.value as ProgressUnit)
+            }
+          />
+          <InputText
+            value={progressValue}
+            placeholder="Progress value"
+            onChange={(event) => onProgressValueChange(event.target.value)}
+          />
+          <Calendar
+            value={progressDate ? new Date(`${progressDate}T00:00:00`) : null}
+            maxDate={new Date()}
+            showIcon
+            dateFormat="mm/dd/yy"
+            onChange={(event) => {
+              if (event.value instanceof Date) {
+                onProgressDateChange(event.value.toISOString().slice(0, 10));
+              }
+            }}
+          />
+        </div>
+        <InputTextarea
+          rows={4}
+          autoResize
+          value={progressNote}
+          placeholder="Session note (optional)"
+          onChange={(event) => onProgressNoteChange(event.target.value)}
+        />
+        <div className="flex justify-end">
+          <Button
+            label="Log progress"
+            loading={progressSaving}
+            onClick={onSubmit}
+          />
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/library/workflows/OpenLibraryEditionResolver.tsx
+++ b/apps/web/src/components/library/workflows/OpenLibraryEditionResolver.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import Image from "next/image";
+import { useMemo, useState } from "react";
+import { Button } from "primereact/button";
+import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
+
+export type OpenLibraryEditionCandidate = {
+  work_key: string;
+  work_title: string | null;
+  work_authors: string[];
+  edition_key: string;
+  title: string | null;
+  publisher: string | null;
+  publish_date: string | null;
+  language: string | null;
+  isbn10: string | null;
+  isbn13: string | null;
+  cover_url: string | null;
+  imported_edition_id: string | null;
+};
+
+type Props = {
+  loading: boolean;
+  error: string;
+  languageFilter: string;
+  items: OpenLibraryEditionCandidate[];
+  importingEditionKey: string | null;
+  onLanguageFilterChange: (value: string) => void;
+  onRefresh: () => void;
+  onImportAndUse: (editionKey: string, workKey: string) => void;
+  onUseImported: (editionId: string) => void;
+};
+
+export function OpenLibraryEditionResolver({
+  loading,
+  error,
+  languageFilter,
+  items,
+  importingEditionKey,
+  onLanguageFilterChange,
+  onRefresh,
+  onImportAndUse,
+  onUseImported,
+}: Props) {
+  const pageSize = 10;
+  const [page, setPage] = useState(1);
+
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pagedItems = useMemo(
+    () => items.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [items, safePage],
+  );
+
+  const workSubtitle = (item: OpenLibraryEditionCandidate) => {
+    const label = item.work_title?.trim();
+    if (label && label !== "Mapped Open Library work") {
+      return item.work_authors.length
+        ? `${label} · ${item.work_authors.join(", ")}`
+        : label;
+    }
+    if (item.work_authors.length) {
+      return item.work_authors.join(", ");
+    }
+    return "";
+  };
+
+  return (
+    <div className="rounded-lg border border-[var(--p-content-border-color)] bg-[var(--surface-ground)] p-3">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm font-medium">Find Open Library editions</p>
+        <div className="flex items-center gap-2">
+          <InputText
+            value={languageFilter}
+            onChange={(event) => onLanguageFilterChange(event.target.value)}
+            placeholder="Language (e.g. eng)"
+            className="w-[11rem]"
+          />
+          <Button
+            label="Refresh editions"
+            size="small"
+            severity="secondary"
+            outlined
+            loading={loading}
+            onClick={onRefresh}
+          />
+        </div>
+      </div>
+
+      {error ? <Message severity="error" text={error} /> : null}
+
+      {items.length ? (
+        <div className="space-y-2">
+          <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
+            {pagedItems.map((item) => (
+              <div
+                key={item.edition_key}
+                className="grid grid-cols-[120px_1fr] gap-3 rounded border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-3"
+              >
+                <div className="h-[180px] w-[120px] overflow-hidden rounded border border-[var(--p-content-border-color)] bg-black/5 dark:bg-white/5">
+                  {item.cover_url ? (
+                    <Image
+                      src={item.cover_url}
+                      alt=""
+                      width={120}
+                      height={180}
+                      unoptimized
+                      className="mx-auto h-full w-auto max-w-full object-contain"
+                    />
+                  ) : null}
+                </div>
+                <div className="flex min-w-0 flex-col gap-1">
+                  <p className="line-clamp-2 text-sm font-semibold">
+                    {item.title || "Untitled edition"}
+                  </p>
+                  {workSubtitle(item) ? (
+                    <p className="line-clamp-1 text-xs text-[var(--p-text-muted-color)]">
+                      {workSubtitle(item)}
+                    </p>
+                  ) : null}
+                  <div className="mt-0.5 space-y-0.5 text-xs text-[var(--p-text-muted-color)]">
+                    <p>
+                      <span className="font-semibold">Publisher:</span>{" "}
+                      {item.publisher || "Unknown"}
+                    </p>
+                    <p>
+                      <span className="font-semibold">Publish Date:</span>{" "}
+                      {item.publish_date || "Unknown"}
+                    </p>
+                    <p>
+                      <span className="font-semibold">Language:</span>{" "}
+                      {item.language || "n/a"}
+                    </p>
+                    <p className="line-clamp-1">
+                      <span className="font-semibold">Edition ID:</span>{" "}
+                      <span className="font-mono">
+                        {(
+                          item.isbn13 ||
+                          item.isbn10 ||
+                          item.edition_key
+                        ).trim()}
+                      </span>
+                    </p>
+                  </div>
+                  <div className="mt-auto pt-1">
+                    {item.imported_edition_id ? (
+                      <Button
+                        label="Use"
+                        size="small"
+                        className="h-9 w-24 self-end justify-center"
+                        onClick={() =>
+                          onUseImported(item.imported_edition_id as string)
+                        }
+                      />
+                    ) : (
+                      <Button
+                        label="Use"
+                        size="small"
+                        className="h-9 w-24 self-end justify-center"
+                        loading={importingEditionKey === item.edition_key}
+                        onClick={() =>
+                          onImportAndUse(item.edition_key, item.work_key)
+                        }
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+          {items.length > pageSize ? (
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <Button
+                label="Previous"
+                size="small"
+                text
+                disabled={safePage <= 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              />
+              <p className="text-xs text-[var(--p-text-muted-color)]">
+                {safePage} / {totalPages}
+              </p>
+              <Button
+                label="Next"
+                size="small"
+                text
+                disabled={safePage >= totalPages}
+                onClick={() =>
+                  setPage((current) => Math.min(totalPages, current + 1))
+                }
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-xs text-[var(--p-text-muted-color)]">
+          No Open Library editions loaded yet.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/library/workflows/SetCoverAndMetadataDialog.tsx
+++ b/apps/web/src/components/library/workflows/SetCoverAndMetadataDialog.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import Image from "next/image";
+import { Button } from "primereact/button";
+import { Dialog } from "primereact/dialog";
+import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
+import { SelectButton } from "primereact/selectbutton";
+import type { Edition } from "@/components/library/workflows/types";
+import { renderDescriptionHtml } from "@/lib/description";
+
+type CoverMetadataMode = "choose" | "upload" | "url";
+type SelectionValue = "current" | "selected";
+
+export type ProviderSourceTile = {
+  provider: "openlibrary" | "googlebooks";
+  source_id: string;
+  title: string;
+  authors: string[];
+  publisher: string | null;
+  publish_date: string | null;
+  language: string | null;
+  identifier: string;
+  cover_url: string | null;
+  source_label: string;
+};
+
+export type CoverMetadataCompareField = {
+  field_key: string;
+  field_label: string;
+  current_value: unknown;
+  selected_value: unknown;
+  selected_available: boolean;
+  provider: "openlibrary" | "googlebooks";
+  provider_id: string;
+};
+
+type Props = {
+  visible: boolean;
+  headerTitle: string;
+  workflowError: string;
+  mode: CoverMetadataMode;
+  loadingSources: boolean;
+  sourceError: string;
+  sourceLanguageFilter: string;
+  sourceTiles: ProviderSourceTile[];
+  selectedSourceKey: string;
+  compareLoading: boolean;
+  compareFields: CoverMetadataCompareField[];
+  fieldSelection: Record<string, SelectionValue>;
+  enrichmentApplying: boolean;
+  coverBusy: boolean;
+  workflowEditions: Edition[];
+  workflowEditionId: string;
+  coverSourceUrl: string;
+  hasSelectedFile: boolean;
+  canEditEditionTarget: boolean;
+  onHide: () => void;
+  onModeChange: (mode: CoverMetadataMode) => void;
+  onSourceLanguageFilterChange: (value: string) => void;
+  onRefreshSources: () => void;
+  onSelectSource: (tile: ProviderSourceTile) => void;
+  onResetAllToCurrent: () => void;
+  onApplySelected: () => void;
+  onFieldSelectionChange: (fieldKey: string, value: SelectionValue) => void;
+  onFileChange: (file: File | null) => void;
+  onUploadCover: () => void;
+  onCoverSourceUrlChange: (value: string) => void;
+  onCacheCover: () => void;
+};
+
+const formatValue = (value: unknown) => {
+  if (value === null || value === undefined) return "(empty)";
+  if (typeof value === "string") return value.trim() || "(empty)";
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const toImageUrl = (value: unknown) => {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.startsWith("http://") || trimmed.startsWith("https://")
+    ? trimmed
+    : "";
+};
+
+const renderFieldText = (fieldKey: string, value: unknown) => {
+  if (
+    fieldKey === "work.description" &&
+    typeof value === "string" &&
+    value.trim()
+  ) {
+    const html = renderDescriptionHtml(value);
+    if (html) {
+      return (
+        <div
+          className="prose prose-sm max-w-none dark:prose-invert"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      );
+    }
+  }
+  return (
+    <p className="whitespace-pre-wrap break-words text-sm">
+      {formatValue(value)}
+    </p>
+  );
+};
+
+export function SetCoverAndMetadataDialog({
+  visible,
+  headerTitle,
+  workflowError,
+  mode,
+  loadingSources,
+  sourceError,
+  sourceLanguageFilter,
+  sourceTiles,
+  selectedSourceKey,
+  compareLoading,
+  compareFields,
+  fieldSelection,
+  enrichmentApplying,
+  coverBusy,
+  workflowEditions,
+  workflowEditionId,
+  coverSourceUrl,
+  hasSelectedFile,
+  canEditEditionTarget,
+  onHide,
+  onModeChange,
+  onSourceLanguageFilterChange,
+  onRefreshSources,
+  onSelectSource,
+  onResetAllToCurrent,
+  onApplySelected,
+  onFieldSelectionChange,
+  onFileChange,
+  onUploadCover,
+  onCoverSourceUrlChange,
+  onCacheCover,
+}: Props) {
+  return (
+    <Dialog
+      visible={visible}
+      onHide={onHide}
+      className="w-full max-w-[84rem]"
+      header={headerTitle}
+      modal
+      draggable={false}
+      data-test="library-workflow-set-cover-and-metadata-dialog"
+    >
+      <div className="flex max-h-[82vh] flex-col gap-4 overflow-hidden">
+        {workflowError ? (
+          <Message severity="error" text={workflowError} />
+        ) : null}
+        <SelectButton
+          value={mode}
+          options={[
+            { label: "Choose", value: "choose" },
+            { label: "Upload", value: "upload" },
+            { label: "URL", value: "url" },
+          ]}
+          optionLabel="label"
+          optionValue="value"
+          onChange={(event) =>
+            onModeChange(event.value as "choose" | "upload" | "url")
+          }
+        />
+
+        {mode === "choose" ? (
+          <div className="flex min-h-0 flex-col gap-3">
+            <div className="rounded-lg border border-[var(--p-content-border-color)] bg-[var(--surface-ground)] p-3">
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm font-medium">Find editions and volumes</p>
+                <div className="flex items-center gap-2">
+                  <InputText
+                    value={sourceLanguageFilter}
+                    onChange={(event) =>
+                      onSourceLanguageFilterChange(event.target.value)
+                    }
+                    placeholder="Language (e.g. eng)"
+                    className="w-[11rem]"
+                  />
+                  <Button
+                    label="Refresh"
+                    size="small"
+                    severity="secondary"
+                    outlined
+                    loading={loadingSources}
+                    onClick={onRefreshSources}
+                  />
+                </div>
+              </div>
+              {sourceError ? (
+                <Message severity="error" text={sourceError} />
+              ) : null}
+
+              <div className="grid max-h-[34vh] gap-3 overflow-auto pr-1 md:grid-cols-2 2xl:grid-cols-3">
+                {sourceTiles.map((item) => {
+                  const sourceKey = `${item.provider}:${item.source_id}`;
+                  const selected = sourceKey === selectedSourceKey;
+                  return (
+                    <button
+                      key={sourceKey}
+                      type="button"
+                      className={`grid grid-cols-[96px_1fr] gap-3 rounded border p-3 text-left transition ${
+                        selected
+                          ? "border-[var(--p-primary-color)] bg-[color-mix(in_srgb,var(--p-primary-color)_8%,transparent)]"
+                          : "border-[var(--p-content-border-color)] bg-[var(--surface-card)]"
+                      }`}
+                      onClick={() => onSelectSource(item)}
+                    >
+                      <div className="h-[144px] w-[96px] overflow-hidden rounded border border-[var(--p-content-border-color)] bg-black/5 dark:bg-white/5">
+                        {item.cover_url ? (
+                          <Image
+                            src={item.cover_url}
+                            alt=""
+                            width={96}
+                            height={144}
+                            unoptimized
+                            className="mx-auto h-full w-auto max-w-full object-contain"
+                          />
+                        ) : null}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="line-clamp-2 text-sm font-semibold">
+                          {item.title}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--p-text-muted-color)]">
+                          {item.source_label}
+                        </p>
+                        <p className="line-clamp-1 text-xs text-[var(--p-text-muted-color)]">
+                          {item.authors.join(", ") || "Unknown author"}
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--p-text-muted-color)]">
+                          <span className="font-semibold">Publisher:</span>{" "}
+                          {item.publisher || "Unknown"}
+                        </p>
+                        <p className="text-xs text-[var(--p-text-muted-color)]">
+                          <span className="font-semibold">Publish Date:</span>{" "}
+                          {item.publish_date || "Unknown"}
+                        </p>
+                        <p className="text-xs text-[var(--p-text-muted-color)]">
+                          <span className="font-semibold">Language:</span>{" "}
+                          {item.language || "n/a"}
+                        </p>
+                        <p className="line-clamp-1 text-xs text-[var(--p-text-muted-color)]">
+                          <span className="font-semibold">ID:</span>{" "}
+                          <span className="font-mono">{item.identifier}</span>
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                label="Reset all to current"
+                severity="secondary"
+                text
+                disabled={!compareFields.length || enrichmentApplying}
+                onClick={onResetAllToCurrent}
+              />
+              <Button
+                label="Apply selected"
+                loading={enrichmentApplying}
+                disabled={!compareFields.length || enrichmentApplying}
+                onClick={onApplySelected}
+              />
+            </div>
+
+            {compareLoading ? (
+              <div className="text-sm text-[var(--p-text-muted-color)]">
+                Loading selected metadata...
+              </div>
+            ) : compareFields.length ? (
+              <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-[var(--p-content-border-color)] bg-[var(--surface-card)] p-3">
+                <div className="grid gap-3 border-b border-[var(--p-content-border-color)] pb-2 text-xs font-semibold uppercase tracking-wide text-[var(--p-text-muted-color)] md:grid-cols-[180px_1fr_1fr]">
+                  <p>Field</p>
+                  <p>Current</p>
+                  <p>Selected</p>
+                </div>
+                <div className="mt-3 flex flex-col gap-3">
+                  {compareFields.map((field) => {
+                    const fieldIsCover = field.field_key === "work.cover_url";
+                    const selectedValue = field.selected_value;
+                    return (
+                      <div
+                        key={field.field_key}
+                        className="grid gap-3 rounded border border-[var(--p-content-border-color)] p-3 md:grid-cols-[180px_1fr_1fr]"
+                      >
+                        <p className="text-sm font-medium">
+                          {field.field_label}
+                        </p>
+                        <label className="flex cursor-pointer flex-col gap-2 rounded border border-[var(--p-content-border-color)] p-3">
+                          <span className="inline-flex items-center gap-2 text-sm font-medium">
+                            <input
+                              type="radio"
+                              checked={
+                                fieldSelection[field.field_key] === "current"
+                              }
+                              onChange={() =>
+                                onFieldSelectionChange(
+                                  field.field_key,
+                                  "current",
+                                )
+                              }
+                              name={`pick-${field.field_key}`}
+                              value="current"
+                              className="h-4 w-4"
+                            />
+                            Current
+                          </span>
+                          {fieldIsCover ? (
+                            <div className="overflow-hidden rounded border border-[var(--p-content-border-color)]">
+                              {toImageUrl(field.current_value) ? (
+                                <Image
+                                  src={toImageUrl(field.current_value)}
+                                  alt=""
+                                  width={240}
+                                  height={144}
+                                  unoptimized
+                                  className="h-36 w-full bg-black/5 object-contain"
+                                />
+                              ) : (
+                                <div className="flex h-36 items-center justify-center bg-[var(--p-surface-100)] text-sm text-[var(--p-text-muted-color)] dark:bg-[var(--p-surface-800)]">
+                                  No current cover
+                                </div>
+                              )}
+                            </div>
+                          ) : (
+                            renderFieldText(
+                              field.field_key,
+                              field.current_value,
+                            )
+                          )}
+                        </label>
+                        <label
+                          className={`flex flex-col gap-2 rounded border p-3 ${
+                            field.selected_available
+                              ? "cursor-pointer border-[var(--p-content-border-color)]"
+                              : "cursor-not-allowed border-[var(--p-content-border-color)] opacity-60"
+                          }`}
+                        >
+                          <span className="inline-flex items-center gap-2 text-sm font-medium">
+                            <input
+                              type="radio"
+                              checked={
+                                fieldSelection[field.field_key] === "selected"
+                              }
+                              onChange={() =>
+                                onFieldSelectionChange(
+                                  field.field_key,
+                                  "selected",
+                                )
+                              }
+                              name={`pick-${field.field_key}`}
+                              value="selected"
+                              disabled={!field.selected_available}
+                              className="h-4 w-4"
+                            />
+                            Selected
+                          </span>
+                          {fieldIsCover ? (
+                            <div className="overflow-hidden rounded border border-[var(--p-content-border-color)]">
+                              {toImageUrl(selectedValue) ? (
+                                <Image
+                                  src={toImageUrl(selectedValue)}
+                                  alt=""
+                                  width={240}
+                                  height={144}
+                                  unoptimized
+                                  className="h-36 w-full bg-black/5 object-contain"
+                                />
+                              ) : (
+                                <div className="flex h-36 items-center justify-center bg-[var(--p-surface-100)] text-sm text-[var(--p-text-muted-color)] dark:bg-[var(--p-surface-800)]">
+                                  Not available
+                                </div>
+                              )}
+                            </div>
+                          ) : field.selected_available ? (
+                            renderFieldText(field.field_key, selectedValue)
+                          ) : (
+                            <p className="whitespace-pre-wrap break-words text-sm">
+                              Not available
+                            </p>
+                          )}
+                        </label>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-[var(--p-text-muted-color)]">
+                Select an edition or volume above to compare metadata.
+              </p>
+            )}
+          </div>
+        ) : null}
+
+        {mode === "upload" ? (
+          <div className="flex flex-col gap-3">
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(event) =>
+                onFileChange(event.target.files?.[0] ?? null)
+              }
+            />
+            <div className="flex justify-end">
+              <Button
+                label="Upload"
+                disabled={
+                  !workflowEditionId ||
+                  workflowEditions.length === 0 ||
+                  !hasSelectedFile ||
+                  coverBusy ||
+                  !canEditEditionTarget
+                }
+                loading={coverBusy}
+                onClick={onUploadCover}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {mode === "url" ? (
+          <div className="flex flex-col gap-3">
+            <InputText
+              value={coverSourceUrl}
+              placeholder="https://covers.openlibrary.org/..."
+              onChange={(event) => onCoverSourceUrlChange(event.target.value)}
+            />
+            <div className="flex justify-end">
+              <Button
+                label="Cache from URL"
+                disabled={
+                  !workflowEditionId ||
+                  workflowEditions.length === 0 ||
+                  !coverSourceUrl.trim() ||
+                  coverBusy ||
+                  !canEditEditionTarget
+                }
+                loading={coverBusy}
+                onClick={onCacheCover}
+              />
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/library/workflows/SetCoverDialog.tsx
+++ b/apps/web/src/components/library/workflows/SetCoverDialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { Button } from "primereact/button";
+import { Dialog } from "primereact/dialog";
+import { InputText } from "primereact/inputtext";
+import { Message } from "primereact/message";
+import { SelectButton } from "primereact/selectbutton";
+import type { Edition } from "@/components/library/workflows/types";
+
+type Props = {
+  visible: boolean;
+  headerTitle: string;
+  workflowError: string;
+  coverBusy: boolean;
+  coverMode: "choose" | "upload" | "url";
+  workflowEditions: Edition[];
+  workflowEditionId: string;
+  coverSourceUrl: string;
+  hasSelectedFile: boolean;
+  canEditEditionTarget: boolean;
+  editionResolver?: ReactNode;
+  onHide: () => void;
+  onCoverModeChange: (mode: "choose" | "upload" | "url") => void;
+  onFileChange: (file: File | null) => void;
+  onUploadCover: () => void;
+  onCoverSourceUrlChange: (value: string) => void;
+  onCacheCover: () => void;
+};
+
+export function SetCoverDialog({
+  visible,
+  headerTitle,
+  workflowError,
+  coverBusy,
+  coverMode,
+  workflowEditions,
+  workflowEditionId,
+  coverSourceUrl,
+  hasSelectedFile,
+  canEditEditionTarget,
+  editionResolver,
+  onHide,
+  onCoverModeChange,
+  onFileChange,
+  onUploadCover,
+  onCoverSourceUrlChange,
+  onCacheCover,
+}: Props) {
+  return (
+    <Dialog
+      visible={visible}
+      onHide={onHide}
+      className="w-full max-w-[80rem]"
+      header={headerTitle}
+      modal
+      draggable={false}
+      data-test="library-workflow-set-cover-dialog"
+    >
+      <div className="flex flex-col gap-4">
+        {workflowError ? (
+          <Message severity="error" text={workflowError} />
+        ) : null}
+
+        <SelectButton
+          value={coverMode}
+          options={[
+            { label: "Choose edition", value: "choose" },
+            { label: "Upload", value: "upload" },
+            { label: "URL", value: "url" },
+          ]}
+          optionLabel="label"
+          optionValue="value"
+          onChange={(event) =>
+            onCoverModeChange(event.value as "choose" | "upload" | "url")
+          }
+        />
+
+        {coverMode === "choose" ? (
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-[var(--p-text-muted-color)]">
+              Choose one edition and click <strong>Use</strong> to apply its
+              cover.
+            </p>
+            {editionResolver}
+          </div>
+        ) : null}
+
+        {coverMode === "upload" ? (
+          <div className="flex flex-col gap-3">
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(event) =>
+                onFileChange(event.target.files?.[0] ?? null)
+              }
+            />
+            <div className="flex justify-end">
+              <Button
+                label="Upload"
+                disabled={
+                  !workflowEditionId ||
+                  workflowEditions.length === 0 ||
+                  !hasSelectedFile ||
+                  coverBusy ||
+                  !canEditEditionTarget
+                }
+                loading={coverBusy}
+                onClick={onUploadCover}
+              />
+            </div>
+            {!canEditEditionTarget ? (
+              <p className="text-xs text-[var(--p-text-muted-color)]">
+                Upload needs a resolvable edition target.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        {coverMode === "url" ? (
+          <div className="flex flex-col gap-3">
+            <InputText
+              value={coverSourceUrl}
+              placeholder="https://covers.openlibrary.org/..."
+              onChange={(event) => onCoverSourceUrlChange(event.target.value)}
+            />
+            <div className="flex justify-end">
+              <Button
+                label="Cache from URL"
+                disabled={
+                  !workflowEditionId ||
+                  workflowEditions.length === 0 ||
+                  !coverSourceUrl.trim() ||
+                  coverBusy ||
+                  !canEditEditionTarget
+                }
+                loading={coverBusy}
+                onClick={onCacheCover}
+              />
+            </div>
+            {!canEditEditionTarget ? (
+              <p className="text-xs text-[var(--p-text-muted-color)]">
+                URL cache needs a resolvable edition target.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/library/workflows/types.ts
+++ b/apps/web/src/components/library/workflows/types.ts
@@ -1,0 +1,29 @@
+export type Edition = {
+  id: string;
+  title?: string | null;
+  format?: string | null;
+};
+
+export type CoverCandidate = {
+  source: "openlibrary" | "googlebooks" | string;
+  source_id?: string | null;
+  source_url?: string | null;
+  image_url?: string | null;
+  thumbnail_url?: string | null;
+  cover_id?: number | null;
+};
+
+export type EnrichmentCandidate = {
+  provider: "openlibrary" | "googlebooks";
+  provider_id: string;
+  value: unknown;
+  display_value: string;
+  source_label: string;
+};
+
+export type EnrichmentField = {
+  field_key: string;
+  current_value: unknown;
+  has_conflict?: boolean;
+  candidates: EnrichmentCandidate[];
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -63,6 +63,7 @@ export async function apiRequest<T>(
     method?: "GET" | "POST" | "PATCH" | "DELETE";
     query?: Record<string, string | number | undefined | null>;
     body?: unknown;
+    signal?: AbortSignal;
   },
 ): Promise<T> {
   const baseUrl = getApiBaseUrl();
@@ -81,6 +82,7 @@ export async function apiRequest<T>(
 
   const response = await fetch(url.toString(), {
     method: options?.method ?? "GET",
+    signal: options?.signal,
     headers: {
       Authorization: `Bearer ${token}`,
       ...(isFormData ? {} : { "Content-Type": "application/json" }),

--- a/apps/web/src/tests/unit/library-context-menu.test.tsx
+++ b/apps/web/src/tests/unit/library-context-menu.test.tsx
@@ -1,0 +1,286 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiRequestMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: ComponentPropsWithoutRef<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: () => <div data-test="next-image-mock" />,
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  };
+});
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createBrowserClient: vi.fn(() => ({ auth: { getSession: vi.fn() } })),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useAppToast: () => ({ show: vi.fn() }),
+}));
+
+import LibraryPage from "@/app/(app)/library/page";
+
+const SAMPLE_ITEMS = [
+  {
+    id: "item-1",
+    work_id: "work-1",
+    work_title: "The Left Hand of Darkness",
+    work_description: "An envoy enters a strange winter world.",
+    author_names: ["Ursula K. Le Guin"],
+    status: "reading",
+    visibility: "private",
+    rating: 8,
+    tags: ["sci-fi"],
+    created_at: "2026-02-01T00:00:00Z",
+  },
+];
+
+function buildLocalStorageMock() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    clear: () => {
+      values.clear();
+    },
+  };
+}
+
+function setupApiMock() {
+  apiRequestMock.mockImplementation(
+    async (_supabase: unknown, path: string) => {
+      if (path === "/api/v1/library/items") {
+        return {
+          items: SAMPLE_ITEMS,
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total_count: 1,
+            total_pages: 1,
+            from: 1,
+            to: 1,
+            has_prev: false,
+            has_next: false,
+          },
+        };
+      }
+      if (path.startsWith("/api/v1/library/items/item-1")) {
+        return SAMPLE_ITEMS[0];
+      }
+      if (path === "/api/v1/works/work-1/editions") {
+        return {
+          items: [{ id: "edition-1", title: "Default Edition", format: null }],
+        };
+      }
+      if (path === "/api/v1/works/work-1/cover-metadata/sources") {
+        return {
+          items: [
+            {
+              provider: "openlibrary",
+              source_id: "/books/OL1M",
+              title: "The Left Hand of Darkness",
+              authors: ["Ursula K. Le Guin"],
+              publisher: "Ace",
+              publish_date: "1969-01-01",
+              language: "eng",
+              identifier: "9780441478129",
+              cover_url: "https://covers.openlibrary.org/b/id/1-M.jpg",
+              source_label: "Open Library",
+            },
+          ],
+          prefetch_compare: {
+            "openlibrary:/books/OL1M": {
+              selected_source: {
+                provider: "openlibrary",
+                source_id: "/books/OL1M",
+                source_label: "Open Library OL1M",
+                edition_id: null,
+              },
+              fields: [
+                {
+                  field_key: "edition.publisher",
+                  field_label: "Publisher",
+                  current_value: "Current publisher",
+                  selected_value: "Ace",
+                  selected_available: true,
+                  provider: "openlibrary",
+                  provider_id: "/books/OL1M",
+                },
+              ],
+            },
+          },
+        };
+      }
+      if (path === "/api/v1/works/work-1/cover-metadata/compare") {
+        return { fields: [] };
+      }
+      throw new Error(`Unhandled apiRequest call: ${path}`);
+    },
+  );
+}
+
+async function openFromOverflowTrigger() {
+  const trigger = (await screen.findAllByLabelText("Open actions menu"))[0];
+  if (!trigger) throw new Error("Missing overflow trigger");
+  fireEvent.click(trigger);
+}
+
+async function setViewMode(mode: "List" | "Grid" | "Table") {
+  const trigger = await waitFor(() =>
+    document.querySelector(
+      `[data-test=\"library-view-select\"] [aria-label=\"${mode}\"]`,
+    ),
+  );
+  if (!trigger) throw new Error(`Missing ${mode} view toggle`);
+  fireEvent.click(trigger);
+}
+
+describe("Library context menu", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset();
+    vi.stubGlobal("localStorage", buildLocalStorageMock());
+    setupApiMock();
+    window.history.replaceState({}, "", "/library");
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens from list right-click and renders 4 actions in order", async () => {
+    localStorage.setItem("seedbed.library.viewMode", "list");
+    render(<LibraryPage />);
+
+    const listTitle = await screen.findByText("The Left Hand of Darkness");
+
+    fireEvent.contextMenu(listTitle);
+
+    await screen.findByText("Set Cover and Metadata");
+    const labels = Array.from(
+      document.querySelectorAll(".p-menuitem-text"),
+    ).map((node) => node.textContent?.trim());
+    expect(labels).toEqual([
+      "Set Cover and Metadata",
+      "Log Progress",
+      "Add Note",
+      "Add Review",
+    ]);
+  });
+
+  it("opens from grid overflow trigger and opens merged workflow dialog without navigation", async () => {
+    render(<LibraryPage />);
+    await setViewMode("Grid");
+
+    await openFromOverflowTrigger();
+    fireEvent.click(await screen.findByText("Set Cover and Metadata"));
+
+    await waitFor(() =>
+      expect(
+        document.querySelector(
+          '[data-test="library-workflow-set-cover-and-metadata-dialog"]',
+        ),
+      ).toBeTruthy(),
+    );
+    expect(window.location.pathname).toBe("/library");
+  });
+
+  it("opens from table row right-click and opens Log Progress dialog", async () => {
+    render(<LibraryPage />);
+    await setViewMode("Table");
+
+    const titleLink = await screen.findByText("The Left Hand of Darkness");
+    const row = titleLink.closest("tr");
+    if (!row) throw new Error("Missing table row");
+
+    fireEvent.contextMenu(row);
+    fireEvent.click(await screen.findByText("Log Progress"));
+
+    await waitFor(() =>
+      expect(
+        document.querySelector(
+          '[data-test="library-workflow-log-progress-dialog"]',
+        ),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("supports keyboard context menu trigger (Shift+F10) for list cards", async () => {
+    localStorage.setItem("seedbed.library.viewMode", "list");
+    render(<LibraryPage />);
+
+    const titleLink = await screen.findByText("The Left Hand of Darkness");
+    const listCard = titleLink.closest(".p-card");
+    if (!listCard) throw new Error("Missing list card");
+
+    fireEvent.keyDown(listCard, { key: "F10", shiftKey: true });
+
+    expect(await screen.findByText("Add Review")).toBeInTheDocument();
+  });
+
+  it("closes menu after action selection", async () => {
+    render(<LibraryPage />);
+    await setViewMode("Grid");
+
+    await openFromOverflowTrigger();
+    fireEvent.click(await screen.findByText("Add Note"));
+
+    await waitFor(() =>
+      expect(
+        document.querySelector(
+          '[data-test="library-workflow-add-note-dialog"]',
+        ),
+      ).toBeTruthy(),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Set Cover and Metadata"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("uses prefetched compare cache when selecting a prefetched tile", async () => {
+    render(<LibraryPage />);
+    await setViewMode("Grid");
+
+    await openFromOverflowTrigger();
+    fireEvent.click(await screen.findByText("Set Cover and Metadata"));
+
+    const prefetchedTile = await screen.findByRole("button", {
+      name: /Open Library/i,
+    });
+    fireEvent.click(prefetchedTile);
+
+    await screen.findByText("Publisher");
+    const compareCalls = apiRequestMock.mock.calls.filter(
+      (entry) => entry[1] === "/api/v1/works/work-1/cover-metadata/compare",
+    );
+    expect(compareCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implements Issue #162 with a shared PrimeReact context menu across Library List, Grid, and Table views
- replaces navigation-based workflow launching with in-place Library dialogs
- ships a unified **Set cover and metadata** workflow that mixes Open Library + Google sources and applies selected fields in place
- restores and modernizes workflow dialogs (`Set cover/metadata`, `Log progress`, `Add note`, `Add review`) with improved layout and accessibility fallbacks
- restricts `Log Progress` context action to items with `reading` status only

## Key behavior changes
- one context menu instance is used across all three Library views with right-click, keyboard (`Menu`, `Shift+F10`), and overflow trigger support
- menu actions are now:
  - Set Cover and Metadata
  - Log Progress (only when item status is `reading`)
  - Add Note
  - Add Review
- cover + metadata comparison now prefers selected Open Library edition data and edition cover in compare payloads
- metadata descriptions render markdown/HTML safely in the dialog UI
- Google candidate matching is tightened to avoid unrelated volumes and prefer true edition-like entries
- dialog-side compare payloads are prefetched/cached for fast source switching

## Validation
- `make quality` was run, but fails on existing repo-wide API coverage gate:
  - required: `95%`
  - current total: `89.06%`
- passing sub-steps before the coverage gate failure:
  - format checks (api/web)
  - lint checks (api/web)
  - type checks (api/web)
  - API test suite execution (all tests passed, coverage threshold failed)
- additional successful checks during implementation:
  - `make build-web`
  - targeted API/router and web unit test runs for the new workflows/context menu

Fixes #162
