### PR TITLE
Replace topbar search raw img with next/image

### DIFF
--- a/apps/web/src/components/app-topbar-book-search.tsx
+++ b/apps/web/src/components/app-topbar-book-search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { Button } from "primereact/button";
 import { Card } from "primereact/card";
@@ -417,10 +418,13 @@ export function AppTopBarBookSearch() {
             >
               <div className="h-16 w-11 shrink-0 overflow-hidden rounded bg-[var(--p-surface-100)]">
                 {item.cover_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
+                  <Image
                     src={item.cover_url}
                     alt=""
+                    width={44}
+                    height={64}
+                    sizes="44px"
+                    unoptimized
                     className="h-full w-full object-cover"
                   />
                 ) : (

--- a/apps/web/src/tests/unit/app-topbar-book-search.test.tsx
+++ b/apps/web/src/tests/unit/app-topbar-book-search.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiRequestMock, imageRenderMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+  imageRenderMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: ComponentPropsWithoutRef<"img">) => {
+    imageRenderMock(props);
+    const { src, alt, className, width, height, sizes } = props;
+    return (
+      <div
+        data-test="next-image-mock"
+        data-alt={alt}
+        data-class={className}
+        data-height={String(height)}
+        data-sizes={sizes}
+        data-src={String(src)}
+        data-width={String(width)}
+      />
+    );
+  },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  };
+});
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createBrowserClient: vi.fn(() => ({ auth: { getSession: vi.fn() } })),
+}));
+
+import { AppTopBarBookSearch } from "@/components/app-topbar-book-search";
+
+async function runSearch(query: string) {
+  const { container } = render(<AppTopBarBookSearch />);
+  const input = container.querySelector(
+    '[data-test="topbar-search-input"]',
+  ) as HTMLInputElement | null;
+  expect(input).not.toBeNull();
+  if (!input) throw new Error("Expected topbar search input");
+  fireEvent.change(input, { target: { value: query } });
+  await waitFor(() => {
+    expect(apiRequestMock).toHaveBeenCalled();
+  });
+  return container;
+}
+
+describe("AppTopBarBookSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders next/image cover thumbnail when cover_url is present", async () => {
+    apiRequestMock.mockImplementation(
+      async (_supabase: unknown, path: string) => {
+        if (path === "/api/v1/library/search") {
+          return { items: [] };
+        }
+        if (path === "/api/v1/books/search") {
+          return {
+            items: [
+              {
+                source: "openlibrary",
+                source_id: "OL1W",
+                work_key: "OL1W",
+                title: "Parable of the Sower",
+                author_names: ["Octavia E. Butler"],
+                cover_url: "https://covers.openlibrary.org/b/id/1234-M.jpg",
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected path in test: ${path}`);
+      },
+    );
+
+    const container = await runSearch("parable");
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-test="next-image-mock"]'),
+      ).toBeInTheDocument();
+    });
+    const image = container.querySelector('[data-test="next-image-mock"]');
+    expect(image).toHaveAttribute(
+      "data-src",
+      "https://covers.openlibrary.org/b/id/1234-M.jpg",
+    );
+    expect(image).toHaveAttribute("data-alt", "");
+    expect(image).toHaveAttribute("data-class", "h-full w-full object-cover");
+    expect(imageRenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        width: 44,
+        height: 64,
+        sizes: "44px",
+        unoptimized: true,
+      }),
+    );
+  });
+
+  it("renders no-cover fallback when cover_url is missing", async () => {
+    apiRequestMock.mockImplementation(
+      async (_supabase: unknown, path: string) => {
+        if (path === "/api/v1/library/search") {
+          return { items: [] };
+        }
+        if (path === "/api/v1/books/search") {
+          return {
+            items: [
+              {
+                source: "openlibrary",
+                source_id: "OL2W",
+                work_key: "OL2W",
+                title: "Kindred",
+                author_names: ["Octavia E. Butler"],
+                cover_url: null,
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected path in test: ${path}`);
+      },
+    );
+
+    const container = await runSearch("kindred");
+
+    expect(await screen.findByText("No cover")).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-test="next-image-mock"]'),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
This PR replaces the remaining raw `<img>` in topbar search results with `next/image`.

## What changed
- Added `Image` import and replaced raw `<img>` with `next/image` in `/Users/ryan/Developer/chapterverse/apps/web/src/components/app-topbar-book-search.tsx`.
- Removed local `@next/next/no-img-element` suppression in that component.
- Preserved existing fallback behavior when no cover exists (`"No cover"`).
- Added focused unit tests in `/Users/ryan/Developer/chapterverse/apps/web/src/tests/unit/app-topbar-book-search.test.tsx` for:
  - cover URL renders via `next/image` mock with expected sizing props
  - no-cover path renders fallback and no image

## Implementation details
- `next/image` is configured with `width={44}`, `height={64}`, `sizes="44px"`, `className="h-full w-full object-cover"`.
- `unoptimized` remains enabled intentionally for this surface because remote image host allowlisting is tracked separately.

## Verification
- `make quality` (passes)
  - format/lint/typecheck/tests/build across API and web
- Focused unit run:
  - `pnpm -C apps/web exec vitest run src/tests/unit/app-topbar-book-search.test.tsx`

## Issue tracking
- Updated issue checkboxes in #168 for completed items.
- Remaining unchecked items in #168 are manual visual QA checks (desktop/mobile rendering and layout regression confirmation).

Refs #168
