### PR TITLE
Migrate web app fonts to next/font

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,15 +17,6 @@
     "quality": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:unit && pnpm build"
   },
   "dependencies": {
-    "@fontsource/atkinson-hyperlegible": "^5.2.8",
-    "@fontsource/averia-libre": "^5.2.7",
-    "@fontsource/dongle": "^5.2.7",
-    "@fontsource/fraunces": "^5.2.9",
-    "@fontsource/ibm-plex-sans": "^5.2.8",
-    "@fontsource/inter": "^5.2.8",
-    "@fontsource/libre-baskerville": "^5.2.10",
-    "@fontsource/lora": "^5.2.8",
-    "@fontsource/nunito-sans": "^5.2.7",
     "@primeuix/themes": "2.0.3",
     "@supabase/ssr": "0.8.0",
     "@supabase/supabase-js": "2.95.3",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -7,33 +7,6 @@ settings:
 importers:
   .:
     dependencies:
-      "@fontsource/atkinson-hyperlegible":
-        specifier: ^5.2.8
-        version: 5.2.8
-      "@fontsource/averia-libre":
-        specifier: ^5.2.7
-        version: 5.2.7
-      "@fontsource/dongle":
-        specifier: ^5.2.7
-        version: 5.2.7
-      "@fontsource/fraunces":
-        specifier: ^5.2.9
-        version: 5.2.9
-      "@fontsource/ibm-plex-sans":
-        specifier: ^5.2.8
-        version: 5.2.8
-      "@fontsource/inter":
-        specifier: ^5.2.8
-        version: 5.2.8
-      "@fontsource/libre-baskerville":
-        specifier: ^5.2.10
-        version: 5.2.10
-      "@fontsource/lora":
-        specifier: ^5.2.8
-        version: 5.2.8
-      "@fontsource/nunito-sans":
-        specifier: ^5.2.7
-        version: 5.2.7
       "@primeuix/themes":
         specifier: 2.0.3
         version: 2.0.3
@@ -668,60 +641,6 @@ packages:
     peerDependenciesMeta:
       "@noble/hashes":
         optional: true
-
-  "@fontsource/atkinson-hyperlegible@5.2.8":
-    resolution:
-      {
-        integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==,
-      }
-
-  "@fontsource/averia-libre@5.2.7":
-    resolution:
-      {
-        integrity: sha512-wj2M7MyrKFiWR+H6BqAhYXu1RwPuqkifyEr+APVySV9Na1WUiJ1aVzgzy9mGOdIO5T9Rtsfe2QaadeicvbNZ/w==,
-      }
-
-  "@fontsource/dongle@5.2.7":
-    resolution:
-      {
-        integrity: sha512-oq/C+mEjjDNVQZLxBFbDNjjAW5qa2BbBMsfeaJl9iuOuXGjYUR9q3xPcJg+xQ9WVGJbbBm/BwrRhApK5yqZtuw==,
-      }
-
-  "@fontsource/fraunces@5.2.9":
-    resolution:
-      {
-        integrity: sha512-XDzuddBtoC7BZgZdBn6b7hsFZY2+V1hgN7yca5fBTKuHjb/lOd45a0Ji8dTUgFhPoL7RdGupo+bC2BFSt6UH8Q==,
-      }
-
-  "@fontsource/ibm-plex-sans@5.2.8":
-    resolution:
-      {
-        integrity: sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==,
-      }
-
-  "@fontsource/inter@5.2.8":
-    resolution:
-      {
-        integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==,
-      }
-
-  "@fontsource/libre-baskerville@5.2.10":
-    resolution:
-      {
-        integrity: sha512-Y/bGj4cOdWhAxU4+sBPen3MB5Og3t/WvezVL+05CJ7cvhDQUKpQFUuw/hm1IQKRc9u0lWs8VP2MKDOK2uQtloQ==,
-      }
-
-  "@fontsource/lora@5.2.8":
-    resolution:
-      {
-        integrity: sha512-AQlfsHw4TP1x/eb2IZ6VjQ70ctKa39m9JN9A4zlvDOeKYLrCs+GaYIEQ86Y6YfSPGHn01bErXkRcyktOW0LOPQ==,
-      }
-
-  "@fontsource/nunito-sans@5.2.7":
-    resolution:
-      {
-        integrity: sha512-Vh+xhMsrH1eA9Q83Va82su3rDmNilYg+ur/TfHAOyr5kTpCOWMB8B1tDoJvSe+yJPpZ2jEWtnBHGqI2LUPVxUA==,
-      }
 
   "@humanfs/core@0.19.1":
     resolution:
@@ -5123,24 +5042,6 @@ snapshots:
       levn: 0.4.1
 
   "@exodus/bytes@1.14.1": {}
-
-  "@fontsource/atkinson-hyperlegible@5.2.8": {}
-
-  "@fontsource/averia-libre@5.2.7": {}
-
-  "@fontsource/dongle@5.2.7": {}
-
-  "@fontsource/fraunces@5.2.9": {}
-
-  "@fontsource/ibm-plex-sans@5.2.8": {}
-
-  "@fontsource/inter@5.2.8": {}
-
-  "@fontsource/libre-baskerville@5.2.10": {}
-
-  "@fontsource/lora@5.2.8": {}
-
-  "@fontsource/nunito-sans@5.2.7": {}
 
   "@humanfs/core@0.19.1": {}
 

--- a/apps/web/src/app/fonts.ts
+++ b/apps/web/src/app/fonts.ts
@@ -1,0 +1,86 @@
+import {
+  Atkinson_Hyperlegible,
+  Averia_Libre,
+  Dongle,
+  Fraunces,
+  IBM_Plex_Sans,
+  Inter,
+  Libre_Baskerville,
+  Lora,
+  Nunito_Sans,
+} from "next/font/google";
+
+const atkinsonHyperlegible = Atkinson_Hyperlegible({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "700"],
+  variable: "--font-atkinson",
+});
+
+const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "600", "700"],
+  variable: "--font-ibm-plex-sans",
+});
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "600", "700"],
+  variable: "--font-fraunces",
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "600", "700"],
+  variable: "--font-inter",
+});
+
+const averiaLibre = Averia_Libre({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "700"],
+  variable: "--font-averia-libre",
+});
+
+const dongle = Dongle({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "700"],
+  variable: "--font-dongle",
+});
+
+const nunitoSans = Nunito_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "600", "700"],
+  variable: "--font-nunito-sans",
+});
+
+const lora = Lora({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "600", "700"],
+  variable: "--font-lora",
+});
+
+const libreBaskerville = Libre_Baskerville({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "700"],
+  variable: "--font-libre-baskerville",
+});
+
+export const appFontVariablesClassName = [
+  atkinsonHyperlegible.variable,
+  ibmPlexSans.variable,
+  fraunces.variable,
+  inter.variable,
+  averiaLibre.variable,
+  dongle.variable,
+  nunitoSans.variable,
+  lora.variable,
+  libreBaskerville.variable,
+].join(" ");

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,28 +1,5 @@
 @import "tailwindcss";
 @import "primeicons/primeicons.css";
-@import "@fontsource/atkinson-hyperlegible/400.css";
-@import "@fontsource/atkinson-hyperlegible/700.css";
-@import "@fontsource/ibm-plex-sans/400.css";
-@import "@fontsource/ibm-plex-sans/600.css";
-@import "@fontsource/ibm-plex-sans/700.css";
-@import "@fontsource/fraunces/400.css";
-@import "@fontsource/fraunces/600.css";
-@import "@fontsource/fraunces/700.css";
-@import "@fontsource/inter/400.css";
-@import "@fontsource/inter/600.css";
-@import "@fontsource/inter/700.css";
-@import "@fontsource/averia-libre/400.css";
-@import "@fontsource/averia-libre/700.css";
-@import "@fontsource/dongle/400.css";
-@import "@fontsource/dongle/700.css";
-@import "@fontsource/nunito-sans/400.css";
-@import "@fontsource/nunito-sans/600.css";
-@import "@fontsource/nunito-sans/700.css";
-@import "@fontsource/lora/400.css";
-@import "@fontsource/lora/600.css";
-@import "@fontsource/lora/700.css";
-@import "@fontsource/libre-baskerville/400.css";
-@import "@fontsource/libre-baskerville/700.css";
 
 @theme {
   --font-sans: var(--app-font-family), ui-sans-serif, system-ui, sans-serif;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ColorModeController } from "@/components/color-mode-controller";
 import { PrimeProvider } from "@/components/prime-react-provider";
 import { ToastProvider } from "@/components/toast-provider";
 import { UserThemeBootstrap } from "@/components/user-theme-bootstrap";
+import { appFontVariablesClassName } from "@/app/fonts";
 import type { ColorMode } from "@/lib/color-mode";
 
 export const metadata: Metadata = {
@@ -29,6 +30,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
+      className={appFontVariablesClassName}
       data-app-ready="false"
       data-color-mode={initialColorMode}
       suppressHydrationWarning

--- a/apps/web/src/lib/user-theme.ts
+++ b/apps/web/src/lib/user-theme.ts
@@ -32,15 +32,17 @@ const DEFAULT_FONT_FAMILY: ThemeFontFamily = "ibm_plex_sans";
 const MIN_SURFACE_CONTRAST = 3;
 
 export const FONT_FAMILY_STACKS: Record<ThemeFontFamily, string> = {
-  atkinson: "'Atkinson Hyperlegible', ui-sans-serif, system-ui, sans-serif",
-  ibm_plex_sans: "'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif",
-  fraunces: "'Fraunces', ui-serif, Georgia, serif",
-  inter: "'Inter', ui-sans-serif, system-ui, sans-serif",
-  averia_libre: "'Averia Libre', ui-sans-serif, system-ui, sans-serif",
-  dongle: "'Dongle', ui-sans-serif, system-ui, sans-serif",
-  nunito_sans: "'Nunito Sans', ui-sans-serif, system-ui, sans-serif",
-  lora: "'Lora', ui-serif, Georgia, serif",
-  libre_baskerville: "'Libre Baskerville', ui-serif, Georgia, serif",
+  atkinson: "var(--font-atkinson), ui-sans-serif, system-ui, sans-serif",
+  ibm_plex_sans:
+    "var(--font-ibm-plex-sans), ui-sans-serif, system-ui, sans-serif",
+  fraunces: "var(--font-fraunces), ui-serif, Georgia, serif",
+  inter: "var(--font-inter), ui-sans-serif, system-ui, sans-serif",
+  averia_libre:
+    "var(--font-averia-libre), ui-sans-serif, system-ui, sans-serif",
+  dongle: "var(--font-dongle), ui-sans-serif, system-ui, sans-serif",
+  nunito_sans: "var(--font-nunito-sans), ui-sans-serif, system-ui, sans-serif",
+  lora: "var(--font-lora), ui-serif, Georgia, serif",
+  libre_baskerville: "var(--font-libre-baskerville), ui-serif, Georgia, serif",
 };
 
 export const FONT_LABELS: Record<ThemeFontFamily, string> = {

--- a/apps/web/src/tests/unit/user-theme.test.ts
+++ b/apps/web/src/tests/unit/user-theme.test.ts
@@ -31,6 +31,24 @@ describe("user theme helpers", () => {
     expect(isThemeFontFamily(null)).toBe(false);
   });
 
+  it("maps each theme font family to a next/font CSS variable stack", () => {
+    expect(FONT_FAMILY_STACKS.atkinson).toContain("var(--font-atkinson)");
+    expect(FONT_FAMILY_STACKS.ibm_plex_sans).toContain(
+      "var(--font-ibm-plex-sans)",
+    );
+    expect(FONT_FAMILY_STACKS.fraunces).toContain("var(--font-fraunces)");
+    expect(FONT_FAMILY_STACKS.inter).toContain("var(--font-inter)");
+    expect(FONT_FAMILY_STACKS.averia_libre).toContain(
+      "var(--font-averia-libre)",
+    );
+    expect(FONT_FAMILY_STACKS.dongle).toContain("var(--font-dongle)");
+    expect(FONT_FAMILY_STACKS.nunito_sans).toContain("var(--font-nunito-sans)");
+    expect(FONT_FAMILY_STACKS.lora).toContain("var(--font-lora)");
+    expect(FONT_FAMILY_STACKS.libre_baskerville).toContain(
+      "var(--font-libre-baskerville)",
+    );
+  });
+
   it("warns for low-contrast colors", () => {
     const warnings = getThemeWarnings({
       theme_primary_color: "#FFFFFF",


### PR DESCRIPTION
## Summary
- migrate web font loading from `@fontsource/*` CSS imports to `next/font/google`
- add centralized font definitions in `apps/web/src/app/fonts.ts` and apply their CSS variables at the root layout level
- keep settings-driven body/heading font selection behavior by mapping `FONT_FAMILY_STACKS` to the new `--font-*` variables
- remove obsolete `@fontsource/*` dependencies from the web package and lockfile
- add a unit test that verifies every supported theme font maps to a `next/font` variable stack

Closes #170.

## Verification
- `make quality`
- Playwright/browser verification of baseline and themed font behavior on `/login` and `/settings`
