### PR TITLE
web: configure next/image remote patterns and fix local cover loading

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,13 @@
 import type { NextConfig } from "next";
 import path from "node:path";
+import { buildImageRemotePatterns } from "./src/lib/image-remote-patterns";
 
 const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname),
+  },
+  images: {
+    remotePatterns: buildImageRemotePatterns(),
   },
 };
 

--- a/apps/web/public/themes/lara-dark-indigo/theme.css
+++ b/apps/web/public/themes/lara-dark-indigo/theme.css
@@ -57,7 +57,7 @@
   font-display: swap;
   font-style: normal;
   font-named-instance: "Regular";
-  src: url("./fonts/InterVariable.woff2") format("woff2");
+  src: url("/themes/lara-dark-indigo/fonts/InterVariable.woff2") format("woff2");
 }
 @font-face {
   font-family: "Inter var";
@@ -65,7 +65,8 @@
   font-display: swap;
   font-style: italic;
   font-named-instance: "Italic";
-  src: url("./fonts/InterVariable-Italic.woff2") format("woff2");
+  src: url("/themes/lara-dark-indigo/fonts/InterVariable-Italic.woff2")
+    format("woff2");
 }
 :root {
   --blue-50: #f5f9ff;

--- a/apps/web/public/themes/lara-light-indigo/theme.css
+++ b/apps/web/public/themes/lara-light-indigo/theme.css
@@ -57,7 +57,8 @@
   font-display: swap;
   font-style: normal;
   font-named-instance: "Regular";
-  src: url("./fonts/InterVariable.woff2") format("woff2");
+  src: url("/themes/lara-light-indigo/fonts/InterVariable.woff2")
+    format("woff2");
 }
 @font-face {
   font-family: "Inter var";
@@ -65,7 +66,8 @@
   font-display: swap;
   font-style: italic;
   font-named-instance: "Italic";
-  src: url("./fonts/InterVariable-Italic.woff2") format("woff2");
+  src: url("/themes/lara-light-indigo/fonts/InterVariable-Italic.woff2")
+    format("woff2");
 }
 :root {
   --blue-50: #f5f9ff;

--- a/apps/web/src/app/(app)/books/[workId]/page.tsx
+++ b/apps/web/src/app/(app)/books/[workId]/page.tsx
@@ -24,6 +24,7 @@ import { Rating } from "primereact/rating";
 import { SelectButton } from "primereact/selectbutton";
 import { ApiClientError, apiRequest } from "@/lib/api";
 import { renderDescriptionHtml } from "@/lib/description";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 import {
   canConvert,
   fromCanonicalPercent,
@@ -1881,7 +1882,7 @@ export default function BookDetailPage({
                   alt=""
                   width={220}
                   height={320}
-                  unoptimized
+                  unoptimized={shouldUseUnoptimizedForUrl(work.cover_url)}
                   className="h-auto w-full object-cover"
                   data-test="book-detail-cover-image"
                 />

--- a/apps/web/src/app/(app)/books/search/page.tsx
+++ b/apps/web/src/app/(app)/books/search/page.tsx
@@ -10,6 +10,7 @@ import { InputText } from "primereact/inputtext";
 import { Message } from "primereact/message";
 import { Skeleton } from "primereact/skeleton";
 import { ApiClientError, apiRequest } from "@/lib/api";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 import { createBrowserClient } from "@/lib/supabase/browser";
 import { useAppToast } from "@/components/toast-provider";
 
@@ -483,7 +484,9 @@ export default function BookSearchPage() {
                         alt=""
                         width={80}
                         height={120}
-                        unoptimized
+                        unoptimized={shouldUseUnoptimizedForUrl(
+                          book.cover_url ?? "",
+                        )}
                         className="h-full w-full object-cover"
                         data-test="search-item-cover"
                         onError={() => {

--- a/apps/web/src/app/(app)/library/page.tsx
+++ b/apps/web/src/app/(app)/library/page.tsx
@@ -39,6 +39,7 @@ import type {
 import type { Edition } from "@/components/library/workflows/types";
 import { ApiClientError, apiRequest } from "@/lib/api";
 import { renderDescriptionHtml } from "@/lib/description";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 import {
   fromCanonicalPercent,
   toCanonicalPercent,
@@ -2428,7 +2429,9 @@ export default function LibraryPage() {
                                 alt=""
                                 width={40}
                                 height={56}
-                                unoptimized
+                                unoptimized={shouldUseUnoptimizedForUrl(
+                                  item.cover_url,
+                                )}
                                 className="h-full w-full object-cover"
                                 data-test="library-item-cover"
                               />
@@ -2751,7 +2754,9 @@ export default function LibraryPage() {
                               alt=""
                               width={112}
                               height={168}
-                              unoptimized
+                              unoptimized={shouldUseUnoptimizedForUrl(
+                                item.cover_url,
+                              )}
                               className="h-full w-full object-contain"
                               data-test="library-item-cover"
                             />
@@ -2898,7 +2903,9 @@ export default function LibraryPage() {
                               alt=""
                               width={256}
                               height={384}
-                              unoptimized
+                              unoptimized={shouldUseUnoptimizedForUrl(
+                                item.cover_url,
+                              )}
                               className="block h-full w-full object-cover"
                               data-test="library-item-cover"
                             />

--- a/apps/web/src/components/app-topbar-book-search.tsx
+++ b/apps/web/src/components/app-topbar-book-search.tsx
@@ -11,6 +11,7 @@ import { Message } from "primereact/message";
 import { SelectButton } from "primereact/selectbutton";
 import { Skeleton } from "primereact/skeleton";
 import { ApiClientError, apiRequest } from "@/lib/api";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 import { createBrowserClient } from "@/lib/supabase/browser";
 
 type SearchScope = "my" | "global" | "both";
@@ -424,7 +425,7 @@ export function AppTopBarBookSearch() {
                     width={44}
                     height={64}
                     sizes="44px"
-                    unoptimized
+                    unoptimized={shouldUseUnoptimizedForUrl(item.cover_url)}
                     className="h-full w-full object-cover"
                   />
                 ) : (

--- a/apps/web/src/components/library/workflows/EnrichMetadataDialog.tsx
+++ b/apps/web/src/components/library/workflows/EnrichMetadataDialog.tsx
@@ -12,6 +12,7 @@ import type {
   EnrichmentCandidate,
   EnrichmentField,
 } from "@/components/library/workflows/types";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 
 type SelectionValue = "keep" | "openlibrary" | "googlebooks";
 
@@ -243,7 +244,9 @@ export function EnrichMetadataDialog({
                                 alt=""
                                 width={240}
                                 height={144}
-                                unoptimized
+                                unoptimized={shouldUseUnoptimizedForUrl(
+                                  toImageUrl(field.current_value),
+                                )}
                                 className="h-36 w-full bg-black/5 object-contain"
                               />
                             ) : (
@@ -314,7 +317,12 @@ export function EnrichMetadataDialog({
                                   alt=""
                                   width={240}
                                   height={144}
-                                  unoptimized
+                                  unoptimized={shouldUseUnoptimizedForUrl(
+                                    toImageUrl(
+                                      candidate?.display_value ||
+                                        candidate?.value,
+                                    ),
+                                  )}
                                   className="h-36 w-full bg-black/5 object-contain"
                                 />
                               ) : (

--- a/apps/web/src/components/library/workflows/OpenLibraryEditionResolver.tsx
+++ b/apps/web/src/components/library/workflows/OpenLibraryEditionResolver.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { Button } from "primereact/button";
 import { InputText } from "primereact/inputtext";
 import { Message } from "primereact/message";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 
 export type OpenLibraryEditionCandidate = {
   work_key: string;
@@ -106,7 +107,7 @@ export function OpenLibraryEditionResolver({
                       alt=""
                       width={120}
                       height={180}
-                      unoptimized
+                      unoptimized={shouldUseUnoptimizedForUrl(item.cover_url)}
                       className="mx-auto h-full w-auto max-w-full object-contain"
                     />
                   ) : null}

--- a/apps/web/src/components/library/workflows/SetCoverAndMetadataDialog.tsx
+++ b/apps/web/src/components/library/workflows/SetCoverAndMetadataDialog.tsx
@@ -8,6 +8,7 @@ import { Message } from "primereact/message";
 import { SelectButton } from "primereact/selectbutton";
 import type { Edition } from "@/components/library/workflows/types";
 import { renderDescriptionHtml } from "@/lib/description";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
 
 type CoverMetadataMode = "choose" | "upload" | "url";
 type SelectionValue = "current" | "selected";
@@ -224,7 +225,9 @@ export function SetCoverAndMetadataDialog({
                             alt=""
                             width={96}
                             height={144}
-                            unoptimized
+                            unoptimized={shouldUseUnoptimizedForUrl(
+                              item.cover_url,
+                            )}
                             className="mx-auto h-full w-auto max-w-full object-contain"
                           />
                         ) : null}
@@ -328,7 +331,9 @@ export function SetCoverAndMetadataDialog({
                                   alt=""
                                   width={240}
                                   height={144}
-                                  unoptimized
+                                  unoptimized={shouldUseUnoptimizedForUrl(
+                                    toImageUrl(field.current_value),
+                                  )}
                                   className="h-36 w-full bg-black/5 object-contain"
                                 />
                               ) : (
@@ -378,7 +383,9 @@ export function SetCoverAndMetadataDialog({
                                   alt=""
                                   width={240}
                                   height={144}
-                                  unoptimized
+                                  unoptimized={shouldUseUnoptimizedForUrl(
+                                    toImageUrl(selectedValue),
+                                  )}
                                   className="h-36 w-full bg-black/5 object-contain"
                                 />
                               ) : (

--- a/apps/web/src/lib/image-optimization.ts
+++ b/apps/web/src/lib/image-optimization.ts
@@ -49,7 +49,18 @@ export function isConfiguredRemoteImageUrl(src: string): boolean {
   });
 }
 
+function isLocalHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
 export function shouldUseUnoptimizedForUrl(src: string): boolean {
+  try {
+    const parsed = new URL(src);
+    if (isLocalHost(parsed.hostname)) return true;
+  } catch {
+    return true;
+  }
+
   // Unknown hosts can still appear in legacy data; avoid runtime hostname errors.
   return !isConfiguredRemoteImageUrl(src);
 }

--- a/apps/web/src/lib/image-optimization.ts
+++ b/apps/web/src/lib/image-optimization.ts
@@ -1,0 +1,55 @@
+import { buildImageRemotePatterns } from "@/lib/image-remote-patterns";
+
+function hostMatches(hostname: string, patternHost: string): boolean {
+  if (!patternHost.startsWith("*.")) {
+    return hostname === patternHost;
+  }
+  const suffix = patternHost.slice(1);
+  return hostname.endsWith(suffix) && hostname.length > suffix.length;
+}
+
+function pathnameMatches(pathname: string, patternPathname: string): boolean {
+  if (patternPathname.endsWith("/**")) {
+    const prefix = patternPathname.slice(0, -3);
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+  }
+  if (patternPathname.endsWith("**")) {
+    const prefix = patternPathname.slice(0, -2);
+    return pathname.startsWith(prefix);
+  }
+  return pathname === patternPathname;
+}
+
+function portMatches(
+  urlPort: string,
+  patternPort: string | undefined,
+): boolean {
+  if (!patternPort) return true;
+  return urlPort === patternPort;
+}
+
+export function isConfiguredRemoteImageUrl(src: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(src);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+
+  const protocol = parsed.protocol.slice(0, -1);
+  const patterns = buildImageRemotePatterns();
+
+  return patterns.some((pattern) => {
+    if (pattern.protocol !== protocol) return false;
+    if (!hostMatches(parsed.hostname, pattern.hostname)) return false;
+    if (!portMatches(parsed.port, pattern.port)) return false;
+    return pathnameMatches(parsed.pathname, pattern.pathname);
+  });
+}
+
+export function shouldUseUnoptimizedForUrl(src: string): boolean {
+  // Unknown hosts can still appear in legacy data; avoid runtime hostname errors.
+  return !isConfiguredRemoteImageUrl(src);
+}

--- a/apps/web/src/lib/image-remote-patterns.ts
+++ b/apps/web/src/lib/image-remote-patterns.ts
@@ -1,0 +1,109 @@
+type RemoteProtocol = "http" | "https";
+
+export type ImageRemotePattern = {
+  protocol: RemoteProtocol;
+  hostname: string;
+  pathname: string;
+  port?: string;
+};
+
+const KNOWN_SUPABASE_HOSTS = [
+  "kypwcksvicrbrrwscdze.supabase.co",
+  "aaohmjvcsgyqqlxomegu.supabase.co",
+] as const;
+
+function addPattern(
+  patterns: ImageRemotePattern[],
+  seen: Set<string>,
+  pattern: ImageRemotePattern,
+) {
+  const key = `${pattern.protocol}|${pattern.hostname}|${pattern.port ?? "*"}|${pattern.pathname}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  patterns.push(pattern);
+}
+
+function parseSupabaseUrl(rawUrl: string | undefined) {
+  if (!rawUrl) return null;
+  try {
+    return new URL(rawUrl);
+  } catch {
+    return null;
+  }
+}
+
+export function buildImageRemotePatterns(
+  supabaseUrl: string | undefined = process.env.NEXT_PUBLIC_SUPABASE_URL,
+): ImageRemotePattern[] {
+  const patterns: ImageRemotePattern[] = [];
+  const seen = new Set<string>();
+
+  addPattern(patterns, seen, {
+    protocol: "https",
+    hostname: "covers.openlibrary.org",
+    pathname: "/b/**",
+  });
+
+  addPattern(patterns, seen, {
+    protocol: "https",
+    hostname: "books.google.com",
+    pathname: "/books/content",
+  });
+
+  addPattern(patterns, seen, {
+    protocol: "https",
+    hostname: "books.google.com",
+    pathname: "/books/content**",
+  });
+
+  addPattern(patterns, seen, {
+    protocol: "https",
+    hostname: "*.googleusercontent.com",
+    pathname: "/**",
+  });
+
+  for (const hostname of KNOWN_SUPABASE_HOSTS) {
+    addPattern(patterns, seen, {
+      protocol: "https",
+      hostname,
+      pathname: "/storage/v1/object/public/**",
+    });
+  }
+
+  addPattern(patterns, seen, {
+    protocol: "http",
+    hostname: "127.0.0.1",
+    port: "54321",
+    pathname: "/storage/v1/object/public/**",
+  });
+  addPattern(patterns, seen, {
+    protocol: "http",
+    hostname: "127.0.0.1",
+    port: "55421",
+    pathname: "/storage/v1/object/public/**",
+  });
+  addPattern(patterns, seen, {
+    protocol: "http",
+    hostname: "localhost",
+    port: "54321",
+    pathname: "/storage/v1/object/public/**",
+  });
+  addPattern(patterns, seen, {
+    protocol: "http",
+    hostname: "localhost",
+    port: "55421",
+    pathname: "/storage/v1/object/public/**",
+  });
+
+  const parsedSupabaseUrl = parseSupabaseUrl(supabaseUrl);
+  if (parsedSupabaseUrl) {
+    addPattern(patterns, seen, {
+      protocol: parsedSupabaseUrl.protocol === "http:" ? "http" : "https",
+      hostname: parsedSupabaseUrl.hostname,
+      port: parsedSupabaseUrl.port || undefined,
+      pathname: "/storage/v1/object/public/**",
+    });
+  }
+
+  return patterns;
+}

--- a/apps/web/src/tests/unit/image-optimization.test.ts
+++ b/apps/web/src/tests/unit/image-optimization.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildImageRemotePatterns } from "@/lib/image-remote-patterns";
+import { shouldUseUnoptimizedForUrl } from "@/lib/image-optimization";
+
+const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+describe("shouldUseUnoptimizedForUrl", () => {
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+  });
+
+  it("allows open library covers through next/image optimization", () => {
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "https://covers.openlibrary.org/b/id/1234-M.jpg",
+      ),
+    ).toBe(false);
+  });
+
+  it("allows google books and googleusercontent covers", () => {
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "https://books.google.com/books/content?id=abc123&printsec=frontcover",
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "https://lh3.googleusercontent.com/books/content?p=abc123",
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "https://books.google.com/books/content/volume?id=abc123",
+      ),
+    ).toBe(false);
+  });
+
+  it("allows known supabase storage hosts including local development", () => {
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "https://kypwcksvicrbrrwscdze.supabase.co/storage/v1/object/public/covers/a.jpg",
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "http://localhost:54321/storage/v1/object/public/covers/a.jpg",
+      ),
+    ).toBe(false);
+  });
+
+  it("allows storage host derived from NEXT_PUBLIC_SUPABASE_URL", () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://custom.supabase.local";
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "https://custom.supabase.local/storage/v1/object/public/covers/a.jpg",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to unoptimized for unknown hosts", () => {
+    expect(
+      shouldUseUnoptimizedForUrl("https://legacy-cdn.example.com/covers/a.jpg"),
+    ).toBe(true);
+  });
+
+  it("falls back to unoptimized when host matches but port does not", () => {
+    expect(
+      shouldUseUnoptimizedForUrl(
+        "http://localhost:9999/storage/v1/object/public/covers/a.jpg",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to unoptimized for invalid URLs", () => {
+    expect(shouldUseUnoptimizedForUrl("not-a-url")).toBe(true);
+  });
+
+  it("falls back to unoptimized for unsupported schemes", () => {
+    expect(shouldUseUnoptimizedForUrl("data:image/png;base64,xyz")).toBe(true);
+  });
+});
+
+describe("buildImageRemotePatterns", () => {
+  it("deduplicates entries when env host matches static host rules", () => {
+    const patterns = buildImageRemotePatterns(
+      "https://kypwcksvicrbrrwscdze.supabase.co",
+    );
+    const hosted = patterns.filter(
+      (pattern) =>
+        pattern.hostname === "kypwcksvicrbrrwscdze.supabase.co" &&
+        pattern.pathname === "/storage/v1/object/public/**" &&
+        pattern.protocol === "https",
+    );
+    expect(hosted).toHaveLength(1);
+  });
+
+  it("parses http supabase hosts including explicit port", () => {
+    const patterns = buildImageRemotePatterns("http://custom.local:5999");
+    expect(patterns).toContainEqual(
+      expect.objectContaining({
+        protocol: "http",
+        hostname: "custom.local",
+        port: "5999",
+        pathname: "/storage/v1/object/public/**",
+      }),
+    );
+  });
+
+  it("ignores invalid supabase URL input", () => {
+    const patterns = buildImageRemotePatterns("not-a-url");
+    expect(patterns.some((pattern) => pattern.hostname === "not-a-url")).toBe(
+      false,
+    );
+  });
+
+  it("accepts a missing supabase URL", () => {
+    const patterns = buildImageRemotePatterns(undefined);
+    expect(patterns.length).toBeGreaterThan(0);
+  });
+
+  it("matches google books content path exactly", () => {
+    const patterns = buildImageRemotePatterns(undefined);
+    expect(
+      patterns.some(
+        (pattern) =>
+          pattern.hostname === "books.google.com" &&
+          pattern.pathname === "/books/content",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #169 by enabling `next/image` remote patterns for known cover hosts, removing unconditional `unoptimized` usage, and adding a safe fallback for unknown/legacy URLs.

## What changed
- Added centralized remote image pattern config:
  - `apps/web/src/lib/image-remote-patterns.ts`
  - Wired in `apps/web/next.config.ts` via `images.remotePatterns`
- Added URL classification and fallback helper:
  - `apps/web/src/lib/image-optimization.ts`
- Replaced hardcoded `unoptimized` with conditional behavior across cover surfaces:
  - Library list/table/grid
  - Book detail
  - Book search
  - Topbar search
  - Workflow dialogs/components
- Added/updated tests:
  - `apps/web/src/tests/unit/image-optimization.test.ts`
  - `apps/web/src/tests/unit/app-topbar-book-search.test.tsx`
- Follow-up runtime fixes from manual verification:
  - Keep localhost/127.0.0.1 cover URLs unoptimized in dev to avoid `/_next/image` 400s
  - Use absolute PrimeReact theme font URLs to prevent route-relative `InterVariable.woff2` 404s:
    - `apps/web/public/themes/lara-light-indigo/theme.css`
    - `apps/web/public/themes/lara-dark-indigo/theme.css`

## Verification
- `make quality` (passes)
- `cd apps/web && pnpm test:unit` (passes, per-file coverage gates pass)
- `cd apps/web && pnpm playwright test tests/e2e/smoke.spec.ts` (passes)

Closes #169.
