### PR TITLE
feat(web): polish login screen auth UI

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -18,6 +18,9 @@
   --app-theme-accent-safe-light: #0f766e;
   --app-theme-accent-safe-dark: #2dd4bf;
   --app-theme-accent-contrast: #111827;
+  --oauth-button-bg: #ffffff;
+  --oauth-button-fg: #1f1f1f;
+  --oauth-button-border: #d1d5db;
   --app-font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
   --app-heading-font-family:
     "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
@@ -92,6 +95,21 @@ html.dark {
   --highlight-text-color: #e0e7ff;
   --maskbg: rgba(2, 6, 23, 0.7);
   color-scheme: dark;
+}
+
+html.dark,
+html[data-color-mode="dark"] {
+  --oauth-button-bg: #0f172a;
+  --oauth-button-fg: #eef4ff;
+  --oauth-button-border: #334155;
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-color-mode="system"] {
+    --oauth-button-bg: #0f172a;
+    --oauth-button-fg: #eef4ff;
+    --oauth-button-border: #334155;
+  }
 }
 
 * {

--- a/apps/web/src/components/pages/login-page.tsx
+++ b/apps/web/src/components/pages/login-page.tsx
@@ -98,39 +98,86 @@ export function LoginPageClient({ returnTo }: { returnTo: string }) {
     setStatus("Check your inbox for the magic link.");
   };
 
+  const oauthButtonClassName =
+    "h-14 w-full justify-center rounded-lg border border-[#d1d5db] bg-white px-4 text-[1.08rem] font-semibold text-[#1f1f1f] shadow-none hover:bg-white";
+  const oauthButtonStyle = {
+    backgroundColor: "var(--oauth-button-bg)",
+    color: "var(--oauth-button-fg)",
+    border: "1px solid var(--oauth-button-border)",
+  };
+
   return (
     <Card className="rounded-xl shadow-sm" data-test="login-card">
-      <h1 className="font-heading text-2xl font-semibold tracking-tight">
-        Welcome back
+      <h1 className="text-center font-heading text-2xl font-semibold tracking-tight">
+        Welcome to The Seedbed
       </h1>
-      <p className="mt-1 text-sm text-[var(--p-text-muted-color)]">
-        Sign in to The Seedbed
+      <p className="mt-1 text-center text-sm font-medium text-[var(--p-text-muted-color)]">
+        Please sign in.
       </p>
 
       <div className="mt-5 flex flex-col gap-3">
         <Button
-          outlined
-          severity="secondary"
-          className="justify-start"
+          className={oauthButtonClassName}
+          style={oauthButtonStyle}
           data-test="login-apple"
           disabled={busy}
           onClick={() => void signInWithProvider("apple")}
         >
-          Continue with Apple
+          <span className="mr-3 inline-flex h-5 w-5 items-center justify-center">
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+              className="h-5 w-5 fill-current"
+            >
+              <path d="M16.365 12.19c.03 3.1 2.73 4.13 2.76 4.14-.02.07-.43 1.47-1.42 2.92-.86 1.25-1.75 2.5-3.16 2.53-1.39.03-1.84-.82-3.43-.82-1.6 0-2.1.79-3.4.84-1.36.05-2.4-1.36-3.27-2.6-1.78-2.57-3.15-7.25-1.31-10.43.91-1.58 2.55-2.57 4.34-2.6 1.35-.03 2.62.9 3.43.9.8 0 2.31-1.12 3.9-.96.67.03 2.55.27 3.76 2.05-.1.07-2.24 1.31-2.22 3.9Zm-2.13-6.74c.72-.87 1.2-2.08 1.07-3.29-1.03.04-2.26.69-3 1.56-.66.76-1.24 1.98-1.09 3.14 1.14.09 2.3-.58 3.02-1.41Z" />
+            </svg>
+          </span>
+          <span>Sign in with Apple</span>
         </Button>
         <Button
-          outlined
-          severity="secondary"
-          className="justify-start"
+          className={oauthButtonClassName}
+          style={oauthButtonStyle}
           data-test="login-google"
           disabled={busy}
           onClick={() => void signInWithProvider("google")}
         >
-          Continue with Google
+          <span className="mr-3 inline-flex h-5 w-5 items-center justify-center">
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+              className="h-5 w-5"
+            >
+              <path
+                fill="#EA4335"
+                d="M12 10.2v3.9h5.4c-.23 1.25-.94 2.3-2.02 3l3.27 2.54c1.9-1.75 3-4.33 3-7.39 0-.7-.06-1.38-.18-2.03H12Z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 21.8c2.7 0 4.97-.9 6.62-2.43l-3.27-2.54c-.9.6-2.05.97-3.35.97-2.58 0-4.77-1.74-5.56-4.08H3.06v2.62A10 10 0 0 0 12 21.8Z"
+              />
+              <path
+                fill="#4A90E2"
+                d="M6.44 13.72A6 6 0 0 1 6.13 12c0-.6.1-1.18.3-1.72V7.66H3.05A10 10 0 0 0 2 12c0 1.6.38 3.1 1.05 4.34l3.39-2.62Z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M12 6.2c1.47 0 2.78.5 3.82 1.5l2.86-2.86C16.96 3.24 14.7 2.2 12 2.2a10 10 0 0 0-8.95 5.46l3.38 2.62C7.22 7.94 9.4 6.2 12 6.2Z"
+              />
+            </svg>
+          </span>
+          <span>Sign in with Google</span>
         </Button>
       </div>
 
-      <div className="mt-5 flex flex-col gap-2">
+      <div className="my-5 flex items-center gap-3 text-sm text-[var(--p-text-muted-color)]">
+        <span className="h-px flex-1 bg-[var(--p-content-border-color)]" />
+        <span className="uppercase tracking-wide">or</span>
+        <span className="h-px flex-1 bg-[var(--p-content-border-color)]" />
+      </div>
+
+      <div className="flex flex-col gap-2">
         <label htmlFor="email" className="text-sm font-medium">
           Email
         </label>
@@ -144,15 +191,17 @@ export function LoginPageClient({ returnTo }: { returnTo: string }) {
         />
       </div>
 
-      <Button
-        className="mt-4 w-full"
-        data-test="login-magic-link"
-        loading={busy}
-        disabled={busy}
-        onClick={() => void sendMagicLink()}
-      >
-        Send magic link
-      </Button>
+      <div className="pt-4">
+        <Button
+          className="w-full justify-center"
+          data-test="login-magic-link"
+          loading={busy}
+          disabled={busy}
+          onClick={() => void sendMagicLink()}
+        >
+          Send magic link
+        </Button>
+      </div>
 
       {status ? (
         <Message className="mt-3" severity="info" text={status} />

--- a/apps/web/src/tests/unit/login-page.test.tsx
+++ b/apps/web/src/tests/unit/login-page.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createBrowserClient: () => ({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      signInWithOAuth: vi.fn(),
+      signInWithOtp: vi.fn(),
+    },
+  }),
+}));
+
+import { LoginPageClient } from "@/components/pages/login-page";
+
+describe("Login page", () => {
+  it("renders oauth buttons with provider icons", () => {
+    const { container } = render(<LoginPageClient returnTo="/library" />);
+
+    const appleButton = container.querySelector('[data-test="login-apple"]');
+    const googleButton = container.querySelector('[data-test="login-google"]');
+
+    expect(appleButton).not.toBeNull();
+    expect(googleButton).not.toBeNull();
+    expect(screen.getByText("Sign in with Apple")).toBeInTheDocument();
+    expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
+    expect(appleButton?.querySelector("svg")).not.toBeNull();
+    expect(googleButton?.querySelector("svg")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- polish the login card copy and alignment (`Welcome to The Seedbed`, centered subtitle)
- restyle OAuth buttons with provider icons, centered labels, and consistent spacing
- add a visual divider between OAuth and magic-link flows
- improve spacing in the magic-link section (explicit padding between email input and submit)
- add CSS variables so OAuth buttons invert appropriately in dark mode while staying white in light mode
- add a unit test that asserts OAuth buttons render with icon SVGs and expected text

## Validation
- `make quality`
- pre-push `make quality` hook (all checks passed)
