### PR TITLE
Fix cover/metadata source filtering and Open Library compare resolution

### DIFF
--- a/apps/api/alembic/versions/0022_user_default_source_language.py
+++ b/apps/api/alembic/versions/0022_user_default_source_language.py
@@ -1,0 +1,46 @@
+"""Add per-user default source language preference.
+
+Revision ID: 0022_user_source_language
+Revises: 0021_heading_font_family
+Create Date: 2026-02-19
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0022_user_source_language"
+down_revision = "0021_heading_font_family"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = inspector.get_columns(table_name)
+    return any(column["name"] == column_name for column in columns)
+
+
+def upgrade() -> None:
+    if _column_exists("users", "default_source_language"):
+        return
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "default_source_language",
+            sa.String(length=8),
+            nullable=False,
+            server_default=sa.text("'eng'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    if not _column_exists("users", "default_source_language"):
+        return
+    op.drop_column("users", "default_source_language")

--- a/apps/api/app/core/schema_guard.py
+++ b/apps/api/app/core/schema_guard.py
@@ -32,6 +32,7 @@ _REQUIRED_COLUMNS: tuple[tuple[str, str], ...] = (
     ("users", "theme_font_family"),
     ("users", "theme_heading_font_family"),
     ("users", "default_progress_unit"),
+    ("users", "default_source_language"),
     # Cover provenance columns: if these aren't present, basic work fetches can 500.
     ("editions", "cover_set_by"),
     ("editions", "cover_set_at"),

--- a/apps/api/app/db/models/users.py
+++ b/apps/api/app/db/models/users.py
@@ -67,6 +67,11 @@ class User(Base):
         nullable=False,
         server_default=sa.text("'pages_read'::reading_progress_unit"),
     )
+    default_source_language: Mapped[str] = mapped_column(
+        sa.String(8),
+        nullable=False,
+        server_default=sa.text("'eng'"),
+    )
     actor_uri: Mapped[str | None] = mapped_column(sa.Text)
     created_at: Mapped[dt.datetime] = mapped_column(
         sa.DateTime(timezone=True),

--- a/apps/api/app/services/user_library.py
+++ b/apps/api/app/services/user_library.py
@@ -28,7 +28,9 @@ ProgressUnit: TypeAlias = Literal[
 DEFAULT_LIBRARY_STATUS: LibraryItemStatus = "to_read"
 DEFAULT_LIBRARY_VISIBILITY: LibraryItemVisibility = "private"
 DEFAULT_PROGRESS_UNIT: ProgressUnit = "pages_read"
+DEFAULT_SOURCE_LANGUAGE = "eng"
 HEX_COLOR_PATTERN = re.compile(r"^#[0-9A-Fa-f]{6}$")
+SOURCE_LANGUAGE_PATTERN = re.compile(r"^[a-z]{2,3}$")
 LibraryItemSortMode: TypeAlias = Literal[
     "newest",
     "oldest",
@@ -63,6 +65,7 @@ def get_or_create_profile(session: Session, *, user_id: uuid.UUID) -> User:
         theme_font_family=None,
         theme_heading_font_family=None,
         default_progress_unit=DEFAULT_PROGRESS_UNIT,
+        default_source_language=DEFAULT_SOURCE_LANGUAGE,
     )
     session.add(profile)
     session.commit()
@@ -82,6 +85,7 @@ def update_profile(
     theme_font_family: str | None,
     theme_heading_font_family: str | None,
     default_progress_unit: ProgressUnit | None,
+    default_source_language: str | None,
 ) -> User:
     profile = get_or_create_profile(session, user_id=user_id)
 
@@ -146,6 +150,14 @@ def update_profile(
 
     if default_progress_unit is not None:
         profile.default_progress_unit = default_progress_unit
+
+    if default_source_language is not None:
+        normalized = default_source_language.strip().lower()
+        if not SOURCE_LANGUAGE_PATTERN.fullmatch(normalized):
+            raise ValueError(
+                "default_source_language must be a 2-3 letter lowercase language code"
+            )
+        profile.default_source_language = normalized
 
     session.commit()
     return profile

--- a/apps/api/tests/test_schema_guard.py
+++ b/apps/api/tests/test_schema_guard.py
@@ -67,6 +67,7 @@ def test_schema_guard_raises_with_actionable_message(
     assert "content_visibility" in message
     assert "public.notes.ap_uri" in message
     assert "public.users.default_progress_unit" in message
+    assert "public.users.default_source_language" in message
     assert "public.works.default_cover_set_by" in message
     assert "public.library_items.cover_override_url" in message
 

--- a/apps/api/tests/test_user_library_models.py
+++ b/apps/api/tests/test_user_library_models.py
@@ -39,6 +39,7 @@ def test_users_table_schema() -> None:
         "theme_font_family",
         "theme_heading_font_family",
         "default_progress_unit",
+        "default_source_language",
         "actor_uri",
         "created_at",
         "updated_at",
@@ -55,6 +56,8 @@ def test_users_table_schema() -> None:
     assert isinstance(table.columns["theme_accent_color"].type, sa.Text)
     assert isinstance(table.columns["theme_font_family"].type, sa.String)
     assert table.columns["theme_font_family"].type.length == 32
+    assert isinstance(table.columns["default_source_language"].type, sa.String)
+    assert table.columns["default_source_language"].type.length == 8
     assert isinstance(table.columns["default_progress_unit"].type, sa.Enum)
     assert table.columns["default_progress_unit"].type.enums == [
         "pages_read",

--- a/apps/api/tests/test_user_library_service.py
+++ b/apps/api/tests/test_user_library_service.py
@@ -138,6 +138,7 @@ def test_update_profile_validates_handle() -> None:
             theme_font_family=None,
             theme_heading_font_family=None,
             default_progress_unit=None,
+            default_source_language=None,
         )
 
 
@@ -160,6 +161,7 @@ def test_update_profile_rejects_duplicate_handle() -> None:
             theme_font_family=None,
             theme_heading_font_family=None,
             default_progress_unit=None,
+            default_source_language=None,
         )
 
 
@@ -181,6 +183,7 @@ def test_update_profile_updates_fields() -> None:
         theme_font_family="ibm_plex_sans",
         theme_heading_font_family=None,
         default_progress_unit="minutes_listened",
+        default_source_language="eng",
     )
     assert updated is profile
     assert updated.handle == "fresh"
@@ -211,6 +214,7 @@ def test_update_profile_rejects_invalid_theme_colors() -> None:
             theme_font_family=None,
             theme_heading_font_family=None,
             default_progress_unit=None,
+            default_source_language=None,
         )
 
     with pytest.raises(ValueError):
@@ -226,6 +230,7 @@ def test_update_profile_rejects_invalid_theme_colors() -> None:
             theme_font_family=None,
             theme_heading_font_family=None,
             default_progress_unit=None,
+            default_source_language=None,
         )
 
 
@@ -247,6 +252,7 @@ def test_update_profile_rejects_invalid_theme_font() -> None:
             theme_font_family=cast(Any, "comic_sans"),
             theme_heading_font_family=None,
             default_progress_unit=None,
+            default_source_language=None,
         )
 
 

--- a/apps/web/src/app/(app)/settings/settings-page-client.tsx
+++ b/apps/web/src/app/(app)/settings/settings-page-client.tsx
@@ -37,6 +37,7 @@ export type MeProfile = {
   theme_font_family: ThemeFontFamily | null;
   theme_heading_font_family: ThemeFontFamily | null;
   default_progress_unit: "pages_read" | "percent_complete" | "minutes_listened";
+  default_source_language: string;
 };
 
 export type SettingsPageClientProps = {
@@ -156,6 +157,15 @@ function suggestionConfidenceText(issue: ImportIssue) {
 const fontOptions = (Object.keys(FONT_LABELS) as ThemeFontFamily[]).map(
   (key) => ({ label: FONT_LABELS[key], value: key }),
 );
+const sourceLanguageOptions = [
+  { label: "English", value: "eng" },
+  { label: "Spanish", value: "spa" },
+  { label: "French", value: "fra" },
+  { label: "German", value: "deu" },
+  { label: "Italian", value: "ita" },
+  { label: "Portuguese", value: "por" },
+  { label: "Japanese", value: "jpn" },
+];
 
 export default function SettingsPageClient({
   initialProfile,
@@ -184,6 +194,7 @@ export default function SettingsPageClient({
   const [defaultProgressUnit, setDefaultProgressUnit] = useState<
     "pages_read" | "percent_complete" | "minutes_listened"
   >("pages_read");
+  const [defaultSourceLanguage, setDefaultSourceLanguage] = useState("eng");
 
   const [storygraphFile, setStorygraphFile] = useState<File | null>(null);
   const [storygraphImporting, setStorygraphImporting] = useState(false);
@@ -283,6 +294,7 @@ export default function SettingsPageClient({
     setThemeFontFamily(bodyFont);
     setThemeHeadingFontFamily(headingFont);
     setDefaultProgressUnit(data.default_progress_unit ?? "pages_read");
+    setDefaultSourceLanguage(data.default_source_language ?? "eng");
     applyUserTheme({
       theme_primary_color: normalizedPrimary,
       theme_accent_color: normalizedAccent,
@@ -372,6 +384,7 @@ export default function SettingsPageClient({
           theme_font_family: themeFontFamily,
           theme_heading_font_family: themeHeadingFontFamily,
           default_progress_unit: defaultProgressUnit,
+          default_source_language: defaultSourceLanguage,
         },
       });
       applyUserTheme({
@@ -1004,6 +1017,17 @@ export default function SettingsPageClient({
               )
             }
             data-test="settings-default-progress-unit"
+          />
+        </label>
+        <label className="grid gap-1 text-sm">
+          Default source language
+          <Dropdown
+            value={defaultSourceLanguage}
+            options={sourceLanguageOptions}
+            optionLabel="label"
+            optionValue="value"
+            onChange={(event) => setDefaultSourceLanguage(String(event.value))}
+            data-test="settings-default-source-language"
           />
         </label>
       </div>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -144,34 +144,39 @@
   }
 
   .p-inputtext {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.875rem;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.8125rem;
   }
 
   .p-button {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-  }
-
-  .p-button.p-button-sm {
     padding: 0.375rem 0.75rem;
     font-size: 0.8125rem;
   }
 
-  .p-button.p-button-icon-only {
-    padding: 0.5rem;
+  .p-button.p-button-sm {
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
   }
 
-  .p-button.p-button-icon-only.p-button-sm {
+  .p-button.p-button-icon-only {
     padding: 0.375rem;
   }
 
+  .p-button.p-button-icon-only.p-button-sm {
+    padding: 0.25rem;
+  }
+
   .p-dropdown .p-dropdown-label {
-    padding: 0.5rem 0.75rem;
+    padding: 0.375rem 0.625rem;
   }
 
   .p-multiselect .p-multiselect-label {
-    padding: 0.5rem 0.75rem;
+    padding: 0.375rem 0.625rem;
+  }
+
+  .p-multiselect.p-multiselect-chip .p-multiselect-token {
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
   }
 
   .p-selectbutton .p-button {

--- a/apps/web/src/components/library/workflows/EnrichMetadataDialog.tsx
+++ b/apps/web/src/components/library/workflows/EnrichMetadataDialog.tsx
@@ -65,9 +65,8 @@ const toImageUrl = (value: unknown) => {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
   if (!trimmed) return "";
-  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-    return trimmed;
-  }
+  if (trimmed.startsWith("/")) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
   return "";
 };
 

--- a/apps/web/src/tests/unit/settings-page.test.tsx
+++ b/apps/web/src/tests/unit/settings-page.test.tsx
@@ -41,6 +41,7 @@ const profileResponse = {
   theme_font_family: "ibm_plex_sans",
   theme_heading_font_family: "ibm_plex_sans",
   default_progress_unit: "pages_read",
+  default_source_language: "eng",
 };
 
 function setupApiMock({


### PR DESCRIPTION
## Summary
This PR completes the cover/metadata source filtering + Open Library compare hardening work and fixes the current-cover regression in compare dialogs.

### Key fixes included
- Additive API + frontend wiring for Open Library source/work resolution:
  - source tiles now carry `openlibrary_work_key`
  - compare endpoint accepts optional `openlibrary_work_key`
  - resolver fallback chain hardened for `/books/...` and `/works/...`
- Language-aware source filtering and speed improvements:
  - user-level `default_source_language` (`/api/v1/me`)
  - new `languages` query support (legacy `language` still supported)
  - filter out entries with missing/invalid language or missing cover
  - tighter caps for Open Library/Google source candidates + prefetch
- Search quality improvements:
  - stronger title matching and title normalization (including parenthetical stripping) to reduce unrelated matches
  - title override support in the Set Cover and Metadata dialog
- Compare/current-cover correctness:
  - compare current cover now follows effective cover precedence (library override -> preferred edition -> work default)
  - dialog cover rendering now accepts relative cover URLs (e.g. storage-backed paths), so existing covers no longer show as “No current cover” incorrectly

## Migration
- Adds Alembic migration:
  - `apps/api/alembic/versions/0022_user_default_source_language.py`

## Testing
- `make quality` (passes)
  - API: format/lint/typecheck/tests/build all pass
  - Web: format/lint/unit/e2e/build all pass
- Added/updated targeted unit tests for:
  - `/me` default source language behavior
  - cover metadata source filtering/caps/language handling
  - Open Library work-key compare resolution
  - title override query behavior
  - dialog compare request wiring and relative current-cover rendering

## Notes
- This is additive/backward-compatible at the API layer.
- Existing clients without `openlibrary_work_key` continue to work via fallback resolver behavior.
