### PR TITLE
feat(web): migrate interception from middleware.ts to proxy.ts

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -53,7 +53,7 @@ Implemented:
 - route and layout parity across all migrated routes
 - auth entry routes (`/login`, `/auth/callback`, `/oauth/consent`)
 - public canonical routes (`/u/:handle`, `/book/:workId`, `/review/:reviewId`)
-- middleware behavior for protected paths and ActivityPub placeholder responses
+- proxy behavior for protected paths and ActivityPub placeholder responses
 - `/.well-known/webfinger` placeholder handler
 - shared API client/error semantics port
 - color mode cookie/system handling + `window.__setColorMode` E2E hook

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/auth-routes";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   const isDev = process.env.NODE_ENV !== "production";
 

--- a/apps/web/src/tests/unit/proxy.test.ts
+++ b/apps/web/src/tests/unit/proxy.test.ts
@@ -1,0 +1,104 @@
+import type { User } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { updateSessionMock } = vi.hoisted(() => ({
+  updateSessionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/middleware", () => ({
+  updateSession: updateSessionMock,
+}));
+
+import { config, proxy } from "../../proxy";
+
+const MATCHER =
+  "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)";
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function requestFor(path: string, headers?: HeadersInit) {
+  return new NextRequest(`http://localhost${path}`, { headers });
+}
+
+describe("proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  it("keeps matcher configuration unchanged", () => {
+    expect(config).toEqual({ matcher: [MATCHER] });
+  });
+
+  it("returns ActivityPub placeholder for profile routes", async () => {
+    const response = await proxy(
+      requestFor("/u/test-user", { accept: "application/activity+json" }),
+    );
+
+    expect(response.status).toBe(406);
+    await expect(response.json()).resolves.toEqual({
+      message: "ActivityPub is not implemented yet.",
+    });
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects authenticated users away from /login", async () => {
+    const passthroughResponse = NextResponse.next();
+    updateSessionMock.mockResolvedValue({
+      response: passthroughResponse,
+      user: { id: "user-1" } as User,
+    });
+
+    const response = await proxy(requestFor("/login"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/library");
+  });
+
+  it("redirects unauthenticated protected routes in production", async () => {
+    process.env.NODE_ENV = "production";
+    const passthroughResponse = NextResponse.next();
+    updateSessionMock.mockResolvedValue({
+      response: passthroughResponse,
+      user: null,
+    });
+
+    const response = await proxy(requestFor("/library?page=2"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/login?returnTo=%2Flibrary%3Fpage%3D2",
+    );
+  });
+
+  it("does not redirect unauthenticated protected routes in development", async () => {
+    process.env.NODE_ENV = "development";
+    const passthroughResponse = NextResponse.next();
+    updateSessionMock.mockResolvedValue({
+      response: passthroughResponse,
+      user: null,
+    });
+
+    const response = await proxy(requestFor("/library"));
+
+    expect(response).toBe(passthroughResponse);
+  });
+
+  it("returns passthrough response for non-protected routes", async () => {
+    process.env.NODE_ENV = "production";
+    const passthroughResponse = NextResponse.next();
+    updateSessionMock.mockResolvedValue({
+      response: passthroughResponse,
+      user: null,
+    });
+
+    const response = await proxy(requestFor("/book/test-work"));
+
+    expect(response).toBe(passthroughResponse);
+    expect(updateSessionMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/tests/unit/proxy.test.ts
+++ b/apps/web/src/tests/unit/proxy.test.ts
@@ -14,7 +14,6 @@ import { config, proxy } from "../../proxy";
 
 const MATCHER =
   "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)";
-const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
 function requestFor(path: string, headers?: HeadersInit) {
   return new NextRequest(`http://localhost${path}`, { headers });
@@ -23,11 +22,11 @@ function requestFor(path: string, headers?: HeadersInit) {
 describe("proxy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    vi.unstubAllEnvs();
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    vi.unstubAllEnvs();
   });
 
   it("keeps matcher configuration unchanged", () => {
@@ -60,7 +59,7 @@ describe("proxy", () => {
   });
 
   it("redirects unauthenticated protected routes in production", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const passthroughResponse = NextResponse.next();
     updateSessionMock.mockResolvedValue({
       response: passthroughResponse,
@@ -76,7 +75,7 @@ describe("proxy", () => {
   });
 
   it("does not redirect unauthenticated protected routes in development", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     const passthroughResponse = NextResponse.next();
     updateSessionMock.mockResolvedValue({
       response: passthroughResponse,
@@ -89,7 +88,7 @@ describe("proxy", () => {
   });
 
   it("returns passthrough response for non-protected routes", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const passthroughResponse = NextResponse.next();
     updateSessionMock.mockResolvedValue({
       response: passthroughResponse,


### PR DESCRIPTION
## Summary
This PR migrates Next.js request interception from `middleware.ts` to `proxy.ts` (issue #167), keeping behavior unchanged while aligning with current Next.js 16 conventions.

## Changes
- moved interception entrypoint from `apps/web/middleware.ts` to `apps/web/src/proxy.ts`
- migrated export to `proxy(request)` with `export const config = { matcher: [...] }`
- preserved existing logic for:
  - ActivityPub `Accept` handling on `/u/*` (406 placeholder)
  - `updateSession` refresh path
  - authenticated `/login` redirect to `/library`
  - unauthenticated protected-route redirect in non-dev
- updated docs wording in `apps/web/README.md` from middleware behavior to proxy behavior
- added focused tests in `apps/web/src/tests/unit/proxy.test.ts`

## Verification
- `make quality` passes
- production-mode runtime verification:
  - unauthenticated `/library` redirects to `/login?returnTo=%2Flibrary`
  - `/u/test-user` with `Accept: application/activity+json` returns `406` with expected JSON message
- existing e2e smoke suite passes

## Issue
Closes #167
